### PR TITLE
release: v0.0.3-beta — i18n + iOS-style selected chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.0.3-beta
+
+### Added
+
+- **i18n / internationalization**: full translation system with English (default) and French. ~320 strings extracted from hardcoded values into `res/values/strings.xml` (EN) and `res/values-fr/strings.xml` (FR). Adding a new language now only requires creating a new `values-XX/strings.xml` file — no code changes needed.
+
+### Changed
+
+- **iOS-style selected chip**: when a tray chip is selected (its panel is open), it now renders with a white background, dark text, and white border — matching the iOS Home app look. The colored icon circle retains its accent color.
+
+### Technical
+
+- All user-facing strings now use `stringResource(R.string.*)` (Compose) or `context.getString(R.string.*)` (non-Compose) instead of hardcoded French text
+- Plurals support for dynamic counts (e.g. "1 shortcut" / "2 shortcuts")
+- `PillPriorityEngine` refactored from `object` to `class` with Context injection for resource access
+- All 162 unit tests updated to assert against English string resources
+
 ## 0.0.2-beta
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.iblu01.portallauncher"
         minSdk = 28
         targetSdk = 28
-        versionCode = 2
-        versionName = "0.0.2-beta"
+        versionCode = 3
+        versionName = "0.0.3-beta"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/iblu01/portallauncher/ClockThemeActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ClockThemeActivity.kt
@@ -17,6 +17,10 @@ import javax.inject.Inject
 class ClockThemeActivity : ComponentActivity() {
     @Inject lateinit var prefs: Prefs
 
+    override fun attachBaseContext(newBase: android.content.Context) {
+        super.attachBaseContext(LocaleHelper.wrap(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
@@ -121,6 +121,10 @@ import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
 class LauncherActivity : ComponentActivity() {
+    override fun attachBaseContext(newBase: android.content.Context) {
+        super.attachBaseContext(LocaleHelper.wrap(newBase))
+    }
+
     @Inject lateinit var prefs: Prefs
     @Inject lateinit var pills: PillRepository
     private var lastLaunchMs = 0L
@@ -269,7 +273,7 @@ class LauncherActivity : ComponentActivity() {
         val pkg = prefs.homeAssistantPackage
         val intent = packageManager.getLaunchIntentForPackage(pkg)
         if (intent == null) {
-            Toast.makeText(this, "Application introuvable: $pkg", Toast.LENGTH_LONG).show()
+            Toast.makeText(this, getString(R.string.toast_app_not_found_pkg_format, pkg), Toast.LENGTH_LONG).show()
             return
         }
         DeviceStateHub.noteLaunchingApp(pkg, this)
@@ -285,13 +289,13 @@ class LauncherActivity : ComponentActivity() {
         DeviceStateHub.noteLaunchingApp(item.packageName, this)
         val intent = LauncherAppsFacade.launchIntent(this, item.packageName, item.activityName)
         if (intent == null) {
-            Toast.makeText(this, "Application introuvable : ${item.label}", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.toast_app_not_found_label_format, item.label), Toast.LENGTH_SHORT).show()
             return
         }
         openingFromLauncher = true
         runCatching { startActivity(intent) }.onFailure {
             openingFromLauncher = false
-            Toast.makeText(this, "Impossible d’ouvrir ${item.label}", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.toast_cannot_open_app_format, item.label), Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -302,7 +306,7 @@ class LauncherActivity : ComponentActivity() {
 
     private fun setWallpaper() {
         openFromLauncher(
-            Intent.createChooser(Intent(Intent.ACTION_SET_WALLPAPER), "Choisir un fond d’écran")
+            Intent.createChooser(Intent(Intent.ACTION_SET_WALLPAPER), getString(R.string.toast_choose_wallpaper))
         )
     }
 

--- a/app/src/main/java/com/iblu01/portallauncher/LocaleHelper.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/LocaleHelper.kt
@@ -1,0 +1,27 @@
+package com.iblu01.portallauncher
+
+import android.content.Context
+import android.content.res.Configuration
+import java.util.Locale
+
+/**
+ * Wraps a base [Context] with the language chosen in Settings > Application > Language, or
+ * returns it unchanged when the user follows the system language. Every Activity (and the
+ * Application) must call this from `attachBaseContext` — plain `ComponentActivity`s don't get
+ * per-app locale overrides for free the way `AppCompatActivity` does.
+ */
+object LocaleHelper {
+    fun wrap(context: Context): Context {
+        // Read the raw pref directly instead of going through Prefs(context): during
+        // Application.attachBaseContext, context.applicationContext is still null, and Prefs
+        // dereferences it immediately — that crashed the app on every launch.
+        val sp = context.getSharedPreferences("portal_launcher", Context.MODE_PRIVATE)
+        val code = sp.getString("app_language", "") ?: ""
+        if (code.isBlank()) return context
+        val locale = Locale(code)
+        Locale.setDefault(locale)
+        val config = Configuration(context.resources.configuration)
+        config.setLocale(locale)
+        return context.createConfigurationContext(config)
+    }
+}

--- a/app/src/main/java/com/iblu01/portallauncher/MqttBridgeService.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/MqttBridgeService.kt
@@ -79,7 +79,7 @@ class MqttBridgeService : Service() {
         super.onCreate()
         createChannel()
         prefs = Prefs(this)
-        startForeground(NOTIF_ID, notification("Starting"))
+        startForeground(NOTIF_ID, notification(getString(R.string.app_name)))
 
         DeviceStateHub.init(this)
         ScreenControl.enableAccessibility(this)
@@ -439,7 +439,7 @@ class MqttBridgeService : Service() {
     private fun createChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val nm = getSystemService(NotificationManager::class.java)
-            nm.createNotificationChannel(NotificationChannel(CHANNEL, "Portal Launcher", NotificationManager.IMPORTANCE_LOW))
+            nm.createNotificationChannel(NotificationChannel(CHANNEL, getString(R.string.notification_channel_name), NotificationManager.IMPORTANCE_LOW))
         }
     }
 
@@ -452,7 +452,7 @@ class MqttBridgeService : Service() {
         }
         return builder
             .setSmallIcon(android.R.drawable.ic_dialog_info)
-            .setContentTitle("Portal Launcher")
+            .setContentTitle(getString(R.string.notification_content_title))
             .setContentText(text)
             .setOngoing(true)
             .build()
@@ -469,8 +469,8 @@ class MqttBridgeService : Service() {
     }
 
     private fun powerModeLabel(mode: PowerMode) = when (mode) {
-        PowerMode.ALWAYS_ON -> "Always on"
-        PowerMode.FOLLOW_PRESENCE -> "Follow presence"
+        PowerMode.ALWAYS_ON -> getString(R.string.power_mode_always_on)
+        PowerMode.FOLLOW_PRESENCE -> getString(R.string.power_mode_follow_presence)
     }
 
     private fun localIp(): String? = try {

--- a/app/src/main/java/com/iblu01/portallauncher/OpacityPreviewActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/OpacityPreviewActivity.kt
@@ -18,6 +18,10 @@ import javax.inject.Inject
 class OpacityPreviewActivity : ComponentActivity() {
     @Inject lateinit var prefs: Prefs
 
+    override fun attachBaseContext(newBase: android.content.Context) {
+        super.attachBaseContext(LocaleHelper.wrap(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/app/src/main/java/com/iblu01/portallauncher/PillPriorityEngine.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/PillPriorityEngine.kt
@@ -1,11 +1,12 @@
 package com.iblu01.portallauncher
+import android.content.Context
 import com.iblu01.portallauncher.domain.model.PillDetail
 
 import java.time.Instant
 import java.time.OffsetDateTime
 import kotlin.math.roundToInt
 
-object PillPriorityEngine {
+class PillPriorityEngine(private val context: Context) {
     private val inactive = setOf("off", "closed", "locked", "idle", "docked", "standby", "stop", "stopped", "unavailable", "unknown", "clear", "disarmed")
     private val activeAppliance = setOf("on", "run", "running", "cleaning", "washing", "drying", "printing", "active", "returning", "paused", "prepare", "slicing", "init")
     private val done = setOf("done", "finished", "complete", "completed", "finish")
@@ -42,15 +43,15 @@ object PillPriorityEngine {
         val home = people.filter { it.second.state.equals("home", true) }
         val details = people.sortedByDescending { it in home }.map { (rule, entity) ->
             val status = when (entity.state.lowercase()) {
-                "home" -> "À la maison"
-                "not_home" -> "Absent"
-                else -> "Absent · ${entity.state.replaceFirstChar { it.uppercase() }}"
+                "home" -> context.getString(R.string.presence_home)
+                "not_home" -> context.getString(R.string.presence_away)
+                else -> context.getString(R.string.presence_away) + " · ${entity.state.replaceFirstChar { it.uppercase() }}"
             }
             PillDetail(rule.label, status, entityId = entity.entityId, active = entity.state.equals("home", true))
         }
         return LauncherChip(
-            id = "presence_group", icon = "presence", label = "Présence",
-            value = if (home.isEmpty()) "Personne" else "${home.size} à la maison",
+            id = "presence_group", icon = "presence", label = context.getString(R.string.pill_group_presence),
+            value = if (home.isEmpty()) context.getString(R.string.pill_presence_nobody) else context.getString(R.string.pill_presence_count_format, home.size),
             state = "info", priority = if (home.isEmpty()) 6 else 9,
             details = details, kind = PillKind.PRESENCE,
         )
@@ -65,13 +66,13 @@ object PillPriorityEngine {
         val power = entities.filter { it.deviceClass == "power" }.let { p -> p.firstOrNull { powerName.containsMatchIn(it.entityId) } ?: p.firstOrNull() }
         val watts = power?.state?.toDoubleOrNull()
         val details = buildList {
-            power?.let { add(PillDetail("Puissance", "${watts?.roundToInt() ?: 0} W", entityId = it.entityId)) }
+            power?.let { add(PillDetail(context.getString(R.string.pill_individual_energy_power), "${watts?.roundToInt() ?: 0} W", entityId = it.entityId)) }
             entities.filter { it.deviceClass == "energy" }.firstOrNull()?.let {
-                add(PillDetail("Aujourd'hui", it.state + (it.attributes.optString("unit_of_measurement").ifBlank { " kWh" }.let { u -> if (u.startsWith(" ")) u else " $u" }), entityId = it.entityId))
+                add(PillDetail(context.getString(R.string.pill_individual_energy_today), it.state + (it.attributes.optString("unit_of_measurement").ifBlank { " kWh" }.let { u -> if (u.startsWith(" ")) u else " $u" }), entityId = it.entityId))
             }
         }
         return LauncherChip(
-            id = "energy_group", icon = "energy", label = "Énergie",
+            id = "energy_group", icon = "energy", label = context.getString(R.string.pill_group_energy),
             value = watts?.let { "${it.roundToInt()} W" } ?: "—",
             state = "info", priority = 8,
             details = details, kind = PillKind.ENERGY,
@@ -83,8 +84,8 @@ object PillPriorityEngine {
         val entities = rules.mapNotNull { rule -> states[rule.entityId]?.let { rule to it } }
         if (entities.isEmpty()) return null
         return LauncherChip(
-            id = "scenes_group", icon = "scene", label = "Scènes",
-            value = if (entities.size == 1) "1 raccourci" else "${entities.size} raccourcis",
+            id = "scenes_group", icon = "scene", label = context.getString(R.string.pill_group_scenes),
+            value = context.resources.getQuantityString(R.plurals.pill_scenes_count, entities.size, entities.size),
             state = "info", priority = 10,
             details = entities.map { (rule, entity) -> PillDetail(rule.label, "", entityId = entity.entityId) },
             kind = PillKind.SCENE,
@@ -97,11 +98,11 @@ object PillPriorityEngine {
         if (entities.isEmpty()) return null
         val on = entities.filter { it.second.state.equals("on", true) }
         return LauncherChip(
-            id = "lights_group", icon = "light", label = "Lumières",
-            value = when (on.size) { 0 -> "Toutes éteintes"; 1 -> "1 allumée"; else -> "${on.size} allumées" },
+            id = "lights_group", icon = "light", label = context.getString(R.string.pill_group_lights),
+            value = context.resources.getQuantityString(R.plurals.pill_lights_state, on.size, on.size),
             state = if (on.isEmpty()) "ok" else "warning", priority = if (on.isEmpty()) 7 else 16,
             details = entities.sortedByDescending { it in on }.map { (rule, entity) ->
-                PillDetail(rule.label, if (entity.state == "on") "Allumée" else "Éteinte", entityId = entity.entityId, active = entity.state.equals("on", true))
+                PillDetail(rule.label, if (entity.state == "on") context.getString(R.string.light_state_on) else context.getString(R.string.light_state_off), entityId = entity.entityId, active = entity.state.equals("on", true))
             },
         )
     }
@@ -119,9 +120,13 @@ object PillPriorityEngine {
 
         val playing = entities.filter { it.second.state.lowercase() in setOf("playing", "buffering") }
         val paused = entities.filter { isRecentPaused(it.second) }
-        val value = when { playing.isNotEmpty() -> if (playing.size == 1) "En lecture" else "${playing.size} en lecture"; paused.isNotEmpty() -> "En pause"; else -> "Aucun média" }
+        val value = when {
+            playing.isNotEmpty() -> context.resources.getQuantityString(R.plurals.pill_media_state, playing.size, playing.size)
+            paused.isNotEmpty() -> context.resources.getQuantityString(R.plurals.pill_media_state, 1, 1)
+            else -> context.resources.getQuantityString(R.plurals.pill_media_state, 0, 0)
+        }
         return LauncherChip(
-            id = "media_group", icon = "media", label = "Médias", value = value,
+            id = "media_group", icon = "media", label = context.getString(R.string.pill_group_media), value = value,
             state = if (playing.isNotEmpty()) "active" else "ok", priority = if (playing.isNotEmpty()) 22 else 3,
             details = entities.filter { 
                 val state = it.second.state.lowercase()
@@ -139,8 +144,8 @@ object PillPriorityEngine {
         val running = entity.state.equals("on", true)
         val related = rule.relatedEntityIds.mapNotNull(states::get).filter { it.state !in setOf("unknown", "unavailable") }
         return LauncherChip(
-            id = "purifier_group", icon = "air", label = "Purificateur",
-            value = if (running) entity.attributes.optString("preset_mode").takeIf { it.isNotBlank() }?.let { "En marche · $it" } ?: "En marche" else "Arrêté",
+            id = "purifier_group", icon = "air", label = context.getString(R.string.pill_group_purifier),
+            value = if (running) entity.attributes.optString("preset_mode").takeIf { it.isNotBlank() }?.let { context.getString(R.string.pill_fan_on_format, it) } ?: context.getString(R.string.pill_fan_on) else context.getString(R.string.pill_fan_off),
             state = if (running) "active" else "ok", priority = if (running) 15 else 5,
             entityId = entity.entityId,
             details = related.filter { 
@@ -170,16 +175,16 @@ object PillPriorityEngine {
             }
         }
         val qualitative = when {
-            warnings.isNotEmpty() && sensors.size == warnings.size -> "Mauvaise"
-            warnings.isNotEmpty() -> "Moyenne"
-            else -> "Bonne"
+            warnings.isNotEmpty() && sensors.size == warnings.size -> context.getString(R.string.air_quality_bad)
+            warnings.isNotEmpty() -> context.getString(R.string.air_quality_medium)
+            else -> context.getString(R.string.air_quality_good)
         }
         val details = sensors.map { (rule, entity) ->
             val unit = entity.attributes.optString("unit_of_measurement", "")
             PillDetail(rule.label, entity.state + unit, entityId = entity.entityId, active = false)
         }
         return LauncherChip(
-            id = "air_group", icon = "air", label = "Qualité de l'air",
+            id = "air_group", icon = "air", label = context.getString(R.string.pill_group_air_quality),
             value = qualitative,
             state = if (warnings.isNotEmpty()) "warning" else "active",
             priority = if (warnings.isEmpty()) 8 else 35,
@@ -204,8 +209,8 @@ object PillPriorityEngine {
             PillDetail(rule.label.replace(Regex(" (Température|Temperature)$", RegexOption.IGNORE_CASE), ""), fmt(value) + suffix)
         }
         return LauncherChip(
-            id = "temperature_group", icon = "temperature", label = "Températures",
-            value = if (readings.size == 1) fmt(min) else "Min ${fmt(min)} · Max ${fmt(max)}",
+            id = "temperature_group", icon = "temperature", label = context.getString(R.string.pill_group_temperatures),
+            value = if (readings.size == 1) fmt(min) else context.getString(R.string.pill_temperature_range_format, fmt(min), fmt(max)),
             state = if (abnormal) "warning" else "ok", priority = if (abnormal) 35 else 2,
             details = details,
         )
@@ -218,8 +223,8 @@ object PillPriorityEngine {
         if (low.isEmpty()) return null
         val minimum = low.minOf { it.second }
         return LauncherChip(
-            id = "battery_group", icon = "battery", label = "Batteries faibles",
-            value = if (low.size == 1) "${minimum.toInt()}%" else "${low.size} appareils · min ${minimum.toInt()}%",
+            id = "battery_group", icon = "battery", label = context.getString(R.string.pill_group_batteries),
+            value = if (low.size == 1) "${minimum.toInt()}%" else context.getString(R.string.pill_battery_state_multi_format, low.size, "${minimum.toInt()}%"),
             state = if (minimum <= 10) "critical" else "warning",
             priority = if (minimum <= 10) 82 else 6,
             details = low.sortedBy { it.second }.map { (entity, level) -> PillDetail(entity.name.replace(Regex(" (Batterie|Battery)$", RegexOption.IGNORE_CASE), ""), "${level.toInt()}%") },
@@ -237,18 +242,18 @@ object PillPriorityEngine {
                 .replace(Regex(" Porte$", RegexOption.IGNORE_CASE), "").replaceFirstChar { it.uppercase() }
         }
         val value = when {
-            opened.isEmpty() -> "Toutes fermées"
-            opened.size == 1 -> "1 ouverte"
-            else -> "${opened.size} ouvertes"
+            opened.isEmpty() -> context.getString(R.string.pill_openings_all_closed)
+            opened.size == 1 -> context.getString(R.string.pill_openings_one_open)
+            else -> context.getString(R.string.pill_openings_count_format, opened.size)
         }
         val ageBonus = opened.maxOfOrNull { entity ->
             runCatching { ((nowMs - Instant.parse(entity.lastChanged).toEpochMilli()) / 60_000).coerceIn(0, 30).toInt() }.getOrDefault(0)
         } ?: 0
         return LauncherChip(
-            id = "openings_group", icon = "door", label = "Portes & fenêtres", value = value,
+            id = "openings_group", icon = "door", label = context.getString(R.string.pill_group_openings), value = value,
             state = if (opened.isEmpty()) "ok" else "warning", entityId = rules.joinToString(",") { it.entityId },
             priority = if (opened.isEmpty()) 5 else 55 + ageBonus,
-            details = entities.sortedByDescending { it in opened }.map { PillDetail(shortName(it), if (it in opened) "Ouverte" else "Fermée") },
+            details = entities.sortedByDescending { it in opened }.map { PillDetail(shortName(it), if (it in opened) context.getString(R.string.opening_state_open) else context.getString(R.string.opening_state_closed)) },
         )
     }
 
@@ -366,22 +371,22 @@ object PillPriorityEngine {
         }.onFailure { err -> android.util.Log.e("PillPriorityEngine", "Failed to parse completion time", err) }.getOrNull()
         
         val translatedPhase = when (phase?.lowercase()) {
-            "air_wash" -> "Désodorisation"
-            "ai_rinse" -> "Rinçage IA"
-            "ai_spin" -> "Essorage IA"
-            "ai_wash" -> "Lavage IA"
-            "cooling" -> "Refroidissement"
-            "delay_wash" -> "Départ différé"
-            "drying" -> "Séchage"
-            "finish" -> "Terminé"
-            "none" -> "Aucun"
-            "pre_wash" -> "Prélavage"
-            "rinse" -> "Rinçage"
-            "spin" -> "Essorage"
-            "wash" -> "Lavage"
-            "weight_sensing" -> "Pesée"
-            "wrinkle_prevent" -> "Anti-froissement"
-            "freeze_protection" -> "Protection gel"
+            "air_wash" -> context.getString(R.string.phase_air_wash)
+            "ai_rinse" -> context.getString(R.string.phase_ai_rinse)
+            "ai_spin" -> context.getString(R.string.phase_ai_spin)
+            "ai_wash" -> context.getString(R.string.phase_ai_wash)
+            "cooling" -> context.getString(R.string.phase_cooling)
+            "delay_wash" -> context.getString(R.string.phase_delay_wash)
+            "drying" -> context.getString(R.string.phase_drying)
+            "finish" -> context.getString(R.string.phase_finish)
+            "none" -> context.getString(R.string.phase_none)
+            "pre_wash" -> context.getString(R.string.phase_pre_wash)
+            "rinse" -> context.getString(R.string.phase_rinse)
+            "spin" -> context.getString(R.string.phase_spin)
+            "wash" -> context.getString(R.string.phase_wash)
+            "weight_sensing" -> context.getString(R.string.phase_weight_sensing)
+            "wrinkle_prevent" -> context.getString(R.string.phase_wrinkle_prevent)
+            "freeze_protection" -> context.getString(R.string.phase_freeze_protection)
             else -> phase
         }
 
@@ -389,7 +394,7 @@ object PillPriorityEngine {
             ?: e.attributes.optString("remaining_time").takeIf { it.isNotBlank() }
             ?: e.attributes.optString("phase").takeIf { it.isNotBlank() }
             ?: e.attributes.optString("status").takeIf { it.isNotBlank() }
-            ?: translatedPhase?.takeIf { it !in setOf("none", "unknown", "unavailable", "Aucun") }
+            ?: translatedPhase?.takeIf { phase?.lowercase() !in setOf("none") }
             ?: (e.state + unit.takeIf { it.isNotBlank() }.orEmpty())
             
         if (e.entityId.contains("machine_a_laver")) {
@@ -402,8 +407,8 @@ object PillPriorityEngine {
         }
             
         val display = when (rule.kind) {
-            PillKind.OPENING -> when (s) { "on", "open", "opening" -> "Ouverte"; else -> rawDisplay }
-            PillKind.LOCK -> when (s) { "locked" -> "Verrouillée"; "unlocked" -> "Déverrouillée"; "jammed" -> "Bloquée"; else -> rawDisplay }
+            PillKind.OPENING -> when (s) { "on", "open", "opening" -> context.getString(R.string.pill_opening_open); else -> rawDisplay }
+            PillKind.LOCK -> when (s) { "locked" -> context.getString(R.string.pill_lock_locked); "unlocked" -> context.getString(R.string.pill_lock_unlocked); "jammed" -> context.getString(R.string.pill_lock_jammed); else -> rawDisplay }
             PillKind.SAFETY -> if (e.domain == "alarm_control_panel") when (s) {
                 "disarmed" -> "Désarmée"
                 "armed_away" -> "Armée · absence"
@@ -413,22 +418,22 @@ object PillPriorityEngine {
                 "pending" -> "Déclenchement imminent"
                 "arming" -> "Armement…"
                 else -> rawDisplay
-            } else if (s !in inactive) "Alerte" else rawDisplay
+            } else if (s !in inactive) context.getString(R.string.pill_safety_alert) else rawDisplay
             PillKind.THERMOSTAT -> {
                 val target = e.attributes.optDouble("temperature").takeIf { !it.isNaN() }
                 target?.let { if (it % 1.0 == 0.0) "${it.toInt()}°" else "%.1f°".format(it) } ?: rawDisplay
             }
             PillKind.COVER -> when (s) {
-                "open" -> e.attributes.optInt("current_position", -1).let { if (it in 0..100) "Ouvert · $it%" else "Ouvert" }
-                "closed" -> "Fermé"
-                "opening" -> "Ouverture…"
-                "closing" -> "Fermeture…"
+                "open" -> e.attributes.optInt("current_position", -1).let { if (it in 0..100) context.getString(R.string.pill_cover_open_format, it.toString()) else context.getString(R.string.pill_cover_open) }
+                "closed" -> context.getString(R.string.pill_cover_closed)
+                "opening" -> context.getString(R.string.pill_cover_opening)
+                "closing" -> context.getString(R.string.pill_cover_closing)
                 else -> rawDisplay
             }
-            PillKind.SWITCH -> when (s) { "on" -> "Allumé"; "off" -> "Éteint"; else -> rawDisplay }
+            PillKind.SWITCH -> when (s) { "on" -> context.getString(R.string.pill_switch_on); "off" -> context.getString(R.string.pill_switch_off); else -> rawDisplay }
             PillKind.FAN -> when (s) {
-                "on" -> e.attributes.optInt("percentage", -1).let { if (it in 0..100) "Marche · $it%" else "En marche" }
-                "off" -> "Arrêté"
+                "on" -> e.attributes.optInt("percentage", -1).let { if (it in 0..100) context.getString(R.string.pill_fan_on_format, it.toString()) else context.getString(R.string.pill_fan_on) }
+                "off" -> context.getString(R.string.pill_fan_off)
                 else -> rawDisplay
             }
             else -> rawDisplay
@@ -444,13 +449,13 @@ object PillPriorityEngine {
             .replace(Regex("^Capteur ", RegexOption.IGNORE_CASE), "")
             .replaceFirstChar { it.uppercase() }
         val qualitativeAir = if (rule.kind == PillKind.AIR) when {
-            visual == "warning" && score >= 70 -> "Mauvaise"
-            visual == "warning" -> "Moyenne"
-            else -> "Bonne"
+            visual == "warning" && score >= 70 -> context.getString(R.string.air_quality_bad)
+            visual == "warning" -> context.getString(R.string.air_quality_medium)
+            else -> context.getString(R.string.air_quality_good)
         } else value
         val finalLabel = when {
-            rule.kind == PillKind.AIR -> "Qualité de l'air"
-            rule.kind == PillKind.SAFETY && e.domain == "alarm_control_panel" -> "Sécurité"
+            rule.kind == PillKind.AIR -> context.getString(R.string.pill_individual_air_quality)
+            rule.kind == PillKind.SAFETY && e.domain == "alarm_control_panel" -> context.getString(R.string.pill_individual_security)
             else -> label
         }
         val details = if (rule.kind == PillKind.AIR) listOf(PillDetail(e.name, e.state + e.attributes.optString("unit_of_measurement"))) else emptyList()

--- a/app/src/main/java/com/iblu01/portallauncher/PillRepository.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/PillRepository.kt
@@ -1,6 +1,8 @@
 package com.iblu01.portallauncher
 
+import android.content.Context
 import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
 import com.iblu01.portallauncher.domain.MediaSessionBuilder
 import com.iblu01.portallauncher.domain.model.ForecastPoint
 import com.iblu01.portallauncher.domain.model.PillSnapshot
@@ -31,7 +33,8 @@ import javax.inject.Singleton
  * pull-consumers with a trailing debounce.
  */
 @Singleton
-class PillRepository @Inject constructor() {
+class PillRepository @Inject constructor(@ApplicationContext private val appContext: Context) {
+    private val priorityEngine = PillPriorityEngine(appContext)
     /** Lightweight change notifier for pull-consumers (the weather card). Carries no payload —
      *  consumers read the cache fields below. */
     fun interface Listener { fun onData() }
@@ -160,7 +163,7 @@ class PillRepository @Inject constructor() {
                 val rules = rulesProvider()   // read once per emission
                 val media = MediaSessionBuilder.build(s.states, haUrl, prevPrimaryIds)
                 val snapshot = PillSnapshot(
-                    chips = PillPriorityEngine.select(rules, s.states),
+                    chips = priorityEngine.select(rules, s.states),
                     media = media,
                     temperatures = temperatureSummary(rules, s.states),
                     connected = s.connected,

--- a/app/src/main/java/com/iblu01/portallauncher/PinShortcutActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/PinShortcutActivity.kt
@@ -22,11 +22,15 @@ import com.iblu01.portallauncher.ui.apps.toAndroidBitmap
  */
 class PinShortcutActivity : ComponentActivity() {
 
+    override fun attachBaseContext(newBase: android.content.Context) {
+        super.attachBaseContext(LocaleHelper.wrap(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val label = acceptPinRequest()
         if (label != null) {
-            Toast.makeText(this, "Raccourci ajouté : $label", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.toast_shortcut_added_format, label), Toast.LENGTH_SHORT).show()
         }
         finish()
     }

--- a/app/src/main/java/com/iblu01/portallauncher/PlaygroundActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/PlaygroundActivity.kt
@@ -11,6 +11,10 @@ import com.iblu01.portallauncher.ui.theme.PortalTheme
  * Launched from the home-screen long-press menu.
  */
 class PlaygroundActivity : ComponentActivity() {
+    override fun attachBaseContext(newBase: android.content.Context) {
+        super.attachBaseContext(LocaleHelper.wrap(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/app/src/main/java/com/iblu01/portallauncher/PortalApp.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/PortalApp.kt
@@ -1,8 +1,13 @@
 package com.iblu01.portallauncher
 
 import android.app.Application
+import android.content.Context
 import dagger.hilt.android.HiltAndroidApp
 
 /** Hilt entry point: hosts the app-wide dependency graph (SingletonComponent). */
 @HiltAndroidApp
-class PortalApp : Application()
+class PortalApp : Application() {
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(LocaleHelper.wrap(base))
+    }
+}

--- a/app/src/main/java/com/iblu01/portallauncher/Prefs.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/Prefs.kt
@@ -87,6 +87,16 @@ class Prefs(private val context: Context) {
         get() = sp.getString("background_mode", "neutral") ?: "neutral"
         set(value) = sp.edit().putString("background_mode", value).apply()
 
+    /**
+     * Language code ("en", "fr", …) or "" to follow the device's system language.
+     * Written with [SharedPreferences.Editor.commit], not `apply()`: the caller kills the
+     * process right after setting this to restart with the new locale, and `apply()`'s async
+     * disk write can lose the race against that — the setting silently reverted otherwise.
+     */
+    var appLanguage: String
+        get() = sp.getString("app_language", "") ?: ""
+        set(value) { sp.edit().putString("app_language", value).commit() }
+
     var bgOverlayOpacity: Float
         get() = sp.getFloat("bg_overlay_opacity", 0.25f)
         set(value) = sp.edit().putFloat("bg_overlay_opacity", value.coerceIn(0f, 0.6f)).apply()
@@ -343,5 +353,16 @@ enum class PowerMode {
     companion object {
         fun from(value: String?): PowerMode =
             values().firstOrNull { it.name == value } ?: FOLLOW_PRESENCE
+    }
+}
+
+/** App display language. [code] is stored in [Prefs.appLanguage]; "" means "follow the system". */
+enum class AppLanguage(val code: String, val flag: String, val nameRes: Int) {
+    SYSTEM("", "🌐", R.string.language_system),
+    ENGLISH("en", "🇬🇧", R.string.language_english),
+    FRENCH("fr", "🇫🇷", R.string.language_french);
+
+    companion object {
+        fun from(code: String): AppLanguage = values().firstOrNull { it.code == code } ?: SYSTEM
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/SettingsActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/SettingsActivity.kt
@@ -44,6 +44,10 @@ class SettingsActivity : ComponentActivity() {
     /** Last persisted MQTT-relevant values, to restart the bridge only when they actually change. */
     private var savedMqttSignature = ""
 
+    override fun attachBaseContext(newBase: android.content.Context) {
+        super.attachBaseContext(LocaleHelper.wrap(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         uiState.pillRules.addAll(prefs.pillRules)
@@ -313,6 +317,6 @@ class SettingsActivity : ComponentActivity() {
             }
             return
         }
-        Toast.makeText(this, "Permissions OK", Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, getString(R.string.toast_permissions_ok), Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/AccessoryToggles.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/AccessoryToggles.kt
@@ -39,6 +39,8 @@ import com.iblu01.portallauncher.ui.LocalCallService
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleMotion
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 /**
  * The big round HomeKit-style accessory button used by simple on/off accessories
@@ -79,7 +81,7 @@ fun SwitchControl(chip: LauncherChip) {
     val on = entity.state.equals("on", true)
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(Modifier.height(6.dp))
-        BigCircleButton(on, AppleColors.active, Icons.Outlined.PowerSettingsNew, if (on) "Allumé" else "Éteint") {
+        BigCircleButton(on, AppleColors.active, Icons.Outlined.PowerSettingsNew, if (on) stringResource(R.string.switch_state_on) else stringResource(R.string.switch_state_off)) {
             callService("switch", "toggle", chip.entityId)
         }
         Spacer(Modifier.height(20.dp))
@@ -95,7 +97,7 @@ fun FanControl(chip: LauncherChip) {
     val on = entity.state.equals("on", true)
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(Modifier.height(6.dp))
-        BigCircleButton(on, AppleColors.accent, Icons.Outlined.Air, if (on) "En marche" else "Arrêté") {
+        BigCircleButton(on, AppleColors.accent, Icons.Outlined.Air, if (on) stringResource(R.string.fan_state_on) else stringResource(R.string.fan_state_off)) {
             callService("fan", "toggle", chip.entityId)
         }
         Spacer(Modifier.height(20.dp))
@@ -104,7 +106,7 @@ fun FanControl(chip: LauncherChip) {
             val committed = entity.attributes.optInt("percentage", 0)
             var slider by remember(committed) { mutableFloatStateOf(committed.toFloat()) }
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                Text("Vitesse", style = AppleTypography.bodyLarge, color = AppleColors.secondary, modifier = Modifier.weight(1f))
+                Text(stringResource(R.string.fan_speed_label), style = AppleTypography.bodyLarge, color = AppleColors.secondary, modifier = Modifier.weight(1f))
                 Text("${slider.toInt()}%", style = AppleTypography.bodyLarge, color = AppleColors.primary)
             }
             Slider(
@@ -120,7 +122,7 @@ fun FanControl(chip: LauncherChip) {
             val oscillating = entity.attributes.optBoolean("oscillating", false)
             Spacer(Modifier.height(4.dp))
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-                PanelModeButton("Oscillation", Icons.Outlined.Sync, oscillating) {
+                PanelModeButton(stringResource(R.string.fan_oscillation_label), Icons.Outlined.Sync, oscillating) {
                     callService("fan", "oscillate", chip.entityId, mapOf("oscillating" to !oscillating))
                 }
             }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/AirQualityPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/AirQualityPanel.kt
@@ -37,6 +37,8 @@ import com.iblu01.portallauncher.LauncherChip
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 @Composable
 fun AirQualityContent(chip: LauncherChip, onBack: () -> Unit) {
@@ -84,13 +86,13 @@ private fun AirQualityHeader(onBack: () -> Unit) {
         ) {
             Icon(
                 Icons.Filled.ArrowBack,
-                contentDescription = "Retour",
+                contentDescription = stringResource(R.string.air_quality_back_desc),
                 tint = AppleColors.secondary,
                 modifier = Modifier.size(18.dp),
             )
         }
         Text(
-            "Qualité de l'air",
+            stringResource(R.string.air_quality_panel_title),
             style = AppleTypography.labelSmall.copy(fontSize = 12.sp, letterSpacing = 1.sp),
             color = AppleColors.tertiary,
             modifier = Modifier.align(Alignment.Center),

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/AlarmPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/AlarmPanel.kt
@@ -37,6 +37,8 @@ import com.iblu01.portallauncher.ui.components.controls.PinKeypad
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 private const val ALARM_DOMAIN = "alarm_control_panel"
 
@@ -69,7 +71,7 @@ fun AlarmControl(chip: LauncherChip) {
                     entityId = chip.entityId,
                     service = service,
                     currentState = state,
-                    prompt = if (service == "alarm_disarm") "Entrez le code pour désarmer" else "Entrez le code",
+                    prompt = if (service == "alarm_disarm") stringResource(R.string.alarm_disarm_prompt) else stringResource(R.string.alarm_arm_prompt),
                     onCancel = if (pendingArm != null) ({ pendingArm = null }) else null,
                 )
             }
@@ -89,7 +91,7 @@ fun AlarmControl(chip: LauncherChip) {
                         .map { option ->
                             AccessoryItem(
                                 id = option.service,
-                                title = option.label,
+                                title = stringResource(option.labelRes),
                                 icon = option.icon,
                                 // Disarmed here, so no option is live — the tiles read as actions.
                                 on = state == option.armedState,
@@ -107,13 +109,13 @@ private enum class ArmOption(
     val feature: Int,
     val service: String,
     val armedState: String,
-    val label: String,
+    val labelRes: Int,
     val icon: ImageVector,
 ) {
-    AWAY(AlarmFeature.ARM_AWAY, "alarm_arm_away", "armed_away", "Absence", Icons.Outlined.Luggage),
-    HOME(AlarmFeature.ARM_HOME, "alarm_arm_home", "armed_home", "Présence", Icons.Outlined.Home),
-    NIGHT(AlarmFeature.ARM_NIGHT, "alarm_arm_night", "armed_night", "Nuit", Icons.Outlined.Bedtime),
-    VACATION(AlarmFeature.ARM_VACATION, "alarm_arm_vacation", "armed_vacation", "Vacances", Icons.Outlined.NightShelter),
+    AWAY(AlarmFeature.ARM_AWAY, "alarm_arm_away", "armed_away", R.string.alarm_mode_away, Icons.Outlined.Luggage),
+    HOME(AlarmFeature.ARM_HOME, "alarm_arm_home", "armed_home", R.string.alarm_mode_home, Icons.Outlined.Home),
+    NIGHT(AlarmFeature.ARM_NIGHT, "alarm_arm_night", "armed_night", R.string.alarm_mode_night, Icons.Outlined.Bedtime),
+    VACATION(AlarmFeature.ARM_VACATION, "alarm_arm_vacation", "armed_vacation", R.string.alarm_mode_vacation, Icons.Outlined.NightShelter),
 }
 
 @Composable
@@ -129,7 +131,7 @@ private fun DisarmButton(highlight: Boolean, onClick: () -> Unit) {
             .padding(vertical = 16.dp),
         contentAlignment = Alignment.Center,
     ) {
-        Text("Désarmer", style = AppleTypography.titleMedium.copy(fontSize = 17.sp), color = color)
+        Text(stringResource(R.string.alarm_disarm_button), style = AppleTypography.titleMedium.copy(fontSize = 17.sp), color = color)
     }
 }
 

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/AppContextMenu.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/AppContextMenu.kt
@@ -44,9 +44,11 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.apps.AppShortcut
 import com.iblu01.portallauncher.ui.apps.GridItem
 import com.iblu01.portallauncher.ui.apps.GridSpan
@@ -168,13 +170,13 @@ fun AppContextMenu(
             } else if (!isDefaultHome && !item.isShortcut) {
                 MenuSeparator()
                 Text(
-                    text = "Raccourcis indisponibles — Portal n’est pas le launcher par défaut",
+                    text = stringResource(R.string.context_menu_shortcuts_unavailable),
                     style = AppleTypography.bodySmall.copy(fontSize = 12.sp),
                     color = AppleColors.tertiary,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 // Actionable, not just an explanation: this is where the user notices the problem.
-                ActionRow(Icons.Outlined.Home, "Définir Portal par défaut") {
+                ActionRow(Icons.Outlined.Home, stringResource(R.string.context_menu_set_default_home)) {
                     onOpenHomeSettings(); onDismiss()
                 }
             }
@@ -184,36 +186,36 @@ fun AppContextMenu(
                 // A widget has no label of its own to rename and no app-level action: what it does
                 // have is a size.
                 SizeStepper(
-                    label = "Largeur",
+                    label = stringResource(R.string.context_menu_width_stepper),
                     value = target.span.width,
                     max = maxSpan.width,
                     onChange = { onResize(target.span.copy(width = it)) },
                 )
                 SizeStepper(
-                    label = "Hauteur",
+                    label = stringResource(R.string.context_menu_height_stepper),
                     value = target.span.height,
                     max = maxSpan.height,
                     onChange = { onResize(target.span.copy(height = it)) },
                 )
                 MenuSeparator()
-                ActionRow(Icons.Outlined.Delete, "Retirer le widget", danger = true) {
+                ActionRow(Icons.Outlined.Delete, stringResource(R.string.context_menu_remove_widget), danger = true) {
                     onRemoveWidget(); onDismiss()
                 }
                 return@Column
             }
-            ActionRow(Icons.Outlined.DriveFileRenameOutline, "Renommer") {
+            ActionRow(Icons.Outlined.DriveFileRenameOutline, stringResource(R.string.context_menu_rename)) {
                 draft = item.label
                 renaming = true
             }
             if (item.isShortcut) {
-                ActionRow(Icons.Outlined.Delete, "Retirer le raccourci") {
+                ActionRow(Icons.Outlined.Delete, stringResource(R.string.context_menu_remove_shortcut)) {
                     onRemoveShortcut(); onDismiss()
                 }
             } else {
-                ActionRow(Icons.Outlined.VisibilityOff, "Masquer") { onHide(); onDismiss() }
-                ActionRow(Icons.Outlined.Info, "Infos de l’application") { onAppInfo(); onDismiss() }
+                ActionRow(Icons.Outlined.VisibilityOff, stringResource(R.string.context_menu_hide)) { onHide(); onDismiss() }
+                ActionRow(Icons.Outlined.Info, stringResource(R.string.context_menu_app_info)) { onAppInfo(); onDismiss() }
                 if (canUninstall) {
-                    ActionRow(Icons.Outlined.Delete, "Désinstaller", danger = true) {
+                    ActionRow(Icons.Outlined.Delete, stringResource(R.string.context_menu_uninstall), danger = true) {
                         onUninstall(); onDismiss()
                     }
                 }
@@ -268,10 +270,10 @@ private fun StepperButton(glyph: String, enabled: Boolean, onClick: () -> Unit) 
 private fun RenameField(value: String, onValueChange: (String) -> Unit, onConfirm: () -> Unit) {
     Column(Modifier.fillMaxWidth()) {
         SettingsTextField(
-            label = "Nom affiché",
+            label = stringResource(R.string.context_menu_rename_label),
             value = value,
             onValueChange = onValueChange,
-            placeholder = "Nom d’origine",
+            placeholder = stringResource(R.string.context_menu_rename_placeholder),
         )
         Row(
             modifier = Modifier
@@ -280,7 +282,7 @@ private fun RenameField(value: String, onValueChange: (String) -> Unit, onConfir
             horizontalArrangement = Arrangement.End,
         ) {
             Text(
-                "Valider",
+                stringResource(R.string.context_menu_confirm),
                 style = AppleTypography.titleMedium,
                 color = AppleColors.accent,
                 modifier = Modifier

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/AutoReturnOverlay.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/AutoReturnOverlay.kt
@@ -21,12 +21,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.dp
 import com.iblu01.portallauncher.AutoReturnUiState
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
@@ -87,7 +89,7 @@ private fun AutoReturnPill(
         }
 
         Text(
-            "Fermeture auto",
+            stringResource(R.string.auto_return_pill_label),
             style = AppleTypography.bodySmall,
             color = AppleColors.primary,
         )
@@ -102,7 +104,7 @@ private fun AutoReturnPill(
         ) {
             Icon(
                 Icons.Outlined.Close,
-                contentDescription = "Annuler",
+                contentDescription = stringResource(R.string.auto_return_cancel_desc),
                 tint = AppleColors.primary,
                 modifier = Modifier.size(14.dp),
             )

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
@@ -32,11 +32,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.LauncherChip
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.domain.model.TemperatureSummary
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
@@ -197,8 +199,8 @@ fun ClockHeader(
                 horizontalArrangement = Arrangement.spacedBy(14.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text("Appartement ${temperatures.indoorMin}–${temperatures.indoorMax}", style = AppleTypography.bodySmall.copy(fontSize = 15.sp), color = AppleColors.primary)
-                Text("Ext. ${temperatures.outdoor.takeUnless { it == "—" } ?: weather.temp}", style = AppleTypography.bodySmall.copy(fontSize = 15.sp), color = AppleColors.secondary)
+                Text(stringResource(R.string.clock_indoor_temp_format, temperatures.indoorMin, temperatures.indoorMax), style = AppleTypography.bodySmall.copy(fontSize = 15.sp), color = AppleColors.primary)
+                Text(stringResource(R.string.clock_outdoor_temp_format, temperatures.outdoor.takeUnless { it == "—" } ?: weather.temp), style = AppleTypography.bodySmall.copy(fontSize = 15.sp), color = AppleColors.secondary)
             }
             if (!connected && lastUpdateAt > 0L) {
                 Spacer(Modifier.height(8.dp * clockTheme.elementSpacing))
@@ -237,13 +239,13 @@ fun ClockTray(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    if (pillsExpanded) "Masquer les informations" else "Voir plus d’informations",
+                    if (pillsExpanded) stringResource(R.string.clock_collapse_pills) else stringResource(R.string.clock_expand_pills),
                     style = AppleTypography.bodySmall.copy(fontSize = 13.sp.scaled()),
                     color = AppleColors.secondary.copy(alpha = 0.62f),
                 )
                 Icon(
                     if (pillsExpanded) Icons.Outlined.KeyboardArrowDown else Icons.Outlined.KeyboardArrowUp,
-                    contentDescription = if (pillsExpanded) "Replier" else "Déplier",
+                    contentDescription = if (pillsExpanded) stringResource(R.string.clock_collapse_content_desc) else stringResource(R.string.clock_expand_content_desc),
                     tint = AppleColors.secondary.copy(alpha = 0.62f),
                 )
             }
@@ -275,7 +277,7 @@ private fun StaleBanner(lastUpdateAt: Long) {
             .padding(horizontal = 14.dp, vertical = 5.dp),
     ) {
         Text(
-            "Hors ligne — infos figées depuis $ago",
+            stringResource(R.string.clock_stale_banner_format, ago),
             style = AppleTypography.bodySmall.copy(fontSize = 13.sp),
             color = Color(0xFFFFC062),
         )

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/CoverPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/CoverPanel.kt
@@ -25,6 +25,8 @@ import com.iblu01.portallauncher.ui.LocalCallService
 import com.iblu01.portallauncher.ui.components.controls.VerticalFillSlider
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 import kotlin.math.roundToInt
 
 @Composable
@@ -45,10 +47,10 @@ fun CoverControl(chip: LauncherChip) {
             when {
                 canSetPosition -> "${sliderPos.roundToInt()} %"
                 position in 0..100 -> "$position %"
-                state == "open" -> "Ouvert"
-                state == "closed" -> "Fermé"
-                state == "opening" -> "Ouverture…"
-                state == "closing" -> "Fermeture…"
+                state == "open" -> stringResource(R.string.cover_state_open)
+                state == "closed" -> stringResource(R.string.cover_state_closed)
+                state == "opening" -> stringResource(R.string.cover_state_opening)
+                state == "closing" -> stringResource(R.string.cover_state_closing)
                 else -> chip.value
             },
             style = AppleTypography.headlineLarge,
@@ -76,19 +78,19 @@ fun CoverControl(chip: LauncherChip) {
             horizontalArrangement = Arrangement.SpaceEvenly,
         ) {
             GlassButton(
-                label = "Ouvrir",
+                label = stringResource(R.string.cover_button_open),
                 icon = Icons.Outlined.KeyboardArrowUp,
                 active = state == "opening",
                 onClick = { callService("cover", "open_cover", chip.entityId) },
             )
             GlassButton(
-                label = "Stop",
+                label = stringResource(R.string.cover_button_stop),
                 icon = Icons.Filled.Stop,
                 active = false,
                 onClick = { callService("cover", "stop_cover", chip.entityId) },
             )
             GlassButton(
-                label = "Fermer",
+                label = stringResource(R.string.cover_button_close),
                 icon = Icons.Outlined.KeyboardArrowDown,
                 active = state == "closing",
                 onClick = { callService("cover", "close_cover", chip.entityId) },

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/DynamicBackground.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/DynamicBackground.kt
@@ -22,6 +22,7 @@ import okhttp3.OkHttpClient
 import java.net.Proxy
 import java.util.concurrent.TimeUnit
 import androidx.compose.runtime.remember
+import com.iblu01.portallauncher.R
 
 private val unsplashUrls = listOf(
     "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=1200&q=80" to "Mer",
@@ -32,9 +33,9 @@ private val unsplashUrls = listOf(
 )
 
 val backgroundModes = listOf(
-    "neutral" to "Neutre",
-    "nature" to "Nature (Unsplash)",
-    "custom" to "Photo perso",
+    "neutral" to R.string.bg_mode_neutral,
+    "nature" to R.string.bg_mode_nature,
+    "custom" to R.string.bg_mode_custom,
 )
 
 @Composable

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/EnergyPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/EnergyPanel.kt
@@ -29,13 +29,15 @@ import com.iblu01.portallauncher.domain.model.PillDetail
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 import com.iblu01.portallauncher.ui.theme.AppleMotion
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 import kotlin.math.roundToInt
 
 /** Live power with an auto-scaling gauge, plus today's energy. */
 @Composable
 fun EnergyActions(chip: LauncherChip) {
-    val powerDetail = chip.details.firstOrNull { it.label == "Puissance" }
-    val energyDetail = chip.details.firstOrNull { it.label == "Aujourd'hui" }
+    val powerDetail = chip.details.firstOrNull { it.label == stringResource(R.string.energy_power_label) }
+    val energyDetail = chip.details.firstOrNull { it.label == stringResource(R.string.energy_today_label) }
     val entity = powerDetail?.entityId?.let { rememberEntity(it) }
     val watts = entity?.state?.toFloatOrNull() ?: powerDetail?.value?.filter { it.isDigit() }?.toFloatOrNull() ?: 0f
 
@@ -54,6 +56,6 @@ fun EnergyActions(chip: LauncherChip) {
         Spacer(Modifier.height(6.dp))
         Text("max ${gaugeMax.roundToInt()} W", style = AppleTypography.bodySmall.copy(fontSize = 12.sp), color = AppleColors.tertiary)
         Spacer(Modifier.height(18.dp))
-        if (energyDetail != null) PanelDetailRow(PillDetail("Aujourd'hui", energyDetail.value))
+        if (energyDetail != null) PanelDetailRow(PillDetail(stringResource(R.string.energy_today_label), energyDetail.value))
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/HiddenAppsDialog.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/HiddenAppsDialog.kt
@@ -23,10 +23,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.apps.GridItem
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
@@ -65,13 +67,13 @@ fun HiddenAppsDialog(
                 .padding(vertical = 12.dp),
         ) {
             Text(
-                "Applications masquées",
+                stringResource(R.string.hidden_apps_title),
                 style = AppleTypography.titleMedium,
                 color = AppleColors.primary,
                 modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
             )
             Text(
-                if (items.isEmpty()) "Aucune" else "Touchez pour remettre sur la grille",
+                if (items.isEmpty()) stringResource(R.string.hidden_apps_empty) else stringResource(R.string.hidden_apps_tap_to_restore),
                 style = AppleTypography.bodySmall.copy(fontSize = 13.sp),
                 color = AppleColors.tertiary,
                 modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 8.dp),

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/LauncherHeaderActions.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/LauncherHeaderActions.kt
@@ -14,11 +14,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
@@ -42,14 +44,14 @@ fun LauncherHeaderActions(
             // empty list, and "Masquer" would have no visible way back.
             HeaderAction(
                 icon = Icons.Outlined.VisibilityOff,
-                contentDescription = "Applications masquées ($hiddenCount)",
+                contentDescription = stringResource(R.string.header_hidden_apps_content_desc, hiddenCount),
                 badge = hiddenCount.toString(),
                 onClick = onShowHidden,
             )
         }
         HeaderAction(
             icon = Icons.Outlined.Settings,
-            contentDescription = "Réglages",
+            contentDescription = stringResource(R.string.header_settings_content_desc),
             onClick = onSettings,
         )
     }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/LightDetailPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/LightDetailPanel.kt
@@ -88,6 +88,8 @@ import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleMotion
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.delay
 import kotlin.math.PI
 import kotlin.math.atan2
@@ -310,7 +312,7 @@ private fun ColumnScope.LandscapeLightDetail(
                 Spacer(Modifier.height(14.dp))
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(7.dp)) {
                     Icon(Icons.Filled.WbSunny, null, tint = AppleColors.secondary, modifier = Modifier.size(18.dp))
-                    Text("Canal blanc intégré", style = AppleTypography.bodySmall, color = AppleColors.secondary)
+                    Text(stringResource(R.string.light_white_channel_label), style = AppleTypography.bodySmall, color = AppleColors.secondary)
                 }
             }
         }
@@ -407,7 +409,7 @@ private fun ColorPresetsBar(
             PowerButton(isOn, onPowerToggle)
         }
     } else {
-        if (supportsColor) Text("Couleurs", style = AppleTypography.bodySmall, color = AppleColors.secondary)
+        if (supportsColor) Text(stringResource(R.string.light_colors_section), style = AppleTypography.bodySmall, color = AppleColors.secondary)
         val colorRows = colorPresets.takeIf { supportsColor }?.chunked(3).orEmpty()
         colorRows.forEachIndexed { index, row ->
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -420,7 +422,7 @@ private fun ColorPresetsBar(
         }
         if (supportsColor && colorPresets.size % 3 == 0) PaletteButton { onOpenWheel(null) }
         if (supportsWhite) {
-            Text(if (whiteChannel) "Blancs · canal W" else "Blancs", style = AppleTypography.bodySmall, color = AppleColors.secondary)
+            Text(if (whiteChannel) stringResource(R.string.light_whites_w_channel_label) else stringResource(R.string.light_whites_label), style = AppleTypography.bodySmall, color = AppleColors.secondary)
             whitePresets.chunked(3).forEach { row ->
                 Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                     row.forEach { (rawKelvin, swatch) ->
@@ -456,7 +458,7 @@ private fun PowerButton(isOn: Boolean, onToggle: (Boolean) -> Unit) {
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Icon(Icons.Filled.PowerSettingsNew, null, tint = if (isOn) AppleColors.accent else AppleColors.secondary, modifier = Modifier.size(17.dp))
-        Text(if (isOn) "Éteindre" else "Allumer", style = AppleTypography.bodySmall, color = AppleColors.primary)
+        Text(if (isOn) stringResource(R.string.light_power_off) else stringResource(R.string.light_power_on), style = AppleTypography.bodySmall, color = AppleColors.primary)
     }
 }
 
@@ -464,9 +466,10 @@ private fun PowerButton(isOn: Boolean, onToggle: (Boolean) -> Unit) {
 private fun PaletteButton(onClick: () -> Unit) {
     var pressed by remember { mutableStateOf(false) }
     val scale by animateFloatAsState(if (pressed) 0.92f else 1f, AppleMotion.spring(), label = "paletteScale")
+    val colorWheelDesc = stringResource(R.string.light_open_color_wheel_desc)
     Box(
         Modifier.scale(scale).size(46.dp).clip(CircleShape).background(AppleColors.frostedFill)
-            .border(1.dp, AppleColors.frostedBorder, CircleShape).semantics { contentDescription = "Ouvrir la roue chromatique" }
+            .border(1.dp, AppleColors.frostedBorder, CircleShape).semantics { contentDescription = colorWheelDesc }
             .pointerInput(onClick) { detectTapGestures(onPress = { pressed = true; tryAwaitRelease(); pressed = false }, onTap = { onClick() }) },
         contentAlignment = Alignment.Center,
     ) {
@@ -479,11 +482,13 @@ private fun PaletteButton(onClick: () -> Unit) {
 private fun ColorDot(color: Color, active: Boolean, onClick: () -> Unit, onLongClick: (() -> Unit)?) {
     var pressed by remember { mutableStateOf(false) }
     val scale by animateFloatAsState(if (pressed) 0.92f else 1f, AppleMotion.spring(), label = "dotScale")
+    val activeDesc = stringResource(R.string.light_color_active_desc)
+    val applyDesc = stringResource(R.string.light_color_apply_desc)
     Box(
         Modifier.scale(scale).size(46.dp)
             .then(if (active) Modifier.shadow(10.dp, CircleShape, ambientColor = color, spotColor = color) else Modifier)
             .clip(CircleShape).background(color).border(if (active) 2.dp else 1.dp, Color.White.copy(alpha = if (active) 0.95f else 0.35f), CircleShape)
-            .semantics { contentDescription = if (active) "Couleur active" else "Appliquer cette couleur" }
+            .semantics { contentDescription = if (active) activeDesc else applyDesc }
             .pointerInput(onClick, onLongClick) {
                 detectTapGestures(
                     onPress = { pressed = true; tryAwaitRelease(); pressed = false },
@@ -507,13 +512,13 @@ private fun SliderModeSwitch(
     ) {
         SliderModeButton(
             icon = Icons.Filled.WbSunny,
-            label = if (compact) null else "Luminosité",
+            label = if (compact) null else stringResource(R.string.light_mode_brightness),
             selected = mode == LightSliderMode.BRIGHTNESS,
             onClick = { onModeChange(LightSliderMode.BRIGHTNESS) },
         )
         SliderModeButton(
             icon = Icons.Filled.NightsStay,
-            label = if (compact) null else "Température",
+            label = if (compact) null else stringResource(R.string.light_mode_temperature),
             selected = mode == LightSliderMode.COLOR_TEMPERATURE,
             onClick = { onModeChange(LightSliderMode.COLOR_TEMPERATURE) },
         )
@@ -561,9 +566,9 @@ private fun ColorWheelOverlay(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
-                        Text("Couleur", style = AppleTypography.titleLarge, color = AppleColors.primary)
+                        Text(stringResource(R.string.light_color_wheel_title), style = AppleTypography.titleLarge, color = AppleColors.primary)
                         Box(Modifier.size(40.dp).clip(CircleShape).background(AppleColors.frostedFill).pointerInput(onDismiss) { detectTapGestures { onDismiss() } }, contentAlignment = Alignment.Center) {
-                            Icon(Icons.Filled.Close, "Fermer", tint = AppleColors.primary, modifier = Modifier.size(20.dp))
+                            Icon(Icons.Filled.Close, stringResource(R.string.light_color_wheel_close_desc), tint = AppleColors.primary, modifier = Modifier.size(20.dp))
                         }
                     }
                     Spacer(Modifier.height(if (landscape) 10.dp else 20.dp))

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/LockPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/LockPanel.kt
@@ -19,6 +19,8 @@ import com.iblu01.portallauncher.ui.LocalCallService
 import com.iblu01.portallauncher.ui.components.controls.VerticalSwitch
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 /**
  * HomeKit-style lock as a 2-position toggle: up/green is locked, down/amber is unlocked.
@@ -34,7 +36,7 @@ fun LockControl(chip: LauncherChip) {
     val jammed = state == "jammed"
 
     val accent = if (jammed) AppleColors.error else AppleColors.active
-    val caption = when { jammed -> "Bloquée"; locked -> "Verrouillée"; else -> "Déverrouillée" }
+    val caption = when { jammed -> stringResource(R.string.lock_state_jammed); locked -> stringResource(R.string.lock_state_locked); else -> stringResource(R.string.lock_state_unlocked) }
 
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(Modifier.height(6.dp))

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/MediaPlayerView.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/MediaPlayerView.kt
@@ -61,12 +61,14 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.domain.model.MediaPlayerVolume
 import com.iblu01.portallauncher.domain.model.PlayingMedia
 import com.iblu01.portallauncher.ui.theme.AppleColors
@@ -141,7 +143,7 @@ fun MediaPlayerView(
         0 -> fallbackSourceName
         1 -> media.playerNames.first()
         2 -> "${media.playerNames[0]} + ${media.playerNames[1]}"
-        else -> "${media.playerNames.first()} + ${media.playerNames.size - 1} autres"
+        else -> stringResource(R.string.media_source_many_format, media.playerNames.first(), media.playerNames.size - 1)
     }
 
     BoxWithConstraints(
@@ -264,12 +266,12 @@ fun MediaPlayerView(
                             AsyncImage(
                                 model = imageRequest,
                                 imageLoader = imageLoader,
-                                contentDescription = "Pochette de ${media.title}",
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier.fillMaxSize()
-                            )
-                        } else {
-                            Icon(Icons.Outlined.MusicNote, "Aucune pochette", tint = AppleColors.secondary, modifier = Modifier.size(64.dp))
+            contentDescription = stringResource(R.string.media_cover_desc_format, media.title),
+                                                contentScale = ContentScale.Crop,
+                                                modifier = Modifier.fillMaxSize()
+                                            )
+                                        } else {
+                                            Icon(Icons.Outlined.MusicNote, stringResource(R.string.media_no_cover_desc), tint = AppleColors.secondary, modifier = Modifier.size(64.dp))
                         }
                     }
 
@@ -313,13 +315,13 @@ fun MediaPlayerView(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             IconButton(onClick = onPrevious, modifier = Modifier.size(40.dp)) {
-                                Icon(Icons.Filled.SkipPrevious, "Titre précédent", tint = AppleColors.primary, modifier = Modifier.size(22.dp))
+                                Icon(Icons.Filled.SkipPrevious, stringResource(R.string.media_previous_track_desc), tint = AppleColors.primary, modifier = Modifier.size(22.dp))
                             }
                             IconButton(onClick = onPlayPause, modifier = Modifier.size(50.dp).background(Color.White, CircleShape)) {
-                                Icon(if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow, if (isPlaying) "Pause" else "Lecture", tint = Color.Black, modifier = Modifier.size(28.dp))
+                                Icon(if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow, if (isPlaying) stringResource(R.string.media_pause_desc) else stringResource(R.string.media_play_desc), tint = Color.Black, modifier = Modifier.size(28.dp))
                             }
                             IconButton(onClick = onNext, modifier = Modifier.size(40.dp)) {
-                                Icon(Icons.Filled.SkipNext, "Titre suivant", tint = AppleColors.primary, modifier = Modifier.size(22.dp))
+                                Icon(Icons.Filled.SkipNext, stringResource(R.string.media_next_track_desc), tint = AppleColors.primary, modifier = Modifier.size(22.dp))
                             }
                         }
 
@@ -333,8 +335,8 @@ fun MediaPlayerView(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(7.dp)
                         ) {
-                            Icon(if (media.isMuted) Icons.Filled.VolumeOff else Icons.Filled.VolumeUp, "Volume", tint = AppleColors.secondary, modifier = Modifier.size(18.dp))
-                            Text(if (media.players.size > 1) "Volumes · ${media.players.size} appareils" else "Volume · ${media.volumePercent}%", style = AppleTypography.bodySmall.copy(fontSize = 12.sp), color = AppleColors.primary)
+                            Icon(if (media.isMuted) Icons.Filled.VolumeOff else Icons.Filled.VolumeUp, stringResource(R.string.media_volume_desc), tint = AppleColors.secondary, modifier = Modifier.size(18.dp))
+                            Text(if (media.players.size > 1) stringResource(R.string.media_volume_multi_format, media.players.size) else stringResource(R.string.media_volume_single_format, media.volumePercent), style = AppleTypography.bodySmall.copy(fontSize = 12.sp), color = AppleColors.primary)
                         }
                     }
                 }
@@ -350,7 +352,7 @@ fun MediaPlayerView(
                             .clickable { onDismiss() },
                         contentAlignment = Alignment.Center,
                     ) {
-                        Icon(Icons.Filled.Close, contentDescription = "Fermer le lecteur", tint = AppleColors.secondary, modifier = Modifier.size(16.dp))
+                        Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.media_close_player_desc), tint = AppleColors.secondary, modifier = Modifier.size(16.dp))
                     }
                 }
             }
@@ -376,7 +378,7 @@ fun MediaPlayerView(
                                 .clickable { onDismiss() },
                             contentAlignment = Alignment.Center,
                         ) {
-                            Icon(Icons.Filled.Close, contentDescription = "Fermer le lecteur", tint = AppleColors.secondary, modifier = Modifier.size(18.dp))
+                            Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.media_close_player_desc), tint = AppleColors.secondary, modifier = Modifier.size(18.dp))
                         }
                     }
                     Row(
@@ -403,10 +405,10 @@ fun MediaPlayerView(
                         .border(1.dp, Color.White.copy(alpha = 0.16f), RoundedCornerShape(28.dp)),
                     contentAlignment = Alignment.Center
                 ) {
-                    if (imageRequest != null) {
-                        AsyncImage(model = imageRequest, imageLoader = imageLoader, contentDescription = "Pochette de ${media.title}", contentScale = ContentScale.Crop, modifier = Modifier.fillMaxSize())
-                    } else {
-                        Icon(Icons.Outlined.MusicNote, "Aucune pochette", tint = AppleColors.secondary, modifier = Modifier.size(82.dp))
+                        if (imageRequest != null) {
+                            AsyncImage(model = imageRequest, imageLoader = imageLoader, contentDescription = stringResource(R.string.media_cover_desc_format, media.title), contentScale = ContentScale.Crop, modifier = Modifier.fillMaxSize())
+                        } else {
+                            Icon(Icons.Outlined.MusicNote, stringResource(R.string.media_no_cover_desc), tint = AppleColors.secondary, modifier = Modifier.size(82.dp))
                     }
                 }
 
@@ -434,13 +436,13 @@ fun MediaPlayerView(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     IconButton(onClick = onPrevious, modifier = Modifier.size(46.dp)) {
-                        Icon(Icons.Filled.SkipPrevious, "Titre précédent", tint = AppleColors.primary, modifier = Modifier.size(26.dp))
+                        Icon(Icons.Filled.SkipPrevious, stringResource(R.string.media_previous_track_desc), tint = AppleColors.primary, modifier = Modifier.size(26.dp))
                     }
                     IconButton(onClick = onPlayPause, modifier = Modifier.size(58.dp).background(Color.White, CircleShape)) {
-                        Icon(if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow, if (isPlaying) "Pause" else "Lecture", tint = Color.Black, modifier = Modifier.size(32.dp))
+                        Icon(if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow, if (isPlaying) stringResource(R.string.media_pause_desc) else stringResource(R.string.media_play_desc), tint = Color.Black, modifier = Modifier.size(32.dp))
                     }
                     IconButton(onClick = onNext, modifier = Modifier.size(46.dp)) {
-                        Icon(Icons.Filled.SkipNext, "Titre suivant", tint = AppleColors.primary, modifier = Modifier.size(26.dp))
+                        Icon(Icons.Filled.SkipNext, stringResource(R.string.media_next_track_desc), tint = AppleColors.primary, modifier = Modifier.size(26.dp))
                     }
                 }
 
@@ -454,8 +456,8 @@ fun MediaPlayerView(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(9.dp)
                 ) {
-                    Icon(if (media.isMuted) Icons.Filled.VolumeOff else Icons.Filled.VolumeUp, "Volume", tint = AppleColors.secondary, modifier = Modifier.size(20.dp))
-                    Text(if (media.players.size > 1) "Volumes · ${media.players.size} appareils" else "Volume · ${media.volumePercent}%", style = AppleTypography.bodySmall.copy(fontSize = 13.sp), color = AppleColors.primary)
+                    Icon(if (media.isMuted) Icons.Filled.VolumeOff else Icons.Filled.VolumeUp, stringResource(R.string.media_volume_desc), tint = AppleColors.secondary, modifier = Modifier.size(20.dp))
+                    Text(if (media.players.size > 1) stringResource(R.string.media_volume_multi_format, media.players.size) else stringResource(R.string.media_volume_single_format, media.volumePercent), style = AppleTypography.bodySmall.copy(fontSize = 13.sp), color = AppleColors.primary)
                 }
             }
         }
@@ -485,7 +487,7 @@ fun MediaPlayerView(
                     }
                     if (secondaryMedia.size > 2) {
                         Text(
-                            "+ ${secondaryMedia.size - 2} autres",
+                            stringResource(R.string.media_secondary_more_format, secondaryMedia.size - 2),
                             style = AppleTypography.bodySmall,
                             color = AppleColors.secondary,
                             modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -509,7 +511,7 @@ fun MediaPlayerView(
                 }
                 if (secondaryMedia.size > 2) {
                     Text(
-                        "+ ${secondaryMedia.size - 2} autres lectures actives",
+                        stringResource(R.string.media_secondary_more_active_format, secondaryMedia.size - 2),
                         style = AppleTypography.bodySmall,
                         color = AppleColors.secondary,
                     )
@@ -528,7 +530,7 @@ fun MediaPlayerView(
                         modifier = Modifier.padding(24.dp).fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(18.dp)
                     ) {
-                        Text("Volumes", style = AppleTypography.headlineLarge.copy(fontSize = 24.sp), color = AppleColors.primary)
+                        Text(stringResource(R.string.media_volume_dialog_title), style = AppleTypography.headlineLarge.copy(fontSize = 24.sp), color = AppleColors.primary)
                         (media.players.ifEmpty {
                             listOf(com.iblu01.portallauncher.domain.model.MediaPlayerVolume(media.entityId, sourceName, media.volumePercent, media.isMuted))
                         }).forEach { player ->
@@ -553,7 +555,7 @@ fun MediaPlayerView(
                             }
                         }
                         Text(
-                            "Fermer",
+                            stringResource(R.string.media_volume_dialog_close),
                             modifier = Modifier.align(Alignment.End).clip(AppleShapes.pill).clickable { volumeDialogVisible = false }
                                 .background(AppleColors.frostedFill).padding(horizontal = 18.dp, vertical = 10.dp),
                             style = AppleTypography.titleMedium,
@@ -574,8 +576,8 @@ fun MediaPlayerView(
                         modifier = Modifier.padding(24.dp).fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
-                        Text("Diffuser dans", style = AppleTypography.headlineLarge.copy(fontSize = 24.sp), color = AppleColors.primary)
-                        Text("Sélectionne les appareils à coupler avec $sourceName", style = AppleTypography.bodySmall, color = AppleColors.secondary)
+                        Text(stringResource(R.string.media_group_dialog_title), style = AppleTypography.headlineLarge.copy(fontSize = 24.sp), color = AppleColors.primary)
+                        Text(stringResource(R.string.media_group_dialog_subtitle_format, sourceName), style = AppleTypography.bodySmall, color = AppleColors.secondary)
                         media.groupablePlayers.forEach { player ->
                             val isLeader = player.entityId == media.entityId
                             val isMember = isLeader || player.entityId in selectedGroupMembers
@@ -601,11 +603,11 @@ fun MediaPlayerView(
                                         .background(if (isMember) AppleColors.active else Color.Transparent),
                                 )
                                 Text(player.name, modifier = Modifier.weight(1f), style = AppleTypography.titleMedium, color = AppleColors.primary)
-                                if (isLeader) Text("Principal", style = AppleTypography.bodySmall, color = AppleColors.secondary)
+                                if (isLeader) Text(stringResource(R.string.media_group_leader_label), style = AppleTypography.bodySmall, color = AppleColors.secondary)
                             }
                         }
                         Text(
-                            "Fermer",
+                            stringResource(R.string.media_group_dialog_close),
                             modifier = Modifier.align(Alignment.End).clip(AppleShapes.pill).clickable { groupDialogVisible = false }
                                 .background(AppleColors.frostedFill).padding(horizontal = 18.dp, vertical = 10.dp),
                             style = AppleTypography.titleMedium,
@@ -635,7 +637,7 @@ private fun SwipeIncomingCard(
         0 -> media.entityId.substringAfter('.').replace('_', ' ')
         1 -> media.playerNames.first()
         2 -> "${media.playerNames[0]} + ${media.playerNames[1]}"
-        else -> "${media.playerNames.first()} + ${media.playerNames.size - 1} autres"
+        else -> stringResource(R.string.media_source_many_format, media.playerNames.first(), media.playerNames.size - 1)
     }
     Box(
         modifier = modifier.clip(AppleShapes.panel).background(Color.Black.copy(alpha = 0.86f))
@@ -723,18 +725,18 @@ private fun MiniMediaPlayer(
             Text(media.artist, style = AppleTypography.bodySmall.copy(fontSize = 11.sp), color = AppleColors.secondary, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
         IconButton(onClick = onPrevious, modifier = Modifier.size(30.dp)) {
-            Icon(Icons.Filled.SkipPrevious, "Titre précédent dans $rooms", tint = AppleColors.primary, modifier = Modifier.size(20.dp))
+            Icon(Icons.Filled.SkipPrevious, stringResource(R.string.media_mini_previous_desc_format, rooms), tint = AppleColors.primary, modifier = Modifier.size(20.dp))
         }
         IconButton(onClick = onPlayPause, modifier = Modifier.size(38.dp).background(Color.White, CircleShape)) {
             Icon(
                 if (playing) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                if (playing) "Mettre en pause $rooms" else "Lire dans $rooms",
+                if (playing) stringResource(R.string.media_mini_pause_desc_format, rooms) else stringResource(R.string.media_mini_play_desc_format, rooms),
                 tint = Color.Black,
                 modifier = Modifier.size(22.dp),
             )
         }
         IconButton(onClick = onNext, modifier = Modifier.size(30.dp)) {
-            Icon(Icons.Filled.SkipNext, "Titre suivant dans $rooms", tint = AppleColors.primary, modifier = Modifier.size(20.dp))
+            Icon(Icons.Filled.SkipNext, stringResource(R.string.media_mini_next_desc_format, rooms), tint = AppleColors.primary, modifier = Modifier.size(20.dp))
         }
     }
 }
@@ -804,18 +806,18 @@ private fun MiniMediaPlayerVertical(
             horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             IconButton(onClick = onPrevious, modifier = Modifier.size(30.dp)) {
-                Icon(Icons.Filled.SkipPrevious, "Titre précédent dans $rooms", tint = AppleColors.primary, modifier = Modifier.size(20.dp))
+                Icon(Icons.Filled.SkipPrevious, stringResource(R.string.media_vertical_previous_desc_format, rooms), tint = AppleColors.primary, modifier = Modifier.size(20.dp))
             }
             IconButton(onClick = onPlayPause, modifier = Modifier.size(38.dp).background(Color.White, CircleShape)) {
                 Icon(
                     if (playing) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                    if (playing) "Mettre en pause $rooms" else "Lire dans $rooms",
+                    if (playing) stringResource(R.string.media_vertical_pause_desc_format, rooms) else stringResource(R.string.media_vertical_play_desc_format, rooms),
                     tint = Color.Black,
                     modifier = Modifier.size(22.dp),
                 )
             }
             IconButton(onClick = onNext, modifier = Modifier.size(30.dp)) {
-                Icon(Icons.Filled.SkipNext, "Titre suivant dans $rooms", tint = AppleColors.primary, modifier = Modifier.size(20.dp))
+                Icon(Icons.Filled.SkipNext, stringResource(R.string.media_vertical_next_desc_format, rooms), tint = AppleColors.primary, modifier = Modifier.size(20.dp))
             }
         }
     }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/PanelHelpers.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/PanelHelpers.kt
@@ -26,6 +26,8 @@ import com.iblu01.portallauncher.ui.LocalHaStates
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 /**
  * Live view of a single HA entity for a control panel. Reads [LocalHaStates] (fed by the VM),
@@ -52,7 +54,7 @@ fun HaEntity?.isUnavailable(): Boolean = this == null || state.lowercase() in se
 
 /** Shown by a control panel when its entity is missing or unavailable, instead of a blank body. */
 @Composable
-fun PanelUnavailable(message: String = "Appareil indisponible") {
+fun PanelUnavailable(message: String = stringResource(R.string.panel_device_unavailable)) {
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/PurifierPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/PurifierPanel.kt
@@ -21,13 +21,15 @@ import com.iblu01.portallauncher.LauncherChip
 import com.iblu01.portallauncher.ui.LocalCallService
 import com.iblu01.portallauncher.ui.components.controls.VerticalSegmentedSelector
 import com.iblu01.portallauncher.ui.theme.AppleColors
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
-private enum class PurifierMode(val preset: String?, val label: String, val icon: ImageVector) {
-    AUTO("auto", "Auto", Icons.Outlined.AutoMode),
-    SLEEP("sleep", "Nuit", Icons.Outlined.Bedtime),
-    MANUAL("manual", "Manuel", Icons.Outlined.Tune),
-    PET("pet", "Animaux", Icons.Outlined.Pets),
-    OFF(null, "Arrêt", Icons.Outlined.PowerSettingsNew),
+private enum class PurifierMode(val preset: String?, val labelRes: Int, val icon: ImageVector) {
+    AUTO("auto", R.string.purifier_mode_auto, Icons.Outlined.AutoMode),
+    SLEEP("sleep", R.string.purifier_mode_sleep, Icons.Outlined.Bedtime),
+    MANUAL("manual", R.string.purifier_mode_manual, Icons.Outlined.Tune),
+    PET("pet", R.string.purifier_mode_pet, Icons.Outlined.Pets),
+    OFF(null, R.string.purifier_mode_off, Icons.Outlined.PowerSettingsNew),
 }
 
 @Composable
@@ -44,6 +46,14 @@ fun PurifierActions(chip: LauncherChip) {
         else -> PurifierMode.MANUAL
     }
 
+    val purifierLabels = mapOf(
+        PurifierMode.AUTO to stringResource(R.string.purifier_mode_auto),
+        PurifierMode.SLEEP to stringResource(R.string.purifier_mode_sleep),
+        PurifierMode.MANUAL to stringResource(R.string.purifier_mode_manual),
+        PurifierMode.PET to stringResource(R.string.purifier_mode_pet),
+        PurifierMode.OFF to stringResource(R.string.purifier_mode_off),
+    )
+
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         VerticalSegmentedSelector(
             options = PurifierMode.entries.toList(),
@@ -55,7 +65,7 @@ fun PurifierActions(chip: LauncherChip) {
                     callService("fan", "set_preset_mode", chip.entityId, mapOf("preset_mode" to mode.preset!!))
                 }
             },
-            label = { it.label },
+            label = { purifierLabels[it]!! },
             icon = { it.icon },
             accent = AppleColors.active,
             isNeutral = { it == PurifierMode.OFF },

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/QuickActionsOverlay.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/QuickActionsOverlay.kt
@@ -44,8 +44,10 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleMotion
 import com.iblu01.portallauncher.ui.theme.AppleShapes
@@ -126,18 +128,18 @@ fun QuickActionsOverlay(
                 if (!isDefaultHome) {
                     // Without the home role there are no app shortcuts and no pinned-shortcut
                     // requests, so this is the first thing to offer, not a footnote.
-                    MenuRow(Icons.Outlined.Home, "Définir comme launcher par défaut") {
+                    MenuRow(Icons.Outlined.Home, stringResource(R.string.quick_actions_set_default_home)) {
                         onDismiss(); onOpenHomeSettings()
                     }
                     MenuDivider()
                 }
-                MenuRow(Icons.Outlined.Widgets, "Ajouter un widget") { onDismiss(); onAddWidget() }
+                MenuRow(Icons.Outlined.Widgets, stringResource(R.string.quick_actions_add_widget)) { onDismiss(); onAddWidget() }
                 MenuDivider()
-                MenuRow(Icons.Outlined.Wallpaper, "Fond d’écran") { onDismiss(); onSetWallpaper() }
+                MenuRow(Icons.Outlined.Wallpaper, stringResource(R.string.quick_actions_wallpaper)) { onDismiss(); onSetWallpaper() }
                 MenuDivider()
-                MenuRow(Icons.Outlined.Settings, "Réglages") { onDismiss(); onSettings() }
+                MenuRow(Icons.Outlined.Settings, stringResource(R.string.quick_actions_settings)) { onDismiss(); onSettings() }
                 MenuDivider()
-                MenuRow(Icons.Outlined.Tune, "Composants (test)") { onDismiss(); onOpenPlayground() }
+                MenuRow(Icons.Outlined.Tune, stringResource(R.string.quick_actions_playground)) { onDismiss(); onOpenPlayground() }
             }
             }
         }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/QuickTiles.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/QuickTiles.kt
@@ -74,12 +74,15 @@ fun StatusChip(chip: LauncherChip, modifier: Modifier = Modifier, selected: Bool
     val target = stateColor(chip.state)
     val accent by animateColorAsState(target, AppleMotion.spring(), label = "chipAccent")
     val animatedProgress by animateFloatAsState(chip.progress, AppleMotion.spring(), label = "chipProgress")
-    // Selected chip (its panel is open) reads as active: accent-tinted fill + border.
-    val borderColor by animateColorAsState(if (selected) accent else AppleColors.frostedBorder, AppleMotion.spring(), label = "chipBorder")
+    // Selected chip: iOS-style — white fill, dark text, matching border.
+    val selectedContent = Color(0xFF1C1C1E)
+    val selectedSubtitle = Color(0xFF3C3C43).copy(alpha = 0.6f)
+    val borderColor by animateColorAsState(if (selected) Color.White else AppleColors.frostedBorder, AppleMotion.spring(), label = "chipBorder")
+    val fillColor by animateColorAsState(if (selected) Color.White else AppleColors.frostedFill, AppleMotion.spring(), label = "chipFill")
     Row(
         modifier = modifier
             .clip(AppleShapes.pill)
-            .background(if (selected) accent.copy(alpha = 0.16f) else AppleColors.frostedFill, AppleShapes.pill)
+            .background(fillColor, AppleShapes.pill)
             .border(if (selected) 1.dp else 0.5.dp, borderColor, AppleShapes.pill)
             .then(if (onClick != null) Modifier.appleClickable(onClick, onLongPress) else Modifier)
             .padding(start = 12.dp.scaled(), end = 22.dp.scaled(), top = 12.dp.scaled(), bottom = 12.dp.scaled()),
@@ -124,13 +127,13 @@ fun StatusChip(chip: LauncherChip, modifier: Modifier = Modifier, selected: Bool
             Text(
                 chip.label,
                 style = AppleTypography.bodyLarge.copy(fontSize = AppleTypography.bodyLarge.fontSize.scaled()),
-                color = AppleColors.secondary,
+                color = if (selected) selectedSubtitle else AppleColors.secondary,
                 maxLines = 1,
             )
             Text(
                 chip.value,
                 style = AppleTypography.titleLarge.copy(fontSize = AppleTypography.titleLarge.fontSize.scaled()),
-                color = AppleColors.primary,
+                color = if (selected) selectedContent else AppleColors.primary,
                 maxLines = 1,
             )
         }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/SettingsComponents.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/SettingsComponents.kt
@@ -496,12 +496,15 @@ fun SettingsTile(
     }
 }
 
-/** Back button + title bar for settings sub-pages. */
+/** Back button + title bar for settings sub-pages.
+ *  [showBack] is false in the two-pane tablet layout, where the sidebar is the navigation
+ *  and a back chevron in the detail pane would be redundant. */
 @Composable
 fun SettingsSubPageHeader(
     title: String,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    showBack: Boolean = true,
 ) {
     Row(
         modifier = modifier
@@ -509,28 +512,83 @@ fun SettingsSubPageHeader(
             .padding(bottom = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(AppleShapes.section)
-                .background(AppleColors.elevated, AppleShapes.section)
-                .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.section)
-                .appleClickable(onBack),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                Icons.Outlined.ChevronLeft,
-                contentDescription = "Retour",
-                tint = AppleColors.accent,
-                modifier = Modifier.size(22.dp)
-            )
+        if (showBack) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(AppleShapes.section)
+                    .background(AppleColors.elevated, AppleShapes.section)
+                    .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.section)
+                    .appleClickable(onBack),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Outlined.ChevronLeft,
+                    contentDescription = "Retour",
+                    tint = AppleColors.accent,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+            Spacer(Modifier.width(16.dp))
         }
-        Spacer(Modifier.width(16.dp))
         Text(
             title,
             style = AppleTypography.headlineLarge,
             color = AppleColors.primary
         )
+    }
+}
+
+/** Fixed-width navigation rail for the two-pane tablet settings layout (width >= 840dp).
+ *  One row per section; the selected section is highlighted, mirroring Android's own
+ *  Settings app list-detail pattern. */
+@Composable
+fun <T> SettingsSidebar(
+    items: List<Triple<T, ImageVector, String>>,
+    selected: T,
+    onSelect: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    header: String = "Portal Launcher",
+) {
+    Column(
+        modifier = modifier
+            .width(300.dp)
+            .fillMaxWidth()
+            .padding(end = 16.dp)
+    ) {
+        Text(
+            header,
+            style = AppleTypography.headlineLarge,
+            color = AppleColors.primary,
+            modifier = Modifier.padding(start = 4.dp, bottom = 16.dp)
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            items.forEach { (value, icon, title) ->
+                val isSelected = value == selected
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(AppleShapes.section)
+                        .background(if (isSelected) AppleColors.accent.copy(alpha = 0.15f) else Color.Transparent, AppleShapes.section)
+                        .appleClickable { onSelect(value) }
+                        .padding(horizontal = 14.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        icon,
+                        contentDescription = null,
+                        tint = if (isSelected) AppleColors.accent else AppleColors.secondary,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(Modifier.width(14.dp))
+                    Text(
+                        title,
+                        style = AppleTypography.titleMedium,
+                        color = if (isSelected) AppleColors.accent else AppleColors.primary
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/SidePanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/SidePanel.kt
@@ -45,6 +45,8 @@ import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 import com.iblu01.portallauncher.ui.theme.scaled
 import com.iblu01.portallauncher.ui.theme.stateColor
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 /**
  * What the side panel is currently showing. Media auto-opens when playback starts
@@ -129,7 +131,7 @@ private fun ChipActionsContent(
             ) {
                 Icon(
                     Icons.Filled.Close,
-                    contentDescription = "Fermer le panneau",
+                    contentDescription = stringResource(R.string.side_panel_close_desc),
                     tint = AppleColors.secondary,
                     modifier = Modifier.size(18.dp.scaled()),
                 )

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/ThermostatPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/ThermostatPanel.kt
@@ -38,6 +38,8 @@ import com.iblu01.portallauncher.LauncherChip
 import com.iblu01.portallauncher.ui.LocalCallService
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.roundToInt
@@ -117,7 +119,7 @@ fun ThermostatControl(chip: LauncherChip) {
             }
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(fmt(target), style = AppleTypography.displayLarge.copy(fontSize = 64.sp), color = AppleColors.primary)
-                if (current != null) Text("actuel ${fmt(current)}", style = AppleTypography.bodyLarge, color = AppleColors.secondary)
+                if (current != null) Text(stringResource(R.string.thermostat_current_temp_format, fmt(current)), style = AppleTypography.bodyLarge, color = AppleColors.secondary)
             }
         }
         Spacer(Modifier.height(20.dp))
@@ -127,7 +129,24 @@ fun ThermostatControl(chip: LauncherChip) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
                 for (i in 0 until modes.length()) {
                     val m = modes.optString(i).lowercase()
-                    val (label, icon) = hvacLabel(m)
+                    val label = when (m) {
+                        "off" -> stringResource(R.string.hvac_mode_off)
+                        "heat" -> stringResource(R.string.hvac_mode_heat)
+                        "cool" -> stringResource(R.string.hvac_mode_cool)
+                        "heat_cool", "auto" -> stringResource(R.string.hvac_mode_auto)
+                        "dry" -> stringResource(R.string.hvac_mode_dry)
+                        "fan_only" -> stringResource(R.string.hvac_mode_fan_only)
+                        else -> m.replaceFirstChar { it.uppercase() }
+                    }
+                    val icon = when (m) {
+                        "off" -> Icons.Outlined.PowerSettingsNew
+                        "heat" -> Icons.Outlined.LocalFireDepartment
+                        "cool" -> Icons.Outlined.AcUnit
+                        "heat_cool", "auto" -> Icons.Outlined.AutoMode
+                        "dry" -> Icons.Outlined.WaterDrop
+                        "fan_only" -> Icons.Outlined.Air
+                        else -> Icons.Outlined.AutoMode
+                    }
                     PanelModeButton(label, icon, active = m == mode) {
                         callService("climate", "set_hvac_mode", chip.entityId, mapOf("hvac_mode" to m))
                     }
@@ -135,14 +154,4 @@ fun ThermostatControl(chip: LauncherChip) {
             }
         }
     }
-}
-
-private fun hvacLabel(mode: String): Pair<String, ImageVector> = when (mode) {
-    "off" -> "Éteint" to Icons.Outlined.PowerSettingsNew
-    "heat" -> "Chauffe" to Icons.Outlined.LocalFireDepartment
-    "cool" -> "Froid" to Icons.Outlined.AcUnit
-    "heat_cool", "auto" -> "Auto" to Icons.Outlined.AutoMode
-    "dry" -> "Sec" to Icons.Outlined.WaterDrop
-    "fan_only" -> "Ventil." to Icons.Outlined.Air
-    else -> mode.replaceFirstChar { it.uppercase() } to Icons.Outlined.AutoMode
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/VacuumPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/VacuumPanel.kt
@@ -22,6 +22,8 @@ import com.iblu01.portallauncher.domain.model.PillDetail
 import com.iblu01.portallauncher.ui.LocalCallService
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 /**
  * Vacuum control: start / pause / stop / dock / locate, gated by the entity's
@@ -37,26 +39,26 @@ fun VacuumControl(chip: LauncherChip) {
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(Modifier.height(2.dp))
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
-            PanelModeButton("Démarrer", Icons.Outlined.PlayArrow, cleaning) {
+            PanelModeButton(stringResource(R.string.vacuum_button_start), Icons.Outlined.PlayArrow, cleaning) {
                 callService("vacuum", "start", chip.entityId)
             }
             if (entity.supports(VacuumFeature.PAUSE)) {
-                PanelModeButton("Pause", Icons.Outlined.Pause, entity.state.equals("paused", true)) {
+                PanelModeButton(stringResource(R.string.vacuum_button_pause), Icons.Outlined.Pause, entity.state.equals("paused", true)) {
                     callService("vacuum", "pause", chip.entityId)
                 }
             }
             if (entity.supports(VacuumFeature.STOP)) {
-                PanelModeButton("Stop", Icons.Filled.Stop, false) {
+                PanelModeButton(stringResource(R.string.vacuum_button_stop), Icons.Filled.Stop, false) {
                     callService("vacuum", "stop", chip.entityId)
                 }
             }
             if (entity.supports(VacuumFeature.RETURN_HOME)) {
-                PanelModeButton("Base", Icons.Outlined.Home, entity.state.equals("returning", true)) {
+                PanelModeButton(stringResource(R.string.vacuum_button_dock), Icons.Outlined.Home, entity.state.equals("returning", true)) {
                     callService("vacuum", "return_to_base", chip.entityId)
                 }
             }
             if (entity.supports(VacuumFeature.LOCATE)) {
-                PanelModeButton("Localiser", Icons.Outlined.MyLocation, false) {
+                PanelModeButton(stringResource(R.string.vacuum_button_locate), Icons.Outlined.MyLocation, false) {
                     callService("vacuum", "locate", chip.entityId)
                 }
             }
@@ -65,10 +67,10 @@ fun VacuumControl(chip: LauncherChip) {
 
         val battery = entity.attributes.optInt("battery_level", -1)
         val status = entity.attributes.optString("status").ifBlank { chip.value }
-        if (status.isNotBlank()) PanelDetailRow(PillDetail("État", status))
+        if (status.isNotBlank()) PanelDetailRow(PillDetail(stringResource(R.string.vacuum_detail_status), status))
         if (battery in 0..100) {
             Spacer(Modifier.height(8.dp))
-            PanelDetailRow(PillDetail("Batterie", "$battery %"))
+            PanelDetailRow(PillDetail(stringResource(R.string.vacuum_detail_battery), "$battery %"))
         }
         chip.details.forEach {
             Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherPanel.kt
@@ -33,6 +33,8 @@ import com.iblu01.portallauncher.domain.model.ForecastPoint
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 import kotlin.math.roundToInt
 
 /** Side panel opened from the clock's temperature pill: current condition + hourly & daily forecast. */
@@ -62,8 +64,8 @@ fun WeatherPanel(weather: WeatherUi, onDismiss: () -> Unit, modifier: Modifier =
                             .background(AppleColors.frostedFill).border(0.5.dp, AppleColors.frostedBorder, CircleShape)
                             .appleClickable(onDismiss),
                         contentAlignment = Alignment.Center,
-                    ) { Icon(Icons.Filled.Close, "Fermer", tint = AppleColors.secondary, modifier = Modifier.size(18.dp)) }
-                    Text("Météo", style = AppleTypography.titleMedium.copy(fontSize = 15.sp), color = AppleColors.secondary, modifier = Modifier.align(Alignment.Center))
+                    ) { Icon(Icons.Filled.Close, stringResource(R.string.weather_close_desc), tint = AppleColors.secondary, modifier = Modifier.size(18.dp)) }
+                    Text(stringResource(R.string.weather_panel_title), style = AppleTypography.titleMedium.copy(fontSize = 15.sp), color = AppleColors.secondary, modifier = Modifier.align(Alignment.Center))
                 }
 
                 Spacer(Modifier.height(18.dp))
@@ -77,7 +79,7 @@ fun WeatherPanel(weather: WeatherUi, onDismiss: () -> Unit, modifier: Modifier =
 
                 if (weather.hourly.isNotEmpty()) {
                     Spacer(Modifier.height(22.dp))
-                    Text("PROCHAINES HEURES", style = AppleTypography.labelSmall, color = AppleColors.tertiary)
+                    Text(stringResource(R.string.weather_section_hourly), style = AppleTypography.labelSmall, color = AppleColors.tertiary)
                     Spacer(Modifier.height(10.dp))
                     Row(Modifier.horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(18.dp)) {
                         weather.hourly.take(12).forEach { HourTile(it) }
@@ -86,7 +88,7 @@ fun WeatherPanel(weather: WeatherUi, onDismiss: () -> Unit, modifier: Modifier =
 
                 if (weather.daily.isNotEmpty()) {
                     Spacer(Modifier.height(22.dp))
-                    Text("PROCHAINS JOURS", style = AppleTypography.labelSmall, color = AppleColors.tertiary)
+                    Text(stringResource(R.string.weather_section_daily), style = AppleTypography.labelSmall, color = AppleColors.tertiary)
                     Spacer(Modifier.height(6.dp))
                     weather.daily.take(7).forEach { DayRow(it) }
                 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/WidgetPickerDialog.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/WidgetPickerDialog.kt
@@ -31,9 +31,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.apps.WidgetOffer
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
@@ -74,13 +76,13 @@ fun WidgetPickerDialog(
                 .padding(vertical = 12.dp),
         ) {
             Text(
-                "Ajouter un widget",
+                stringResource(R.string.widget_picker_title),
                 style = AppleTypography.titleMedium,
                 color = AppleColors.primary,
                 modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
             )
             Text(
-                if (offers.isEmpty()) "Aucun widget disponible" else "Taille en cellules indiquée",
+                if (offers.isEmpty()) stringResource(R.string.widget_picker_empty) else stringResource(R.string.widget_picker_size_hint),
                 style = AppleTypography.bodySmall.copy(fontSize = 13.sp),
                 color = AppleColors.tertiary,
                 modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 8.dp),

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalAccessory.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalAccessory.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.ui.components.appleClickable
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 /**
  * HomeKit accessory-tile radius. Tuned to Apple's Home app: a rounded rectangle that is neither
@@ -118,7 +120,7 @@ fun AccessoryTile(
             if (warning) {
                 Icon(
                     Icons.Filled.Warning,
-                    contentDescription = "Attention",
+                    contentDescription = stringResource(R.string.accessory_warning_desc),
                     tint = onContent,
                     modifier = Modifier
                         .align(Alignment.TopEnd)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalKeypad.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalKeypad.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 import kotlin.math.roundToInt
 
 /** iOS lock-screen letter groups shown under each digit. */
@@ -203,7 +205,7 @@ fun PinKeypad(
         if (!fixed && onCancel != null) {
             Spacer(Modifier.height(14.dp))
             Text(
-                "Annuler",
+                stringResource(R.string.keypad_cancel),
                 style = AppleTypography.bodyLarge,
                 color = AppleColors.secondary,
                 modifier = Modifier
@@ -237,7 +239,7 @@ private fun KeypadKey(
     if (key == "cancel") {
         Box(Modifier.size(diameter), contentAlignment = Alignment.Center) {
             Text(
-                "Annuler",
+                stringResource(R.string.keypad_cancel),
                 style = AppleTypography.bodyLarge,
                 color = AppleColors.secondary,
                 modifier = Modifier
@@ -255,6 +257,9 @@ private fun KeypadKey(
 
     val interaction = remember { MutableInteractionSource() }
     val pressed by interaction.collectIsPressedAsState()
+    val backDesc = stringResource(R.string.keypad_back_desc)
+    val okDesc = stringResource(R.string.keypad_confirm_desc)
+    val keyDescFormat = stringResource(R.string.keypad_key_desc_format)
     val background by animateColorAsState(
         if (pressed && enabled) Color.White.copy(alpha = 0.24f) else AppleColors.frostedFill,
         tween(if (pressed) 40 else 260), label = "keyPress",
@@ -272,7 +277,11 @@ private fun KeypadKey(
                 enabled = enabled,
                 onClick = onClick,
             )
-            .semantics { contentDescription = keyDescription(key) },
+            .semantics { contentDescription = when (key) {
+                "back" -> backDesc
+                "ok" -> okDesc
+                else -> java.lang.String.format(keyDescFormat, key)
+            } },
         contentAlignment = Alignment.Center,
     ) {
         when (key) {
@@ -291,10 +300,4 @@ private fun KeypadKey(
             }
         }
     }
-}
-
-private fun keyDescription(key: String): String = when (key) {
-    "back" -> "Effacer"
-    "ok" -> "Valider"
-    else -> "Touche $key"
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalVacuum.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalVacuum.kt
@@ -35,6 +35,8 @@ import com.iblu01.portallauncher.ui.components.appleClickable
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 /** A room the robot knows about. [icon] is optional. */
 data class VacuumRoom(val id: String, val name: String, val icon: ImageVector? = null)
@@ -43,11 +45,12 @@ data class VacuumRoom(val id: String, val name: String, val icon: ImageVector? =
 enum class VacuumMode { VACUUM, VACUUM_AND_MOP, VACUUM_THEN_MOP, MOP }
 
 /** French label for a [VacuumMode], ready for a [WheelPicker]. */
+@Composable
 fun VacuumMode.frLabel(): String = when (this) {
-    VacuumMode.VACUUM -> "Aspiration"
-    VacuumMode.VACUUM_AND_MOP -> "Aspiration + lavage"
-    VacuumMode.VACUUM_THEN_MOP -> "Aspiration puis lavage"
-    VacuumMode.MOP -> "Lavage"
+    VacuumMode.VACUUM -> stringResource(R.string.vacuum_mode_vacuum)
+    VacuumMode.VACUUM_AND_MOP -> stringResource(R.string.vacuum_mode_vacuum_and_mop)
+    VacuumMode.VACUUM_THEN_MOP -> stringResource(R.string.vacuum_mode_vacuum_then_mop)
+    VacuumMode.MOP -> stringResource(R.string.vacuum_mode_mop)
 }
 
 /**
@@ -73,7 +76,7 @@ fun VacuumRunButton(
     ) {
         Icon(
             if (running) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-            contentDescription = if (running) "Mettre en pause" else "Démarrer",
+            contentDescription = if (running) stringResource(R.string.vacuum_pause_desc) else stringResource(R.string.vacuum_start_desc),
             tint = Color.Black,
             modifier = Modifier.size(size * 0.34f),
         )

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
@@ -38,10 +38,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.LauncherChip
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.domain.model.TemperatureSummary
 import com.iblu01.portallauncher.ui.components.AmbientBackground
 import com.iblu01.portallauncher.ui.components.ClockScreen
@@ -129,7 +131,7 @@ fun ClockThemeScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             // Font picker.
-            ControlLabel("Police")
+            ControlLabel(stringResource(R.string.clock_theme_label_font))
             Row(
                 Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -161,7 +163,7 @@ fun ClockThemeScreen(
 
             // Weight.
             LabeledSlider(
-                label = "Graisse",
+                label = stringResource(R.string.clock_theme_label_weight),
                 value = theme.weight.toFloat(),
                 range = ClockTheme.WeightRange,
                 valueText = theme.weight.toString(),
@@ -169,7 +171,7 @@ fun ClockThemeScreen(
             )
             // Size.
             LabeledSlider(
-                label = "Taille",
+                label = stringResource(R.string.clock_theme_label_size),
                 value = theme.size,
                 range = ClockTheme.SizeRange,
                 valueText = "${theme.size.roundToInt()}",
@@ -177,7 +179,7 @@ fun ClockThemeScreen(
             )
             // Letter spacing.
             LabeledSlider(
-                label = "Espacement",
+                label = stringResource(R.string.clock_theme_label_letter_spacing),
                 value = theme.letterSpacing,
                 range = ClockTheme.LetterSpacingRange,
                 valueText = "%.1f".format(theme.letterSpacing),
@@ -185,7 +187,7 @@ fun ClockThemeScreen(
             )
             // Vertical gap between date / time / weather-temperature rows.
             LabeledSlider(
-                label = "Écart entre éléments",
+                label = stringResource(R.string.clock_theme_label_element_spacing),
                 value = theme.elementSpacing,
                 range = ClockTheme.ElementSpacingRange,
                 valueText = "%.1f×".format(theme.elementSpacing),
@@ -193,7 +195,7 @@ fun ClockThemeScreen(
             )
 
             // Tint.
-            ControlLabel("Couleur")
+            ControlLabel(stringResource(R.string.clock_theme_label_color))
             Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
                 ClockTint.entries.forEach { tint ->
                     val selected = tint == theme.tint
@@ -217,7 +219,7 @@ fun ClockThemeScreen(
                 Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                ControlLabel("Format 24 h")
+                ControlLabel(stringResource(R.string.clock_theme_label_format_24h))
                 Spacer(Modifier.weight(1f))
                 Switch(
                     checked = theme.format24h,
@@ -239,7 +241,7 @@ fun ClockThemeScreen(
                 .clickable { onClose() },
             contentAlignment = Alignment.Center,
         ) {
-            Icon(Icons.Filled.Close, "Fermer", tint = AppleColors.secondary, modifier = Modifier.size(20.dp))
+            Icon(Icons.Filled.Close, stringResource(R.string.clock_theme_close), tint = AppleColors.secondary, modifier = Modifier.size(20.dp))
         }
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/HomeConnectionPage.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/HomeConnectionPage.kt
@@ -1,6 +1,5 @@
 package com.iblu01.portallauncher.ui.screens
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,10 +16,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.iblu01.portallauncher.HaInstance
 import com.iblu01.portallauncher.HaMdnsDiscovery
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.components.HaDiscoveryDialog
 import com.iblu01.portallauncher.ui.components.SettingsDivider
 import com.iblu01.portallauncher.ui.components.SettingsInfoDialog
@@ -29,6 +30,7 @@ import com.iblu01.portallauncher.ui.components.SettingsSection
 import com.iblu01.portallauncher.ui.components.SettingsStatusRow
 import com.iblu01.portallauncher.ui.components.SettingsSubPageHeader
 import com.iblu01.portallauncher.ui.components.SettingsTextField
+import com.iblu01.portallauncher.ui.components.SettingsToggle
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 
@@ -67,12 +69,14 @@ fun HomeConnectionPage(
     onTestHa: () -> Unit,
     onTestMqtt: () -> Unit,
     onBack: () -> Unit,
+    showBack: Boolean = true,
 ) {
     val context = LocalContext.current
     val discovered = remember { mutableStateListOf<HaInstance>() }
     var showDiscovery by remember { mutableStateOf(false) }
     var showKeyHelp by remember { mutableStateOf(false) }
-    var showAdvanced by remember { mutableStateOf(false) }
+    // Most MQTT brokers require a login; default the toggle to whatever is already saved.
+    var mqttAuthEnabled by remember { mutableStateOf(mqttUsername.isNotBlank() || mqttPassword.isNotBlank()) }
 
     // Auto-scan the LAN while this page is on screen; always stop on dispose.
     DisposableEffect(Unit) {
@@ -97,7 +101,7 @@ fun HomeConnectionPage(
 
     if (showKeyHelp) {
         SettingsInfoDialog(
-            title = "Où trouver ma clé ?",
+            title = stringResource(R.string.home_connection_label_key_help),
             lines = accessKeyHelpLines,
             onDismiss = { showKeyHelp = false },
         )
@@ -107,18 +111,18 @@ fun HomeConnectionPage(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        SettingsSubPageHeader(title = "Ma maison", onBack = onBack)
+        SettingsSubPageHeader(title = stringResource(R.string.home_connection_title), onBack = onBack, showBack = showBack)
         Text(
-            "Portal se connecte à ton serveur Home Assistant pour afficher l'état de ta maison.",
+            stringResource(R.string.home_connection_subtitle),
             style = AppleTypography.bodyLarge,
             color = AppleColors.secondary
         )
 
-        SettingsSection(title = "HOME ASSISTANT") {
+        SettingsSection(title = stringResource(R.string.home_connection_section_address)) {
             val suggestion = discovered.firstOrNull()
             if (suggestion != null) {
                 SettingsRow(
-                    label = "Home Assistant détecté",
+                    label = stringResource(R.string.home_connection_ha_detected),
                     value = suggestion.name,
                     onClick = {
                         if (discovered.size == 1) onSelectInstance(suggestion) else showDiscovery = true
@@ -127,98 +131,102 @@ fun HomeConnectionPage(
                 SettingsDivider()
             }
             SettingsTextField(
-                label = "Adresse",
+                label = stringResource(R.string.home_connection_label_address),
                 value = haUrl,
                 onValueChange = onUrlChange,
-                placeholder = "http://homeassistant.local:8123"
+                placeholder = stringResource(R.string.home_connection_placeholder_address)
             )
             SettingsDivider()
             SettingsRow(
-                label = "Chercher sur le réseau",
-                value = if (discovered.isEmpty()) "Recherche…" else "${discovered.size} trouvé(s)",
+                label = stringResource(R.string.home_connection_label_scan_network),
+                value = if (discovered.isEmpty()) stringResource(R.string.home_connection_scanning)
+                    else stringResource(R.string.home_connection_scan_found_format, discovered.size),
                 onClick = { showDiscovery = true },
             )
-            SettingsDivider()
+        }
+
+        SettingsSection(title = stringResource(R.string.home_connection_section_access_key)) {
             SettingsTextField(
-                label = "Clé d'accès",
+                label = stringResource(R.string.home_connection_label_access_key),
                 value = haToken,
                 onValueChange = onTokenChange,
-                placeholder = "Colle ta clé ici",
+                placeholder = stringResource(R.string.home_connection_placeholder_paste_key),
                 isPassword = true
             )
             SettingsDivider()
-            SettingsRow(label = "Où trouver ma clé ?", onClick = { showKeyHelp = true })
-            SettingsDivider()
+            SettingsRow(label = stringResource(R.string.home_connection_label_key_help), onClick = { showKeyHelp = true })
+        }
+
+        SettingsSection(title = stringResource(R.string.home_connection_section_status)) {
             SettingsStatusRow(
-                label = "Connexion",
+                label = stringResource(R.string.home_connection_label_connection),
                 status = uiState.haTest,
                 detail = uiState.haTestMessage,
                 onClick = onTestHa,
             )
         }
 
-        SettingsSection(title = "AVANCÉ") {
-            SettingsRow(
-                label = "Notifications entre appareils",
-                value = if (showAdvanced) "Masquer" else "Afficher",
-                onClick = { showAdvanced = !showAdvanced },
+        // MQTT is used to receive live Home Assistant notifications on this device.
+        // Always shown in full: almost every broker requires a login, so hiding it behind
+        // a disclosure toggle just hid a mandatory field.
+        SettingsSection(title = stringResource(R.string.home_connection_section_mqtt)) {
+            SettingsTextField(
+                label = stringResource(R.string.home_connection_label_mqtt_server),
+                value = mqttHost,
+                onValueChange = onMqttHostChange,
+                placeholder = stringResource(R.string.home_connection_placeholder_mqtt_server)
             )
-        }
-
-        AnimatedVisibility(visible = showAdvanced) {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(
-                    "Pré-rempli depuis l'adresse de ta maison. Ne touche à ces réglages que si ton broker MQTT est sur une autre machine.",
-                    style = AppleTypography.bodyMedium,
-                    color = AppleColors.secondary,
-                    modifier = Modifier.padding(horizontal = 4.dp)
+            SettingsDivider()
+            SettingsTextField(
+                label = stringResource(R.string.home_connection_label_mqtt_port),
+                value = mqttPort,
+                onValueChange = onMqttPortChange,
+                placeholder = stringResource(R.string.home_connection_placeholder_mqtt_port),
+                keyboardType = KeyboardType.Number
+            )
+            SettingsDivider()
+            SettingsToggle(
+                label = stringResource(R.string.home_connection_toggle_mqtt_auth),
+                checked = mqttAuthEnabled,
+                onCheckedChange = { enabled ->
+                    mqttAuthEnabled = enabled
+                    if (!enabled) {
+                        onMqttUsernameChange("")
+                        onMqttPasswordChange("")
+                    }
+                },
+            )
+            if (mqttAuthEnabled) {
+                SettingsDivider()
+                SettingsTextField(
+                    label = stringResource(R.string.home_connection_label_mqtt_username),
+                    value = mqttUsername,
+                    onValueChange = onMqttUsernameChange,
+                    placeholder = stringResource(R.string.home_connection_placeholder_username)
                 )
-                SettingsSection(title = "MQTT") {
-                    SettingsTextField(
-                        label = "Adresse du serveur",
-                        value = mqttHost,
-                        onValueChange = onMqttHostChange,
-                        placeholder = "homeassistant.local"
-                    )
-                    SettingsDivider()
-                    SettingsTextField(
-                        label = "Port",
-                        value = mqttPort,
-                        onValueChange = onMqttPortChange,
-                        placeholder = "1883",
-                        keyboardType = KeyboardType.Number
-                    )
-                    SettingsDivider()
-                    SettingsTextField(
-                        label = "Identifiant",
-                        value = mqttUsername,
-                        onValueChange = onMqttUsernameChange,
-                        placeholder = "optionnel"
-                    )
-                    SettingsDivider()
-                    SettingsTextField(
-                        label = "Mot de passe",
-                        value = mqttPassword,
-                        onValueChange = onMqttPasswordChange,
-                        placeholder = "optionnel",
-                        isPassword = true
-                    )
-                    SettingsDivider()
-                    SettingsTextField(
-                        label = "Nom de cet appareil",
-                        value = deviceName,
-                        onValueChange = onDeviceNameChange,
-                        placeholder = "Portal"
-                    )
-                    SettingsDivider()
-                    SettingsStatusRow(
-                        label = "Connexion MQTT",
-                        status = uiState.mqttTest,
-                        detail = uiState.mqttTestMessage,
-                        onClick = onTestMqtt,
-                    )
-                }
+                SettingsDivider()
+                SettingsTextField(
+                    label = stringResource(R.string.home_connection_label_mqtt_password),
+                    value = mqttPassword,
+                    onValueChange = onMqttPasswordChange,
+                    placeholder = stringResource(R.string.home_connection_placeholder_password),
+                    isPassword = true
+                )
             }
+            SettingsDivider()
+            SettingsTextField(
+                label = stringResource(R.string.home_connection_label_device_name),
+                value = deviceName,
+                onValueChange = onDeviceNameChange,
+                placeholder = stringResource(R.string.home_connection_placeholder_device_name)
+            )
+            SettingsDivider()
+            SettingsStatusRow(
+                label = stringResource(R.string.home_connection_label_mqtt_connection),
+                status = uiState.mqttTest,
+                detail = uiState.mqttTestMessage,
+                onClick = onTestMqtt,
+            )
         }
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/LanguagePage.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/LanguagePage.kt
@@ -1,0 +1,99 @@
+package com.iblu01.portallauncher.ui.screens
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.iblu01.portallauncher.AppLanguage
+import com.iblu01.portallauncher.LauncherActivity
+import com.iblu01.portallauncher.Prefs
+import com.iblu01.portallauncher.R
+import com.iblu01.portallauncher.ui.components.SettingsDivider
+import com.iblu01.portallauncher.ui.components.SettingsSection
+import com.iblu01.portallauncher.ui.components.SettingsSubPageHeader
+import com.iblu01.portallauncher.ui.components.appleClickable
+import com.iblu01.portallauncher.ui.theme.AppleColors
+import com.iblu01.portallauncher.ui.theme.AppleTypography
+
+/**
+ * Language picker (Settings > Application > Language). Plain `ComponentActivity`s don't get
+ * per-app locale switching for free, so [Prefs.appLanguage] is applied via `attachBaseContext`
+ * ([com.iblu01.portallauncher.LocaleHelper]) — changing it here restarts the app to take effect.
+ */
+@Composable
+fun LanguagePage(prefs: Prefs, onBack: () -> Unit, showBack: Boolean = true) {
+    val context = LocalContext.current
+    val current = AppLanguage.from(prefs.appLanguage)
+
+    Column(
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        SettingsSubPageHeader(title = stringResource(R.string.language_page_title), onBack = onBack, showBack = showBack)
+
+        SettingsSection(title = stringResource(R.string.settings_app_section_language)) {
+            AppLanguage.values().forEachIndexed { index, language ->
+                val isSelected = language == current
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .defaultMinSize(minHeight = 44.dp)
+                        .appleClickable {
+                            if (!isSelected) {
+                                prefs.appLanguage = language.code
+                                restartApp(context)
+                            }
+                        }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(language.flag, style = AppleTypography.titleLarge)
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        stringResource(language.nameRes),
+                        style = AppleTypography.titleMedium,
+                        color = AppleColors.primary,
+                        modifier = Modifier.weight(1f)
+                    )
+                    if (isSelected) {
+                        Icon(
+                            Icons.Outlined.Check,
+                            contentDescription = null,
+                            tint = AppleColors.accent,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
+                if (index != AppLanguage.values().lastIndex) SettingsDivider()
+            }
+        }
+    }
+}
+
+/** Full process restart so every Activity re-reads the new locale from a fresh `attachBaseContext`. */
+private fun restartApp(context: android.content.Context) {
+    val intent = Intent(context, LauncherActivity::class.java).apply {
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+    }
+    context.startActivity(intent)
+    Runtime.getRuntime().exit(0)
+}

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/OpacityPreviewScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/OpacityPreviewScreen.kt
@@ -33,6 +33,8 @@ import com.iblu01.portallauncher.ui.components.WeatherGlyph
 import com.iblu01.portallauncher.ui.components.WeatherUi
 import com.iblu01.portallauncher.ui.components.controls.VerticalFillSlider
 import com.iblu01.portallauncher.ui.theme.AppleColors
+import com.iblu01.portallauncher.R
+import androidx.compose.ui.res.stringResource
 
 /** Frozen mock content used to judge the overlay against a real wallpaper — no HA dependency. */
 private val previewWeather = WeatherUi(temp = "19°", indoorTemp = "22°", city = "Appartement", condition = "Dégagé", glyph = WeatherGlyph())
@@ -131,7 +133,7 @@ fun OpacityPreviewScreen(
         ) {
             Icon(
                 Icons.Filled.Close,
-                contentDescription = "Fermer",
+                contentDescription = stringResource(R.string.opacity_preview_close_desc),
                 tint = AppleColors.secondary,
                 modifier = Modifier.size(20.dp),
             )

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/PillsSettingsPage.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/PillsSettingsPage.kt
@@ -19,9 +19,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.iblu01.portallauncher.PillCandidate
 import com.iblu01.portallauncher.PillFamily
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.friendlyEntityState
 import com.iblu01.portallauncher.ui.components.PillButton
 import com.iblu01.portallauncher.ui.components.SettingsDivider
@@ -44,6 +46,7 @@ fun PillsSettingsPage(
     onRefresh: () -> Unit,
     onSetEnabled: (List<PillCandidate>, Boolean) -> Unit,
     onBack: () -> Unit,
+    showBack: Boolean = true,
 ) {
     LaunchedEffect(Unit) { onRefresh() }
     var search by remember { mutableStateOf("") }
@@ -70,6 +73,7 @@ fun PillsSettingsPage(
                 onRefresh = onRefresh,
                 onSetEnabled = onSetEnabled,
                 onBack = onBack,
+                showBack = showBack,
             )
         } else {
             PillFamilyPage(
@@ -93,6 +97,7 @@ private fun PillsHomePage(
     onRefresh: () -> Unit,
     onSetEnabled: (List<PillCandidate>, Boolean) -> Unit,
     onBack: () -> Unit,
+    showBack: Boolean = true,
 ) {
     val query = search.trim().lowercase()
     val searching = query.isNotEmpty()
@@ -104,27 +109,27 @@ private fun PillsHomePage(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        SettingsSubPageHeader(title = "Informations affichées", onBack = onBack)
+        SettingsSubPageHeader(title = stringResource(R.string.pills_page_title), onBack = onBack, showBack = showBack)
         Text(
-            "Active ce que Portal peut afficher en haut de l'écran. Les informations les plus importantes remontent automatiquement.",
+            stringResource(R.string.pills_page_description),
             style = AppleTypography.bodyLarge,
             color = AppleColors.secondary
         )
 
         when {
             uiState.pillLoading -> Text(
-                "Chargement depuis ta maison…",
+                stringResource(R.string.pills_loading),
                 color = AppleColors.secondary
             )
-            uiState.pillError != null -> SettingsSection(title = "CONNEXION") {
+            uiState.pillError != null -> SettingsSection(title = stringResource(R.string.pills_section_connection)) {
                 SettingsRow(
-                    label = uiState.pillError ?: "Erreur",
-                    value = "Réessayer",
+                    label = uiState.pillError ?: stringResource(R.string.pills_error_fallback),
+                    value = stringResource(R.string.pills_retry),
                     onClick = onRefresh
                 )
             }
             uiState.pillCandidates.isEmpty() -> Text(
-                "Aucun appareil compatible détecté. Vérifie la connexion dans « Ma maison ».",
+                stringResource(R.string.pills_no_devices),
                 color = AppleColors.secondary
             )
             else -> {
@@ -132,17 +137,17 @@ private fun PillsHomePage(
 
                 if (searching) {
                     if (results.isEmpty()) {
-                        Text("Aucun résultat pour « $search ».", color = AppleColors.secondary)
+                        Text(stringResource(R.string.pills_no_results_format, search), color = AppleColors.secondary)
                     } else {
                         CandidateSection(
-                            title = "RÉSULTATS",
+                            title = stringResource(R.string.pills_section_results),
                             candidates = results,
                             enabledIds = enabledIds,
                             onSetEnabled = onSetEnabled,
                         )
                     }
                 } else {
-                    SettingsSection(title = "CATÉGORIES") {
+                    SettingsSection(title = stringResource(R.string.pills_section_categories)) {
                         val families = PillFamily.values()
                             .map { f -> f to uiState.pillCandidates.filter { PillFamily.of(it.kind) == f } }
                             .filter { it.second.isNotEmpty() }
@@ -156,7 +161,7 @@ private fun PillsHomePage(
                             if (index != families.lastIndex) SettingsDivider()
                         }
                     }
-                    PillButton(label = "Actualiser la liste", onClick = onRefresh)
+                    PillButton(label = stringResource(R.string.pills_button_refresh), onClick = onRefresh)
                 }
             }
         }
@@ -180,10 +185,10 @@ private fun PillFamilyPage(
     ) {
         SettingsSubPageHeader(title = family.label, onBack = onBack)
         CandidateSection(
-            title = "ÉLÉMENTS DÉTECTÉS",
+            title = stringResource(R.string.pills_section_detected),
             candidates = candidates,
             enabledIds = enabledIds,
-            bulkLabel = if (allEnabled) "Tout masquer" else "Tout afficher",
+            bulkLabel = if (allEnabled) stringResource(R.string.pills_bulk_hide_all) else stringResource(R.string.pills_bulk_show_all),
             onBulk = { onSetEnabled(candidates, !allEnabled) },
             onSetEnabled = onSetEnabled,
         )

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/PlaygroundScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/PlaygroundScreen.kt
@@ -43,10 +43,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.components.appleClickable
 import com.iblu01.portallauncher.ui.components.controls.AccessoryGrid
 import com.iblu01.portallauncher.ui.components.controls.AccessoryItem
@@ -60,7 +62,6 @@ import com.iblu01.portallauncher.ui.components.controls.VacuumRoom
 import com.iblu01.portallauncher.ui.components.controls.VacuumRoomChips
 import com.iblu01.portallauncher.ui.components.controls.VacuumRunButton
 import com.iblu01.portallauncher.ui.components.controls.VacuumStatusChip
-import com.iblu01.portallauncher.ui.components.controls.frLabel
 import com.iblu01.portallauncher.ui.components.controls.VerticalColorTempSlider
 import com.iblu01.portallauncher.ui.components.controls.VerticalFillSlider
 import com.iblu01.portallauncher.ui.components.controls.WheelPicker
@@ -71,15 +72,6 @@ import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 
 /** Named accents so adaptivity is obvious at a glance. */
-private val accentSwatches = listOf(
-    "Bleu" to AppleColors.accent,
-    "Vert" to Color(0xFF30D158),
-    "Menthe" to Color(0xFF63E6BE),
-    "Jaune" to AppleColors.warning,
-    "Rouge" to AppleColors.error,
-    "Violet" to Color(0xFFAF52DE),
-    "Gris" to Color(0xFFD8D8DA),
-)
 
 private enum class Presence { HOME, AWAY, OFF }
 
@@ -90,6 +82,15 @@ private enum class Presence { HOME, AWAY, OFF }
  */
 @Composable
 fun PlaygroundScreen(onBack: () -> Unit) {
+    val accentSwatches = listOf(
+        stringResource(R.string.playground_swatch_blue) to AppleColors.accent,
+        stringResource(R.string.playground_swatch_green) to Color(0xFF30D158),
+        stringResource(R.string.playground_swatch_mint) to Color(0xFF63E6BE),
+        stringResource(R.string.playground_swatch_yellow) to AppleColors.warning,
+        stringResource(R.string.playground_swatch_red) to AppleColors.error,
+        stringResource(R.string.playground_swatch_purple) to Color(0xFFAF52DE),
+        stringResource(R.string.playground_swatch_gray) to Color(0xFFD8D8DA),
+    )
     var accent by remember { mutableStateOf(accentSwatches.first().second) }
 
     Column(
@@ -110,19 +111,19 @@ fun PlaygroundScreen(onBack: () -> Unit) {
                     .appleClickable(onBack),
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "Retour", tint = AppleColors.primary, modifier = Modifier.size(19.dp))
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.playground_back_desc), tint = AppleColors.primary, modifier = Modifier.size(19.dp))
             }
             Spacer(Modifier.width(14.dp))
             Column {
-                Text("Composants", style = AppleTypography.headlineLarge, color = AppleColors.primary)
-                Text("Banc d'essai des contrôles", style = AppleTypography.bodySmall, color = AppleColors.secondary)
+                Text(stringResource(R.string.playground_title), style = AppleTypography.headlineLarge, color = AppleColors.primary)
+                Text(stringResource(R.string.playground_subtitle), style = AppleTypography.bodySmall, color = AppleColors.secondary)
             }
         }
 
         Spacer(Modifier.height(20.dp))
 
         // Accent picker — the whole point: everything below re-skins instantly.
-        Text("Couleur d'accent", style = AppleTypography.bodySmall, color = AppleColors.secondary)
+        Text(stringResource(R.string.playground_accent_color_label), style = AppleTypography.bodySmall, color = AppleColors.secondary)
         Spacer(Modifier.height(10.dp))
         Row(
             Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
@@ -152,12 +153,12 @@ fun PlaygroundScreen(onBack: () -> Unit) {
         Spacer(Modifier.height(28.dp))
 
         // 1 · Fill sliders
-        SectionTitle("Curseur vertical")
+        SectionTitle(stringResource(R.string.playground_section_vertical_slider))
         Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
             var bottom by remember { mutableFloatStateOf(0.45f) }
             var top by remember { mutableFloatStateOf(0.45f) }
             var disabled by remember { mutableFloatStateOf(0.7f) }
-            LabeledControl("Depuis le bas") {
+            LabeledControl(stringResource(R.string.playground_slider_from_bottom)) {
                 VerticalFillSlider(
                     value = bottom, onValueChange = { bottom = it },
                     origin = FillOrigin.BOTTOM, accent = accent,
@@ -165,14 +166,14 @@ fun PlaygroundScreen(onBack: () -> Unit) {
                     modifier = Modifier.controlSize(),
                 )
             }
-            LabeledControl("Depuis le haut") {
+            LabeledControl(stringResource(R.string.playground_slider_from_top)) {
                 VerticalFillSlider(
                     value = top, onValueChange = { top = it },
                     origin = FillOrigin.TOP, accent = accent,
                     modifier = Modifier.controlSize(),
                 )
             }
-            LabeledControl("Désactivé") {
+            LabeledControl(stringResource(R.string.playground_slider_disabled)) {
                 VerticalFillSlider(
                     value = disabled, onValueChange = { disabled = it },
                     accent = accent, enabled = false,
@@ -184,18 +185,18 @@ fun PlaygroundScreen(onBack: () -> Unit) {
         Spacer(Modifier.height(28.dp))
 
         // 2 · Gradient sliders
-        SectionTitle("Curseur dégradé")
+        SectionTitle(stringResource(R.string.playground_section_gradient_slider))
         Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
             var kelvin by remember { mutableIntStateOf(4000) }
             var disabledKelvin by remember { mutableIntStateOf(3000) }
-            LabeledControl("Température") {
+            LabeledControl(stringResource(R.string.playground_slider_temperature)) {
                 VerticalColorTempSlider(
                     kelvin = kelvin, onKelvinChange = { kelvin = it },
                     minKelvin = 2200, maxKelvin = 6500,
                     modifier = Modifier.controlSize(),
                 )
             }
-            LabeledControl("Désactivé") {
+            LabeledControl(stringResource(R.string.playground_slider_disabled)) {
                 VerticalColorTempSlider(
                     kelvin = disabledKelvin, onKelvinChange = { disabledKelvin = it },
                     minKelvin = 2200, maxKelvin = 6500, enabled = false,
@@ -206,28 +207,33 @@ fun PlaygroundScreen(onBack: () -> Unit) {
 
         Spacer(Modifier.height(28.dp))
 
-        // 3 · Segmented selectors (2 … 6 options — the control grows taller with the count)
-        SectionTitle("Sélecteur")
+        // 3 · Segmented selectors
+        SectionTitle(stringResource(R.string.playground_section_selector))
         Row(horizontalArrangement = Arrangement.spacedBy(20.dp), verticalAlignment = Alignment.Top) {
             var two by remember { mutableStateOf(true) }
             var three by remember { mutableStateOf(Presence.HOME) }
             var six by remember { mutableIntStateOf(2) }
-            LabeledControl("2 options") {
+            val selectorAutoLabel = stringResource(R.string.playground_selector_auto)
+            val selectorManualLabel = stringResource(R.string.playground_selector_manual)
+            LabeledControl(stringResource(R.string.playground_selector_2_options)) {
                 VerticalSegmentedSelector(
                     options = listOf(true, false),
                     selected = two, onSelect = { two = it },
-                    label = { if (it) "Auto" else "Manuel" },
+                    label = { if (it) selectorAutoLabel else selectorManualLabel },
                     accent = accent,
                     modifier = Modifier.width(88.dp),
                 )
             }
-            LabeledControl("Icône empilée") {
+            val presenceHomeLabel = stringResource(R.string.playground_presence_home)
+            val presenceAwayLabel = stringResource(R.string.playground_presence_away)
+            val presenceOffLabel = stringResource(R.string.playground_presence_off)
+            LabeledControl(stringResource(R.string.playground_selector_icon_stacked)) {
                 VerticalSegmentedSelector(
                     options = Presence.entries.toList(),
                     selected = three, onSelect = { three = it },
                     label = {
                         when (it) {
-                            Presence.HOME -> "Au domicile"; Presence.AWAY -> "Absent"; Presence.OFF -> "Désactivée"
+                            Presence.HOME -> presenceHomeLabel; Presence.AWAY -> presenceAwayLabel; Presence.OFF -> presenceOffLabel
                         }
                     },
                     icon = {
@@ -240,7 +246,7 @@ fun PlaygroundScreen(onBack: () -> Unit) {
                     modifier = Modifier.width(88.dp),
                 )
             }
-            LabeledControl("6 options") {
+            LabeledControl(stringResource(R.string.playground_selector_6_options)) {
                 VerticalSegmentedSelector(
                     options = listOf(1, 2, 3, 4, 5, 6),
                     selected = six, onSelect = { six = it },
@@ -256,17 +262,17 @@ fun PlaygroundScreen(onBack: () -> Unit) {
         Spacer(Modifier.height(28.dp))
 
         // 4 · Vertical switches
-        SectionTitle("Interrupteur")
+        SectionTitle(stringResource(R.string.playground_section_switch))
         Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
             var on by remember { mutableStateOf(true) }
             var off by remember { mutableStateOf(false) }
-            LabeledControl(if (on) "Activé" else "Désactivé") {
+            LabeledControl(if (on) stringResource(R.string.playground_switch_on) else stringResource(R.string.playground_switch_off)) {
                 VerticalSwitch(
                     checked = on, onCheckedChange = { on = it }, accent = accent,
                     modifier = Modifier.controlSize(),
                 )
             }
-            LabeledControl("Icône + texte") {
+            LabeledControl(stringResource(R.string.playground_switch_icon_text)) {
                 VerticalSwitch(
                     checked = off, onCheckedChange = { off = it }, accent = accent,
                     icon = { Icons.Filled.PowerSettingsNew },
@@ -274,7 +280,7 @@ fun PlaygroundScreen(onBack: () -> Unit) {
                     modifier = Modifier.controlSize(),
                 )
             }
-            LabeledControl("Désactivé") {
+            LabeledControl(stringResource(R.string.playground_switch_disabled)) {
                 VerticalSwitch(
                     checked = true, onCheckedChange = {}, accent = accent, enabled = false,
                     modifier = Modifier.controlSize(),
@@ -285,12 +291,12 @@ fun PlaygroundScreen(onBack: () -> Unit) {
         Spacer(Modifier.height(28.dp))
 
         // 5 · Keypad
-        SectionTitle("Clavier")
+        SectionTitle(stringResource(R.string.playground_section_keypad))
         var pinError by remember { mutableStateOf(false) }
         var unlocked by remember { mutableStateOf(false) }
         var keypadEnabled by remember { mutableStateOf(true) }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Text("Clavier actif", style = AppleTypography.bodyLarge, color = AppleColors.secondary)
+            Text(stringResource(R.string.playground_keypad_active), style = AppleTypography.bodyLarge, color = AppleColors.secondary)
             Spacer(Modifier.width(12.dp))
             VerticalSwitch(
                 checked = keypadEnabled, onCheckedChange = { keypadEnabled = it }, accent = accent,
@@ -300,8 +306,8 @@ fun PlaygroundScreen(onBack: () -> Unit) {
         Spacer(Modifier.height(12.dp))
         PinKeypad(
             codeLength = 4,
-            title = if (unlocked) "Déverrouillé ✓" else "Code : 1234",
-            subtitle = "Un mauvais code fait trembler les points",
+            title = if (unlocked) stringResource(R.string.playground_keypad_unlocked) else stringResource(R.string.playground_keypad_code_hint),
+            subtitle = stringResource(R.string.playground_keypad_wrong_code_hint),
             accent = accent,
             error = pinError,
             onErrorConsumed = { pinError = false },
@@ -314,8 +320,8 @@ fun PlaygroundScreen(onBack: () -> Unit) {
 
         Spacer(Modifier.height(28.dp))
 
-        // 6 · Thermostat arc + cylinder mode picker
-        SectionTitle("Thermostat")
+        // 6 · Thermostat
+        SectionTitle(stringResource(R.string.playground_section_thermostat))
         var tMode by remember { mutableStateOf(ThermostatMode.HEAT_COOL) }
         var low by remember { mutableFloatStateOf(63f) }
         var high by remember { mutableFloatStateOf(70f) }
@@ -328,6 +334,10 @@ fun PlaygroundScreen(onBack: () -> Unit) {
             modifier = Modifier.fillMaxWidth().height(300.dp),
         )
         Spacer(Modifier.height(8.dp))
+        val thermoOffLabel = stringResource(R.string.playground_thermo_mode_off)
+        val thermoCoolLabel = stringResource(R.string.playground_thermo_mode_cool)
+        val thermoHeatLabel = stringResource(R.string.playground_thermo_mode_heat)
+        val thermoAutoLabel = stringResource(R.string.playground_thermo_mode_auto)
         val modes = listOf(ThermostatMode.OFF, ThermostatMode.COOL, ThermostatMode.HEAT, ThermostatMode.HEAT_COOL)
         WheelPicker(
             options = modes,
@@ -335,8 +345,8 @@ fun PlaygroundScreen(onBack: () -> Unit) {
             onSelect = { tMode = it },
             label = {
                 when (it) {
-                    ThermostatMode.OFF -> "Éteint"; ThermostatMode.COOL -> "Refroidir"
-                    ThermostatMode.HEAT -> "Chauffer"; ThermostatMode.HEAT_COOL -> "Auto"
+                    ThermostatMode.OFF -> thermoOffLabel; ThermostatMode.COOL -> thermoCoolLabel
+                    ThermostatMode.HEAT -> thermoHeatLabel; ThermostatMode.HEAT_COOL -> thermoAutoLabel
                 }
             },
             accent = accent,
@@ -345,29 +355,43 @@ fun PlaygroundScreen(onBack: () -> Unit) {
 
         Spacer(Modifier.height(28.dp))
 
-        // 7 · Robot vacuum — Apple-simple layout
-        SectionTitle("Aspirateur robot")
+        // 7 · Robot vacuum
+        SectionTitle(stringResource(R.string.playground_section_vacuum))
+        val livingName = stringResource(R.string.playground_vacuum_living_room)
+        val kitchenName = stringResource(R.string.playground_vacuum_kitchen)
+        val bedroomName = stringResource(R.string.playground_vacuum_bedroom)
+        val bathName = stringResource(R.string.playground_vacuum_bathroom)
         val rooms = remember {
             listOf(
-                VacuumRoom("living", "Salon", Icons.Outlined.Weekend),
-                VacuumRoom("kitchen", "Cuisine", Icons.Outlined.Kitchen),
-                VacuumRoom("bedroom", "Chambre", Icons.Outlined.Bed),
-                VacuumRoom("bath", "Salle de bain", Icons.Outlined.Bathtub),
+                VacuumRoom("living", livingName, Icons.Outlined.Weekend),
+                VacuumRoom("kitchen", kitchenName, Icons.Outlined.Kitchen),
+                VacuumRoom("bedroom", bedroomName, Icons.Outlined.Bed),
+                VacuumRoom("bath", bathName, Icons.Outlined.Bathtub),
             )
         }
         var running by remember { mutableStateOf(true) }
         var mode by remember { mutableStateOf(VacuumMode.VACUUM) }
         var vacRooms by remember { mutableStateOf(setOf<String>()) }
         Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-            Text("emmy", style = AppleTypography.headlineLarge, color = AppleColors.primary)
+            Text(stringResource(R.string.playground_vacuum_name), style = AppleTypography.headlineLarge, color = AppleColors.primary)
             Text(
-                if (running) "Nettoyage" else "En pause",
+                if (running) stringResource(R.string.playground_vacuum_cleaning) else stringResource(R.string.playground_vacuum_paused),
                 style = AppleTypography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
                 color = accent,
             )
             Spacer(Modifier.height(28.dp))
             VacuumRunButton(running = running, onToggle = { running = it })
             Spacer(Modifier.height(28.dp))
+            val vacuumLabelVacuum = stringResource(R.string.vacuum_mode_vacuum)
+            val vacuumLabelVacAndMop = stringResource(R.string.vacuum_mode_vacuum_and_mop)
+            val vacuumLabelVacThenMop = stringResource(R.string.vacuum_mode_vacuum_then_mop)
+            val vacuumLabelMop = stringResource(R.string.vacuum_mode_mop)
+            val vacuumModeLabels = mapOf(
+                VacuumMode.VACUUM to vacuumLabelVacuum,
+                VacuumMode.VACUUM_AND_MOP to vacuumLabelVacAndMop,
+                VacuumMode.VACUUM_THEN_MOP to vacuumLabelVacThenMop,
+                VacuumMode.MOP to vacuumLabelMop,
+            )
             val modes = listOf(
                 VacuumMode.VACUUM, VacuumMode.VACUUM_AND_MOP,
                 VacuumMode.VACUUM_THEN_MOP, VacuumMode.MOP,
@@ -376,12 +400,14 @@ fun PlaygroundScreen(onBack: () -> Unit) {
                 options = modes,
                 selected = mode,
                 onSelect = { mode = it },
-                label = { it.frLabel() },
+                label = { vacuumModeLabels[it]!! },
                 accent = AppleColors.primary,
                 modifier = Modifier.fillMaxWidth(),
             )
             Spacer(Modifier.height(16.dp))
-            VacuumStatusChip(if (running) "Préparation" else "En pause", prominent = true)
+            val inProgressLabel = stringResource(R.string.playground_vacuum_in_progress)
+            val queuedLabel = stringResource(R.string.playground_vacuum_queued)
+            VacuumStatusChip(if (running) stringResource(R.string.playground_vacuum_preparing) else stringResource(R.string.playground_vacuum_paused), prominent = true)
             Spacer(Modifier.height(20.dp))
             VacuumRoomChips(
                 rooms = rooms,
@@ -390,7 +416,7 @@ fun PlaygroundScreen(onBack: () -> Unit) {
                     vacRooms = if (id in vacRooms) vacRooms - id else vacRooms + id
                 },
                 currentRoomId = "living",
-                roomState = { if (running) "En cours" else "En file" },
+                roomState = { if (running) inProgressLabel else queuedLabel },
                 accent = accent,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -398,34 +424,34 @@ fun PlaygroundScreen(onBack: () -> Unit) {
 
         Spacer(Modifier.height(28.dp))
 
-        // 8 · HomeKit accessory grid
-        SectionTitle("Accessoires (HomeKit)")
+        // 8 · Accessories
+        SectionTitle(stringResource(R.string.playground_section_accessories))
         var deskOn by remember { mutableStateOf(true) }
         var lampOn by remember { mutableStateOf(false) }
         var plugOn by remember { mutableStateOf(true) }
         val accessories = listOf(
             AccessoryItem(
-                "desk", "Bureau", Icons.Outlined.Lightbulb, deskOn,
-                subtitle = if (deskOn) "36 %" else "Éteinte",
+                "desk", stringResource(R.string.playground_accessory_desk), Icons.Outlined.Lightbulb, deskOn,
+                subtitle = if (deskOn) "36 %" else stringResource(R.string.playground_accessory_off),
                 accent = AppleColors.warning, onToggle = { deskOn = it },
             ),
             AccessoryItem(
-                "blinds", "Volet", Icons.Outlined.Blinds, false,
-                subtitle = "Mise à jour…", accent = accent, warning = true,
+                "blinds", stringResource(R.string.playground_accessory_blinds), Icons.Outlined.Blinds, false,
+                subtitle = stringResource(R.string.playground_accessory_updating), accent = accent, warning = true,
             ),
             AccessoryItem(
-                "lamp", "Lampe salon", Icons.Outlined.Lightbulb, lampOn,
-                subtitle = if (lampOn) "Allumée" else "Éteinte",
+                "lamp", stringResource(R.string.playground_accessory_lamp), Icons.Outlined.Lightbulb, lampOn,
+                subtitle = if (lampOn) stringResource(R.string.playground_accessory_on) else stringResource(R.string.playground_accessory_off),
                 accent = AppleColors.warning, onToggle = { lampOn = it },
             ),
             AccessoryItem(
-                "plug", "Prise TV", Icons.Outlined.Power, plugOn,
-                subtitle = if (plugOn) "Activée" else "Désactivée",
+                "plug", stringResource(R.string.playground_accessory_plug_tv), Icons.Outlined.Power, plugOn,
+                subtitle = if (plugOn) stringResource(R.string.playground_accessory_active) else stringResource(R.string.playground_accessory_inactive),
                 accent = accent, onToggle = { plugOn = it },
             ),
             AccessoryItem(
-                "plug2", "Prise 2", Icons.Outlined.Power, false,
-                subtitle = "Pas de réponse", warning = true,
+                "plug2", stringResource(R.string.playground_accessory_plug2), Icons.Outlined.Power, false,
+                subtitle = stringResource(R.string.playground_accessory_no_response), warning = true,
             ),
         )
         AccessoryGrid(items = accessories)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
@@ -9,10 +9,12 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -37,6 +39,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -49,7 +52,9 @@ import com.iblu01.portallauncher.ui.components.AppGridInsets
 import com.iblu01.portallauncher.ui.components.ClockHeaderCollapsedHeight
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import com.iblu01.portallauncher.AppLanguage
 import com.iblu01.portallauncher.Prefs
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.HaInstance
 import com.iblu01.portallauncher.HaEntity
 import com.iblu01.portallauncher.PillRule
@@ -63,6 +68,7 @@ import com.iblu01.portallauncher.ui.components.PillButton
 import com.iblu01.portallauncher.ui.components.SettingsDivider
 import com.iblu01.portallauncher.ui.components.SettingsRow
 import com.iblu01.portallauncher.ui.components.SettingsSection
+import com.iblu01.portallauncher.ui.components.SettingsSidebar
 import com.iblu01.portallauncher.ui.components.SettingsSlider
 import com.iblu01.portallauncher.ui.components.SettingsSubPageHeader
 import com.iblu01.portallauncher.ui.components.SettingsTile
@@ -204,11 +210,11 @@ fun SettingsScreen(
     }
 
     val homeSubtitle = when {
-        haToken.isBlank() -> "À configurer"
-        uiState.haTest == ConnStatus.TESTING -> "Vérification…"
-        uiState.haTest == ConnStatus.OK -> "Connectée"
-        uiState.haTest == ConnStatus.ERROR -> "Vérifier la connexion"
-        else -> "Adresse, clé d'accès"
+        haToken.isBlank() -> stringResource(R.string.settings_home_subtitle_not_configured)
+        uiState.haTest == ConnStatus.TESTING -> stringResource(R.string.settings_home_subtitle_testing)
+        uiState.haTest == ConnStatus.OK -> stringResource(R.string.settings_home_subtitle_connected)
+        uiState.haTest == ConnStatus.ERROR -> stringResource(R.string.settings_home_subtitle_error)
+        else -> stringResource(R.string.settings_home_subtitle_default)
     }
 
     if (showAppPicker) {
@@ -220,92 +226,143 @@ fun SettingsScreen(
         )
     }
 
+    // Shared between the narrow (single sub-page, back button) and expanded (sidebar +
+    // detail pane, no back button) layouts below.
+    val detailContent: @Composable (SettingsPage, Boolean) -> Unit = { page, showBack ->
+        when (page) {
+            SettingsPage.MAIN -> MainPage(
+                homeSubtitle = homeSubtitle,
+                onNavigate = { currentPage = it },
+            )
+            SettingsPage.SETUP -> SetupWizard(
+                uiState = uiState,
+                haUrl = haUrl, haToken = haToken,
+                onUrlChange = onUrlChange,
+                onTokenChange = onTokenChange,
+                onSelectInstance = onSelectInstance,
+                onTest = { callbacks.onTestHaApi(haUrl, haToken) },
+                onFinish = { save(); currentPage = SettingsPage.MAIN },
+                onSkip = { currentPage = SettingsPage.MAIN },
+            )
+            SettingsPage.HOME -> HomeConnectionPage(
+                uiState = uiState,
+                haUrl = haUrl, haToken = haToken,
+                mqttHost = host, mqttPort = port,
+                mqttUsername = username, mqttPassword = password,
+                deviceName = deviceName,
+                onUrlChange = onUrlChange,
+                onTokenChange = onTokenChange,
+                onSelectInstance = onSelectInstance,
+                onMqttHostChange = { host = it; brokerAuto = false },
+                onMqttPortChange = { port = it },
+                onMqttUsernameChange = { username = it },
+                onMqttPasswordChange = { password = it },
+                onDeviceNameChange = { deviceName = it },
+                onTestHa = { callbacks.onTestHaApi(haUrl, haToken) },
+                onTestMqtt = { callbacks.onTestMqtt(host, port.toIntOrNull() ?: 1883, username, password) },
+                onBack = { save(); currentPage = SettingsPage.MAIN },
+                showBack = showBack,
+            )
+            SettingsPage.APPLICATION -> AppPage(
+                prefs = prefs,
+                haPackage = haPackage,
+                currentAppLabel = currentAppLabel,
+                onShowAppPicker = { showAppPicker = true },
+                bgMode = bgMode,
+                onBgModeChange = { bgMode = it; callbacks.onSetBackgroundMode(it) },
+                bgOverlayOpacity = bgOverlayOpacity,
+                onOpenOpacityPreview = callbacks::onOpenOpacityPreview,
+                onOpenClockTheme = callbacks::onOpenClockTheme,
+                powerAlwaysOn = powerAlwaysOn,
+                onPowerAlwaysOnChange = { powerAlwaysOn = it; callbacks.onTogglePowerAlwaysOn(it) },
+                timeoutEnabled = timeoutEnabled,
+                onTimeoutEnabledChange = { timeoutEnabled = it; callbacks.onToggleTimeoutEnabled(it) },
+                timeoutMinutes = timeoutMinutes,
+                onTimeoutMinutesChange = { timeoutMinutes = it; callbacks.onSetTimeoutMinutes(it.toInt()) },
+                autoReturnEnabled = autoReturnEnabled,
+                onAutoReturnEnabledChange = { autoReturnEnabled = it; prefs.autoReturnEnabled = it },
+                autoReturnDelay = autoReturnDelay,
+                onAutoReturnDelayChange = { autoReturnDelay = it; prefs.autoReturnDelaySeconds = it.toInt() },
+                gridScale = gridScale,
+                onGridScaleChange = { gridScale = it; prefs.gridScale = it },
+                onBack = { currentPage = SettingsPage.MAIN },
+                showBack = showBack,
+            )
+            SettingsPage.PILLS -> PillsSettingsPage(
+                uiState = uiState,
+                onRefresh = callbacks::onLoadPillEntities,
+                onSetEnabled = callbacks::onSetPillEnabled,
+                onBack = { currentPage = SettingsPage.MAIN },
+                showBack = showBack,
+            )
+            SettingsPage.DEVELOPER -> DeveloperPage(
+                prefs = prefs,
+                devKeep = devKeep,
+                onDevKeepChange = { devKeep = it; callbacks.onToggleDevKeepScreenOn(it) },
+                onGrantPermissions = { callbacks.onGrantPermissions() },
+                onBack = { currentPage = SettingsPage.MAIN },
+                showBack = showBack,
+            )
+        }
+    }
+
     Scaffold(
         containerColor = AppleColors.groupedBg,
         contentWindowInsets = WindowInsets.safeDrawing
     ) { inner ->
         Box(modifier = Modifier.fillMaxSize().padding(inner)) {
-            AnimatedContent(
-                targetState = currentPage,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp, vertical = 20.dp),
-                transitionSpec = {
-                    val dir = if (targetState.ordinal > initialState.ordinal) 1 else -1
-                    (slideInHorizontally { it * dir } + fadeIn()) togetherWith
-                        (slideOutHorizontally { -it * dir } + fadeOut())
-                },
-                label = "settingsPage"
-            ) { page ->
-                when (page) {
-                    SettingsPage.MAIN -> MainPage(
-                        homeSubtitle = homeSubtitle,
-                        onNavigate = { currentPage = it },
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                // Mirrors androidx WindowSizeClass: Expanded starts at 840dp width, where a
+                // tablet has room for a permanent nav sidebar next to the detail pane.
+                val isExpanded = maxWidth >= 840.dp
+
+                if (currentPage == SettingsPage.SETUP) {
+                    Box(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp, vertical = 20.dp)) {
+                        detailContent(SettingsPage.SETUP, true)
+                    }
+                } else if (isExpanded) {
+                    val sidebarItems = listOf(
+                        Triple(SettingsPage.HOME, Icons.Outlined.Home, stringResource(R.string.settings_tile_home_title)),
+                        Triple(SettingsPage.PILLS, Icons.Outlined.Dashboard, stringResource(R.string.settings_tile_pills_title)),
+                        Triple(SettingsPage.APPLICATION, Icons.Outlined.Settings, stringResource(R.string.settings_tile_app_title)),
+                        Triple(SettingsPage.DEVELOPER, Icons.Outlined.Build, stringResource(R.string.settings_tile_dev_title)),
                     )
-                    SettingsPage.SETUP -> SetupWizard(
-                        uiState = uiState,
-                        haUrl = haUrl, haToken = haToken,
-                        onUrlChange = onUrlChange,
-                        onTokenChange = onTokenChange,
-                        onSelectInstance = onSelectInstance,
-                        onTest = { callbacks.onTestHaApi(haUrl, haToken) },
-                        onFinish = { save(); currentPage = SettingsPage.MAIN },
-                        onSkip = { currentPage = SettingsPage.MAIN },
-                    )
-                    SettingsPage.HOME -> HomeConnectionPage(
-                        uiState = uiState,
-                        haUrl = haUrl, haToken = haToken,
-                        mqttHost = host, mqttPort = port,
-                        mqttUsername = username, mqttPassword = password,
-                        deviceName = deviceName,
-                        onUrlChange = onUrlChange,
-                        onTokenChange = onTokenChange,
-                        onSelectInstance = onSelectInstance,
-                        onMqttHostChange = { host = it; brokerAuto = false },
-                        onMqttPortChange = { port = it },
-                        onMqttUsernameChange = { username = it },
-                        onMqttPasswordChange = { password = it },
-                        onDeviceNameChange = { deviceName = it },
-                        onTestHa = { callbacks.onTestHaApi(haUrl, haToken) },
-                        onTestMqtt = { callbacks.onTestMqtt(host, port.toIntOrNull() ?: 1883, username, password) },
-                        onBack = { save(); currentPage = SettingsPage.MAIN },
-                    )
-                    SettingsPage.APPLICATION -> AppPage(
-                        haPackage = haPackage,
-                        currentAppLabel = currentAppLabel,
-                        onShowAppPicker = { showAppPicker = true },
-                        bgMode = bgMode,
-                        onBgModeChange = { bgMode = it; callbacks.onSetBackgroundMode(it) },
-                        bgOverlayOpacity = bgOverlayOpacity,
-                        onOpenOpacityPreview = callbacks::onOpenOpacityPreview,
-                        onOpenClockTheme = callbacks::onOpenClockTheme,
-                        powerAlwaysOn = powerAlwaysOn,
-                        onPowerAlwaysOnChange = { powerAlwaysOn = it; callbacks.onTogglePowerAlwaysOn(it) },
-                        timeoutEnabled = timeoutEnabled,
-                        onTimeoutEnabledChange = { timeoutEnabled = it; callbacks.onToggleTimeoutEnabled(it) },
-                        timeoutMinutes = timeoutMinutes,
-                        onTimeoutMinutesChange = { timeoutMinutes = it; callbacks.onSetTimeoutMinutes(it.toInt()) },
-                        autoReturnEnabled = autoReturnEnabled,
-                        onAutoReturnEnabledChange = { autoReturnEnabled = it; prefs.autoReturnEnabled = it },
-                        autoReturnDelay = autoReturnDelay,
-                        onAutoReturnDelayChange = { autoReturnDelay = it; prefs.autoReturnDelaySeconds = it.toInt() },
-                        gridScale = gridScale,
-                        onGridScaleChange = { gridScale = it; prefs.gridScale = it },
-                        onBack = { currentPage = SettingsPage.MAIN },
-                    )
-                    SettingsPage.PILLS -> PillsSettingsPage(
-                        uiState = uiState,
-                        onRefresh = callbacks::onLoadPillEntities,
-                        onSetEnabled = callbacks::onSetPillEnabled,
-                        onBack = { currentPage = SettingsPage.MAIN },
-                    )
-                    SettingsPage.DEVELOPER -> DeveloperPage(
-                        prefs = prefs,
-                        devKeep = devKeep,
-                        onDevKeepChange = { devKeep = it; callbacks.onToggleDevKeepScreenOn(it) },
-                        onGrantPermissions = { callbacks.onGrantPermissions() },
-                        onBack = { currentPage = SettingsPage.MAIN },
-                    )
+                    // The MAIN tile grid only exists for the narrow layout; land on "Ma maison" instead.
+                    val selectedPage = if (currentPage == SettingsPage.MAIN) SettingsPage.HOME else currentPage
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 16.dp, vertical = 20.dp)
+                    ) {
+                        SettingsSidebar(
+                            items = sidebarItems,
+                            selected = selectedPage,
+                            onSelect = { currentPage = it },
+                            modifier = Modifier.fillMaxHeight(),
+                            header = stringResource(R.string.settings_main_title),
+                        )
+                        Box(modifier = Modifier.weight(1f).fillMaxHeight()) {
+                            AnimatedContent(
+                                targetState = selectedPage,
+                                transitionSpec = { fadeIn() togetherWith fadeOut() },
+                                label = "settingsDetail"
+                            ) { page -> detailContent(page, false) }
+                        }
+                    }
+                } else {
+                    AnimatedContent(
+                        targetState = currentPage,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 16.dp, vertical = 20.dp),
+                        transitionSpec = {
+                            val dir = if (targetState.ordinal > initialState.ordinal) 1 else -1
+                            (slideInHorizontally { it * dir } + fadeIn()) togetherWith
+                                (slideOutHorizontally { -it * dir } + fadeOut())
+                        },
+                        label = "settingsPage"
+                    ) { page -> detailContent(page, true) }
                 }
             }
 
@@ -317,17 +374,17 @@ fun SettingsScreen(
 @Composable
 private fun MainPage(homeSubtitle: String, onNavigate: (SettingsPage) -> Unit) {
     val tiles = listOf(
-        TileDef(SettingsPage.HOME, Icons.Outlined.Home, "Ma maison", homeSubtitle),
-        TileDef(SettingsPage.PILLS, Icons.Outlined.Dashboard, "Informations affichées", "Ce que Portal montre en haut de l'écran"),
-        TileDef(SettingsPage.APPLICATION, Icons.Outlined.Settings, "Application", "Fond d'écran, veille, applications"),
-        TileDef(SettingsPage.DEVELOPER, Icons.Outlined.Build, "Développeur", "Options avancées"),
+        TileDef(SettingsPage.HOME, Icons.Outlined.Home, stringResource(R.string.settings_tile_home_title), homeSubtitle),
+        TileDef(SettingsPage.PILLS, Icons.Outlined.Dashboard, stringResource(R.string.settings_tile_pills_title), stringResource(R.string.settings_tile_pills_subtitle)),
+        TileDef(SettingsPage.APPLICATION, Icons.Outlined.Settings, stringResource(R.string.settings_tile_app_title), stringResource(R.string.settings_tile_app_subtitle)),
+        TileDef(SettingsPage.DEVELOPER, Icons.Outlined.Build, stringResource(R.string.settings_tile_dev_title), stringResource(R.string.settings_tile_dev_subtitle)),
     )
 
     Column(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        Text("Portal Launcher", style = AppleTypography.headlineLarge, color = AppleColors.primary, modifier = Modifier.padding(start = 4.dp))
+        Text(stringResource(R.string.settings_main_title), style = AppleTypography.headlineLarge, color = AppleColors.primary, modifier = Modifier.padding(start = 4.dp))
 
         tiles.chunked(2).forEach { rowTiles ->
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -344,6 +401,7 @@ private fun MainPage(homeSubtitle: String, onNavigate: (SettingsPage) -> Unit) {
 
 @Composable
 private fun AppPage(
+    prefs: Prefs,
     haPackage: String, currentAppLabel: String, onShowAppPicker: () -> Unit,
     bgMode: String, onBgModeChange: (String) -> Unit,
     bgOverlayOpacity: Float = 0.25f, onOpenOpacityPreview: () -> Unit = {},
@@ -355,40 +413,56 @@ private fun AppPage(
     autoReturnDelay: Float, onAutoReturnDelayChange: (Float) -> Unit,
     gridScale: Float = 1f, onGridScaleChange: (Float) -> Unit = {},
     onBack: () -> Unit,
+    showBack: Boolean = true,
 ) {
+    var showLanguagePage by remember { mutableStateOf(false) }
+    if (showLanguagePage) {
+        LanguagePage(prefs = prefs, onBack = { showLanguagePage = false })
+        return
+    }
+
     Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()), verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        SettingsSubPageHeader(title = "Application", onBack = onBack)
+        SettingsSubPageHeader(title = stringResource(R.string.settings_app_page_title), onBack = onBack, showBack = showBack)
+
+        SettingsSection(title = stringResource(R.string.settings_app_section_language)) {
+            val currentLanguage = AppLanguage.from(prefs.appLanguage)
+            SettingsRow(
+                label = stringResource(R.string.settings_app_label_language),
+                value = "${currentLanguage.flag} ${stringResource(currentLanguage.nameRes)}",
+                onClick = { showLanguagePage = true },
+            )
+        }
 
         // Any app, not just Home Assistant: this is the launcher's headline gesture, and HA is
         // only the default choice.
-        SettingsSection(title = "TAP SUR L'ÉCRAN D'ACCUEIL") {
+        SettingsSection(title = stringResource(R.string.settings_app_section_tap_home)) {
             SettingsRow(
-                label = "Application à ouvrir",
+                label = stringResource(R.string.settings_app_label_app_to_open),
                 value = currentAppLabel.ifBlank { haPackage },
                 onClick = onShowAppPicker,
             )
         }
 
-        SettingsSection(title = "FOND D'ÉCRAN") {
+        SettingsSection(title = stringResource(R.string.settings_app_section_wallpaper)) {
             backgroundModes.forEach { (key, label) ->
-                SettingsRow(label = label, value = if (key == bgMode) "✓" else "", onClick = { onBgModeChange(key) })
+                SettingsRow(label = stringResource(label), value = if (key == bgMode) "✓" else "", onClick = { onBgModeChange(key) })
                 if (key != backgroundModes.last().first) SettingsDivider()
             }
             if (bgMode != "neutral") {
                 SettingsDivider()
                 SettingsRow(
-                    label = "Opacité du voile",
+                    label = stringResource(R.string.settings_app_label_overlay_opacity),
                     value = "${(bgOverlayOpacity * 100).toInt()} %",
                     onClick = onOpenOpacityPreview,
                 )
             }
         }
 
-        SettingsSection(title = "HORLOGE") {
-            SettingsRow(label = "Thème de l'horloge", value = "", onClick = onOpenClockTheme)
+        SettingsSection(title = stringResource(R.string.settings_app_section_clock)) {
+            SettingsRow(label = stringResource(R.string.settings_app_label_clock_theme), value = "", onClick = onOpenClockTheme)
         }
 
-        SettingsSection(title = "GRILLE D'APPLICATIONS") {
+        SettingsSection(title = stringResource(R.string.settings_app_section_app_grid)) {
             val configuration = LocalConfiguration.current
             val spec = remember(gridScale, configuration.screenWidthDp, configuration.screenHeightDp) {
                 gridSpecFor(
@@ -399,7 +473,7 @@ private fun AppPage(
                 )
             }
             SettingsSlider(
-                label = "Taille des icônes",
+                label = stringResource(R.string.settings_app_label_icon_size),
                 value = gridScale * 100f,
                 valueRange = 70f..130f,
                 steps = 11,
@@ -408,21 +482,21 @@ private fun AppPage(
             )
         }
 
-        SettingsSection(title = "ÉCRAN & VEILLE") {
-            SettingsToggle(label = "Mode toujours allumé", checked = powerAlwaysOn, onCheckedChange = onPowerAlwaysOnChange)
+        SettingsSection(title = stringResource(R.string.settings_app_section_screen_sleep)) {
+            SettingsToggle(label = stringResource(R.string.settings_app_toggle_always_on), checked = powerAlwaysOn, onCheckedChange = onPowerAlwaysOnChange)
             SettingsDivider()
-            SettingsToggle(label = "Extinction automatique", checked = timeoutEnabled, onCheckedChange = onTimeoutEnabledChange)
+            SettingsToggle(label = stringResource(R.string.settings_app_toggle_auto_timeout), checked = timeoutEnabled, onCheckedChange = onTimeoutEnabledChange)
             if (timeoutEnabled) {
                 SettingsDivider()
-                SettingsSlider(label = "Délai", value = timeoutMinutes, valueRange = 1f..240f, steps = 238, onValueChange = onTimeoutMinutesChange, valueSuffix = " min")
+                SettingsSlider(label = stringResource(R.string.settings_app_label_timeout_delay), value = timeoutMinutes, valueRange = 1f..240f, steps = 238, onValueChange = onTimeoutMinutesChange, valueSuffix = " min")
             }
         }
 
-        SettingsSection(title = "RETOUR AUTOMATIQUE") {
-            SettingsToggle(label = "Retour à l'écran principal", checked = autoReturnEnabled, onCheckedChange = onAutoReturnEnabledChange)
+        SettingsSection(title = stringResource(R.string.settings_app_section_auto_return)) {
+            SettingsToggle(label = stringResource(R.string.settings_app_toggle_auto_return), checked = autoReturnEnabled, onCheckedChange = onAutoReturnEnabledChange)
             if (autoReturnEnabled) {
                 SettingsDivider()
-                SettingsSlider(label = "Délai d'inactivité", value = autoReturnDelay, valueRange = 5f..60f, steps = 54, onValueChange = onAutoReturnDelayChange, valueSuffix = " s")
+                SettingsSlider(label = stringResource(R.string.settings_app_label_auto_return_delay), value = autoReturnDelay, valueRange = 5f..60f, steps = 54, onValueChange = onAutoReturnDelayChange, valueSuffix = " s")
             }
         }
 
@@ -436,6 +510,7 @@ private fun DeveloperPage(
     onDevKeepChange: (Boolean) -> Unit,
     onGrantPermissions: () -> Unit,
     onBack: () -> Unit,
+    showBack: Boolean = true,
 ) {
     var rebootLoading by remember { mutableStateOf(false) }
 
@@ -443,17 +518,17 @@ private fun DeveloperPage(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        SettingsSubPageHeader(title = "Développeur", onBack = onBack)
+        SettingsSubPageHeader(title = stringResource(R.string.settings_dev_page_title), onBack = onBack, showBack = showBack)
 
-        SettingsSection(title = "DÉBOGAGE") {
-            SettingsToggle(label = "Écran toujours allumé (dev)", checked = devKeep, onCheckedChange = onDevKeepChange)
+        SettingsSection(title = stringResource(R.string.settings_dev_section_debug)) {
+            SettingsToggle(label = stringResource(R.string.settings_dev_toggle_keep_screen_on), checked = devKeep, onCheckedChange = onDevKeepChange)
         }
 
-        SettingsSection(title = "SYSTÈME") {
-            SettingsRow(label = "Permissions capteurs / son / luminosité", onClick = onGrantPermissions)
+        SettingsSection(title = stringResource(R.string.settings_dev_section_system)) {
+            SettingsRow(label = stringResource(R.string.settings_dev_label_permissions), onClick = onGrantPermissions)
             SettingsDivider()
             SettingsRow(
-                label = if (rebootLoading) "Redémarrage…" else "Redémarrer",
+                label = if (rebootLoading) stringResource(R.string.settings_dev_rebooting) else stringResource(R.string.settings_dev_reboot),
                 value = null,
                 onClick = {
                     if (!rebootLoading) {

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/SetupWizard.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/SetupWizard.kt
@@ -22,9 +22,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.iblu01.portallauncher.HaInstance
 import com.iblu01.portallauncher.HaMdnsDiscovery
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.components.ConnStatus
 import com.iblu01.portallauncher.ui.components.PillButton
 import com.iblu01.portallauncher.ui.components.SettingsDivider
@@ -76,7 +78,7 @@ fun SetupWizard(
 
     if (showKeyHelp) {
         SettingsInfoDialog(
-            title = "Où trouver ma clé ?",
+            title = stringResource(R.string.setup_label_where_to_find_key),
             lines = accessKeyHelpLines,
             onDismiss = { showKeyHelp = false },
         )
@@ -90,9 +92,9 @@ fun SetupWizard(
 
         when (step) {
             0 -> {
-                Text("Bienvenue", style = AppleTypography.headlineLarge, color = AppleColors.primary)
+                Text(stringResource(R.string.setup_welcome_title), style = AppleTypography.headlineLarge, color = AppleColors.primary)
                 Text(
-                    "Commençons par trouver ta maison. Assure-toi que Home Assistant est allumé sur le même réseau.",
+                    stringResource(R.string.setup_welcome_subtitle),
                     style = AppleTypography.bodyLarge,
                     color = AppleColors.secondary
                 )
@@ -110,57 +112,57 @@ fun SetupWizard(
                 }
                 if (discovered.isEmpty()) {
                     Text(
-                        "Recherche sur le réseau…",
+                        stringResource(R.string.setup_scanning_network),
                         style = AppleTypography.bodyMedium,
                         color = AppleColors.tertiary
                     )
                 }
 
-                SettingsSection(title = "OU SAISIS L'ADRESSE") {
+                SettingsSection(title = stringResource(R.string.setup_section_manual_address)) {
                     SettingsTextField(
-                        label = "Adresse",
+                        label = stringResource(R.string.setup_label_address),
                         value = haUrl,
                         onValueChange = onUrlChange,
-                        placeholder = "http://homeassistant.local:8123"
+                        placeholder = stringResource(R.string.setup_placeholder_address)
                     )
                 }
 
-                PillButton(label = "Continuer", primary = true, onClick = { step = 1 })
-                PillButton(label = "Configurer plus tard", onClick = onSkip)
+                PillButton(label = stringResource(R.string.setup_button_continue), primary = true, onClick = { step = 1 })
+                PillButton(label = stringResource(R.string.setup_button_configure_later), onClick = onSkip)
             }
 
             1 -> {
-                Text("Ta clé d'accès", style = AppleTypography.headlineLarge, color = AppleColors.primary)
+                Text(stringResource(R.string.setup_access_key_title), style = AppleTypography.headlineLarge, color = AppleColors.primary)
                 Text(
-                    "Pour laisser Portal lire l'état de ta maison, colle une clé d'accès créée dans Home Assistant.",
+                    stringResource(R.string.setup_access_key_subtitle),
                     style = AppleTypography.bodyLarge,
                     color = AppleColors.secondary
                 )
 
-                SettingsSection(title = "CLÉ D'ACCÈS") {
+                SettingsSection(title = stringResource(R.string.setup_section_access_key)) {
                     SettingsTextField(
-                        label = "Clé d'accès",
+                        label = stringResource(R.string.setup_label_access_key),
                         value = haToken,
                         onValueChange = onTokenChange,
-                        placeholder = "Colle ta clé ici",
+                        placeholder = stringResource(R.string.setup_placeholder_paste_key),
                         isPassword = true
                     )
                     SettingsDivider()
                     SettingsRow(
-                        label = "Où trouver ma clé ?",
+                        label = stringResource(R.string.setup_label_where_to_find_key),
                         onClick = { showKeyHelp = true }
                     )
                     SettingsDivider()
                     SettingsStatusRow(
-                        label = "Connexion",
+                        label = stringResource(R.string.setup_label_connection),
                         status = uiState.haTest,
                         detail = uiState.haTestMessage,
                         onClick = onTest,
                     )
                 }
 
-                PillButton(label = "Vérifier la connexion", primary = true, onClick = onTest)
-                PillButton(label = "Retour", onClick = { step = 0 })
+                PillButton(label = stringResource(R.string.setup_button_test_connection), primary = true, onClick = onTest)
+                PillButton(label = stringResource(R.string.setup_button_back), onClick = { step = 0 })
             }
 
             else -> {
@@ -170,13 +172,13 @@ fun SetupWizard(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    Text("Tout est prêt !", style = AppleTypography.headlineLarge, color = AppleColors.primary)
+                    Text(stringResource(R.string.setup_done_title), style = AppleTypography.headlineLarge, color = AppleColors.primary)
                     Text(
-                        "Portal va maintenant afficher l'état de ta maison.",
+                        stringResource(R.string.setup_done_subtitle),
                         style = AppleTypography.bodyLarge,
                         color = AppleColors.secondary
                     )
-                    PillButton(label = "Commencer", primary = true, onClick = onFinish)
+                    PillButton(label = stringResource(R.string.setup_button_start), primary = true, onClick = onFinish)
                 }
             }
         }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,517 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ===== SETUP WIZARD ===== -->
+    <string name="setup_welcome_title">Bienvenue</string>
+    <string name="setup_welcome_subtitle">Commençons par trouver ta maison. Assure-toi que Home Assistant est allumé sur le même réseau.</string>
+    <string name="setup_scanning_network">Recherche sur le réseau…</string>
+    <string name="setup_section_manual_address">OU SAISIS L\'ADRESSE</string>
+    <string name="setup_label_address">Adresse</string>
+    <string name="setup_placeholder_address">http://homeassistant.local:8123</string>
+    <string name="setup_button_continue">Continuer</string>
+    <string name="setup_button_configure_later">Configurer plus tard</string>
+    <string name="setup_access_key_title">Ta clé d\'accès</string>
+    <string name="setup_access_key_subtitle">Pour laisser Portal lire l\'état de ta maison, colle une clé d\'accès créée dans Home Assistant.</string>
+    <string name="setup_section_access_key">CLÉ D\'ACCÈS</string>
+    <string name="setup_label_access_key">Clé d\'accès</string>
+    <string name="setup_placeholder_paste_key">Colle ta clé ici</string>
+    <string name="setup_label_where_to_find_key">Où trouver ma clé ?</string>
+    <string name="setup_label_connection">Connexion</string>
+    <string name="setup_button_test_connection">Vérifier la connexion</string>
+    <string name="setup_button_back">Retour</string>
+    <string name="setup_done_title">Tout est prêt !</string>
+    <string name="setup_done_subtitle">Portal va maintenant afficher l\'état de ta maison.</string>
+    <string name="setup_button_start">Commencer</string>
+    <string name="setup_access_key_help_step_1">1. Ouvre Home Assistant → Paramètres → Utilisateurs</string>
+    <string name="setup_access_key_help_step_2">2. Sélectionne ton utilisateur</string>
+    <string name="setup_access_key_help_step_3">3. Touche « Jetons d\'accès longue durée »</string>
+    <string name="setup_access_key_help_step_4">4. Crée un jeton nommé « Portal »</string>
+    <string name="setup_access_key_help_step_5">5. Copie-le et colle-le ici</string>
+
+    <!-- ===== HOME CONNECTION PAGE ===== -->
+    <string name="home_connection_title">Ma maison</string>
+    <string name="home_connection_subtitle">Portal se connecte à ton serveur Home Assistant pour afficher l\'état de ta maison.</string>
+    <string name="home_connection_section_address">ADRESSE</string>
+    <string name="home_connection_ha_detected">Home Assistant détecté</string>
+    <string name="home_connection_label_address">Adresse</string>
+    <string name="home_connection_placeholder_address">http://homeassistant.local:8123</string>
+    <string name="home_connection_label_scan_network">Chercher sur le réseau</string>
+    <string name="home_connection_scanning">Recherche…</string>
+    <string name="home_connection_scan_found_format">%1$d trouvé(s)</string>
+    <string name="home_connection_section_access_key">CLÉ D\'ACCÈS</string>
+    <string name="home_connection_label_access_key">Clé d\'accès</string>
+    <string name="home_connection_placeholder_paste_key">Colle ta clé ici</string>
+    <string name="home_connection_label_key_help">Où trouver ma clé ?</string>
+    <string name="home_connection_section_status">STATUT DE LA CONNEXION</string>
+    <string name="home_connection_label_connection">Connexion</string>
+    <string name="home_connection_section_mqtt">MQTT</string>
+    <string name="home_connection_label_mqtt_server">Adresse du serveur</string>
+    <string name="home_connection_placeholder_mqtt_server">homeassistant.local</string>
+    <string name="home_connection_label_mqtt_port">Port</string>
+    <string name="home_connection_placeholder_mqtt_port">1883</string>
+    <string name="home_connection_toggle_mqtt_auth">Le serveur demande une authentification</string>
+    <string name="home_connection_label_mqtt_username">Identifiant</string>
+    <string name="home_connection_placeholder_username">Identifiant</string>
+    <string name="home_connection_label_mqtt_password">Mot de passe</string>
+    <string name="home_connection_placeholder_password">Mot de passe</string>
+    <string name="home_connection_label_device_name">Nom de cet appareil</string>
+    <string name="home_connection_placeholder_device_name">Portal</string>
+    <string name="home_connection_label_mqtt_connection">Connexion MQTT</string>
+
+    <!-- ===== MAIN SETTINGS SCREEN ===== -->
+    <string name="settings_home_subtitle_not_configured">À configurer</string>
+    <string name="settings_home_subtitle_testing">Vérification…</string>
+    <string name="settings_home_subtitle_connected">Connectée</string>
+    <string name="settings_home_subtitle_error">Vérifier la connexion</string>
+    <string name="settings_home_subtitle_default">Adresse, clé d\'accès</string>
+    <string name="settings_tile_home_title">Ma maison</string>
+    <string name="settings_tile_pills_title">Informations affichées</string>
+    <string name="settings_tile_pills_subtitle">Ce que Portal montre en haut de l\'écran</string>
+    <string name="settings_tile_app_title">Application</string>
+    <string name="settings_tile_app_subtitle">Fond d\'écran, veille, applications</string>
+    <string name="settings_tile_dev_title">Développeur</string>
+    <string name="settings_tile_dev_subtitle">Options avancées</string>
+    <string name="settings_main_title">Portal Launcher</string>
+    <string name="settings_app_page_title">Application</string>
+    <string name="settings_app_section_language">LANGUE</string>
+    <string name="settings_app_label_language">Langue</string>
+    <string name="language_page_title">Langue</string>
+    <string name="language_system">Langue du système</string>
+    <string name="language_english">English</string>
+    <string name="language_french">Français</string>
+    <string name="settings_app_section_tap_home">TAP SUR L\'ÉCRAN D\'ACCUEIL</string>
+    <string name="settings_app_label_app_to_open">Application à ouvrir</string>
+    <string name="settings_app_section_wallpaper">FOND D\'ÉCRAN</string>
+    <string name="settings_app_label_overlay_opacity">Opacité du voile</string>
+    <string name="settings_app_section_clock">HORLOGE</string>
+    <string name="settings_app_label_clock_theme">Thème de l\'horloge</string>
+    <string name="settings_app_section_app_grid">GRILLE D\'APPLICATIONS</string>
+    <string name="settings_app_label_icon_size">Taille des icônes</string>
+    <string name="settings_app_section_screen_sleep">ÉCRAN &amp; VEILLE</string>
+    <string name="settings_app_toggle_always_on">Mode toujours allumé</string>
+    <string name="settings_app_toggle_auto_timeout">Extinction automatique</string>
+    <string name="settings_app_label_timeout_delay">Délai</string>
+    <string name="settings_app_section_auto_return">RETOUR AUTOMATIQUE</string>
+    <string name="settings_app_toggle_auto_return">Retour à l\'écran principal</string>
+    <string name="settings_app_label_auto_return_delay">Délai d\'inactivité</string>
+    <string name="settings_dev_page_title">Développeur</string>
+    <string name="settings_dev_section_debug">DÉBOGAGE</string>
+    <string name="settings_dev_toggle_keep_screen_on">Écran toujours allumé (dev)</string>
+    <string name="settings_dev_section_system">SYSTÈME</string>
+    <string name="settings_dev_label_permissions">Permissions capteurs / son / luminosité</string>
+    <string name="settings_dev_rebooting">Redémarrage…</string>
+    <string name="settings_dev_reboot">Redémarrer</string>
+
+    <!-- ===== PILL SETTINGS PAGE ===== -->
+    <string name="pills_page_title">Informations affichées</string>
+    <string name="pills_page_description">Active ce que Portal peut afficher en haut de l\'écran. Les éléments désactivés ne sont jamais montrés même s\'ils sont détectés.</string>
+    <string name="pills_loading">Chargement depuis ta maison…</string>
+    <string name="pills_section_connection">CONNEXION</string>
+    <string name="pills_error_fallback">Erreur</string>
+    <string name="pills_retry">Réessayer</string>
+    <string name="pills_no_devices">Aucun appareil compatible détecté. Vérifie la connexion dans « Ma maison ».</string>
+    <string name="pills_no_results_format">Aucun résultat pour « %1$s ».</string>
+    <string name="pills_section_results">RÉSULTATS</string>
+    <string name="pills_section_categories">CATÉGORIES</string>
+    <string name="pills_category_count_format">%1$d sur %2$d</string>
+    <string name="pills_button_refresh">Actualiser la liste</string>
+    <string name="pills_section_detected">ÉLÉMENTS DÉTECTÉS</string>
+    <string name="pills_bulk_hide_all">Tout masquer</string>
+    <string name="pills_bulk_show_all">Tout afficher</string>
+    <string name="pills_extra_battery">batterie</string>
+    <string name="pills_extra_cycle">cycle</string>
+    <string name="pills_extra_completion">fin prévue</string>
+
+    <!-- ===== CLOCK THEME EDITOR ===== -->
+    <string name="clock_theme_label_font">Police</string>
+    <string name="clock_theme_label_weight">Graisse</string>
+    <string name="clock_theme_label_size">Taille</string>
+    <string name="clock_theme_label_letter_spacing">Espacement</string>
+    <string name="clock_theme_label_element_spacing">Écart entre éléments</string>
+    <string name="clock_theme_label_color">Couleur</string>
+    <string name="clock_theme_label_format_24h">Format 24 h</string>
+    <string name="clock_theme_close">Fermer</string>
+
+    <!-- ===== LAUNCHER HOME SCREEN ===== -->
+    <string name="clock_indoor_temp_format">Appartement %1$s–%2$s</string>
+    <string name="clock_outdoor_temp_format">Ext. %1$s</string>
+    <string name="clock_collapse_pills">Masquer les informations</string>
+    <string name="clock_expand_pills">Voir plus d\'informations</string>
+    <string name="clock_collapse_content_desc">Replier</string>
+    <string name="clock_expand_content_desc">Déplier</string>
+    <string name="clock_stale_banner_format">Hors ligne — infos figées depuis %1$s</string>
+    <string name="header_hidden_apps_content_desc">Applications masquées (%1$d)</string>
+    <string name="header_settings_content_desc">Réglages</string>
+    <string name="auto_return_pill_label">Fermeture auto</string>
+    <string name="auto_return_cancel_desc">Annuler</string>
+    <string name="bg_mode_neutral">Neutre</string>
+    <string name="bg_mode_nature">Nature (Unsplash)</string>
+    <string name="bg_mode_custom">Photo perso</string>
+
+    <!-- ===== QUICK ACTIONS OVERLAY ===== -->
+    <string name="quick_actions_set_default_home">Définir comme launcher par défaut</string>
+    <string name="quick_actions_add_widget">Ajouter un widget</string>
+    <string name="quick_actions_wallpaper">Fond d\'écran</string>
+    <string name="quick_actions_settings">Réglages</string>
+    <string name="quick_actions_playground">Composants (test)</string>
+
+    <!-- ===== APP CONTEXT MENU ===== -->
+    <string name="context_menu_shortcuts_unavailable">Raccourcis indisponibles — Portal n\'est pas le launcher par défaut</string>
+    <string name="context_menu_set_default_home">Définir Portal par défaut</string>
+    <string name="context_menu_width_stepper">Largeur</string>
+    <string name="context_menu_height_stepper">Hauteur</string>
+    <string name="context_menu_remove_widget">Retirer le widget</string>
+    <string name="context_menu_rename">Renommer</string>
+    <string name="context_menu_remove_shortcut">Retirer le raccourci</string>
+    <string name="context_menu_hide">Masquer</string>
+    <string name="context_menu_app_info">Infos de l\'application</string>
+    <string name="context_menu_uninstall">Désinstaller</string>
+    <string name="context_menu_rename_label">Nom affiché</string>
+    <string name="context_menu_rename_placeholder">Nom d\'origine</string>
+    <string name="context_menu_confirm">Valider</string>
+
+    <!-- ===== HIDDEN APPS DIALOG ===== -->
+    <string name="hidden_apps_title">Applications masquées</string>
+    <string name="hidden_apps_empty">Aucune</string>
+    <string name="hidden_apps_tap_to_restore">Touchez pour remettre sur la grille</string>
+
+    <!-- ===== WIDGET PICKER DIALOG ===== -->
+    <string name="widget_picker_title">Ajouter un widget</string>
+    <string name="widget_picker_empty">Aucun widget disponible</string>
+    <string name="widget_picker_size_hint">Taille en cellules indiquée</string>
+
+    <!-- ===== SETTINGS SHARED COMPONENTS ===== -->
+    <string name="connection_status_idle">Vérifier</string>
+    <string name="connection_status_testing">Vérification…</string>
+    <string name="connection_status_ok">Connecté</string>
+    <string name="connection_status_error">Échec</string>
+    <string name="search_placeholder">Rechercher…</string>
+    <string name="dialog_button_ok">OK</string>
+    <string name="subpage_back_desc">Retour</string>
+    <string name="app_picker_title">Choisir une application</string>
+    <string name="app_picker_empty">Aucune application trouvée</string>
+    <string name="dialog_button_cancel">Annuler</string>
+    <string name="ha_discovery_title">Home Assistant sur le réseau</string>
+    <string name="ha_discovery_scanning">Recherche en cours…</string>
+    <string name="ha_discovery_cancel">Annuler</string>
+
+    <!-- ===== WEATHER PANEL ===== -->
+    <string name="weather_close_desc">Fermer</string>
+    <string name="weather_panel_title">Météo</string>
+    <string name="weather_section_hourly">PROCHAINES HEURES</string>
+    <string name="weather_section_daily">PROCHAINS JOURS</string>
+
+    <!-- ===== AIR QUALITY PANEL ===== -->
+    <string name="air_quality_back_desc">Retour</string>
+    <string name="air_quality_panel_title">Qualité de l\'air</string>
+    <string name="air_quality_sensor_count">%1$d capteurs</string>
+
+    <!-- ===== MEDIA PLAYER VIEW ===== -->
+    <string name="media_source_many_format">%1$s + %2$d autres</string>
+    <string name="media_cover_desc_format">Pochette de %1$s</string>
+    <string name="media_no_cover_desc">Aucune pochette</string>
+    <string name="media_previous_track_desc">Titre précédent</string>
+    <string name="media_pause_desc">Pause</string>
+    <string name="media_play_desc">Lecture</string>
+    <string name="media_next_track_desc">Titre suivant</string>
+    <string name="media_volume_desc">Volume</string>
+    <string name="media_volume_single_format">Volume · %1$d%%</string>
+    <string name="media_volume_multi_format">Volumes · %1$d appareils</string>
+    <string name="media_close_player_desc">Fermer le lecteur</string>
+    <string name="media_secondary_more_format">+ %1$d autres</string>
+    <string name="media_secondary_more_active_format">+ %1$d autres lectures actives</string>
+    <string name="media_volume_dialog_title">Volumes</string>
+    <string name="media_volume_dialog_close">Fermer</string>
+    <string name="media_group_dialog_title">Diffuser dans</string>
+    <string name="media_group_dialog_subtitle_format">Sélectionne les appareils à coupler avec %1$s</string>
+    <string name="media_group_leader_label">Principal</string>
+    <string name="media_group_dialog_close">Fermer</string>
+    <string name="media_mini_previous_desc_format">Titre précédent dans %1$s</string>
+    <string name="media_mini_pause_desc_format">Mettre en pause %1$s</string>
+    <string name="media_mini_play_desc_format">Lire dans %1$s</string>
+    <string name="media_mini_next_desc_format">Titre suivant dans %1$s</string>
+    <string name="media_vertical_previous_desc_format">Titre précédent dans %1$s</string>
+    <string name="media_vertical_pause_desc_format">Mettre en pause %1$s</string>
+    <string name="media_vertical_play_desc_format">Lire dans %1$s</string>
+    <string name="media_vertical_next_desc_format">Titre suivant dans %1$s</string>
+
+    <!-- ===== LIGHT DETAIL PANEL ===== -->
+    <string name="light_white_channel_label">Canal blanc intégré</string>
+    <string name="light_colors_section">Couleurs</string>
+    <string name="light_whites_w_channel_label">Blancs · canal W</string>
+    <string name="light_whites_label">Blancs</string>
+    <string name="light_power_off">Éteindre</string>
+    <string name="light_power_on">Allumer</string>
+    <string name="light_open_color_wheel_desc">Ouvrir la roue chromatique</string>
+    <string name="light_color_active_desc">Couleur active</string>
+    <string name="light_color_apply_desc">Appliquer cette couleur</string>
+    <string name="light_mode_brightness">Luminosité</string>
+    <string name="light_mode_temperature">Température</string>
+    <string name="light_color_wheel_title">Couleur</string>
+    <string name="light_color_wheel_close_desc">Fermer</string>
+    <string name="light_color_wheel_semantics_format">Roue chromatique, teinte %1$d degrés</string>
+
+    <!-- ===== ALARM PANEL ===== -->
+    <string name="alarm_disarm_prompt">Entrez le code pour désarmer</string>
+    <string name="alarm_arm_prompt">Entrez le code</string>
+    <string name="alarm_mode_away">Absence</string>
+    <string name="alarm_mode_home">Présence</string>
+    <string name="alarm_mode_night">Nuit</string>
+    <string name="alarm_mode_vacation">Vacances</string>
+    <string name="alarm_disarm_button">Désarmer</string>
+
+    <!-- ===== COVER PANEL (Blinds) ===== -->
+    <string name="cover_state_open">Ouvert</string>
+    <string name="cover_state_closed">Fermé</string>
+    <string name="cover_state_opening">Ouverture…</string>
+    <string name="cover_state_closing">Fermeture…</string>
+    <string name="cover_button_open">Ouvrir</string>
+    <string name="cover_button_stop">Stop</string>
+    <string name="cover_button_close">Fermer</string>
+
+    <!-- ===== THERMOSTAT PANEL ===== -->
+    <string name="thermostat_current_temp_format">actuel %1$s</string>
+    <string name="hvac_mode_off">Éteint</string>
+    <string name="hvac_mode_heat">Chauffe</string>
+    <string name="hvac_mode_cool">Froid</string>
+    <string name="hvac_mode_auto">Auto</string>
+    <string name="hvac_mode_dry">Sec</string>
+    <string name="hvac_mode_fan_only">Ventil.</string>
+
+    <!-- ===== VACUUM PANEL ===== -->
+    <string name="vacuum_button_start">Démarrer</string>
+    <string name="vacuum_button_pause">Pause</string>
+    <string name="vacuum_button_stop">Stop</string>
+    <string name="vacuum_button_dock">Base</string>
+    <string name="vacuum_button_locate">Localiser</string>
+    <string name="vacuum_detail_status">État</string>
+    <string name="vacuum_detail_battery">Batterie</string>
+    <string name="vacuum_mode_vacuum">Aspiration</string>
+    <string name="vacuum_mode_vacuum_and_mop">Aspiration + lavage</string>
+    <string name="vacuum_mode_vacuum_then_mop">Aspiration puis lavage</string>
+    <string name="vacuum_mode_mop">Lavage</string>
+    <string name="vacuum_pause_desc">Mettre en pause</string>
+    <string name="vacuum_start_desc">Démarrer</string>
+
+    <!-- ===== LOCK PANEL ===== -->
+    <string name="lock_state_jammed">Bloquée</string>
+    <string name="lock_state_locked">Verrouillée</string>
+    <string name="lock_state_unlocked">Déverrouillée</string>
+
+    <!-- ===== SWITCH / FAN / PURIFIER ===== -->
+    <string name="switch_state_on">Allumé</string>
+    <string name="switch_state_off">Éteint</string>
+    <string name="fan_state_on">En marche</string>
+    <string name="fan_state_off">Arrêté</string>
+    <string name="fan_speed_label">Vitesse</string>
+    <string name="fan_oscillation_label">Oscillation</string>
+    <string name="purifier_mode_auto">Auto</string>
+    <string name="purifier_mode_sleep">Nuit</string>
+    <string name="purifier_mode_manual">Manuel</string>
+    <string name="purifier_mode_pet">Animaux</string>
+    <string name="purifier_mode_off">Arrêt</string>
+
+    <!-- ===== ENERGY PANEL ===== -->
+    <string name="energy_power_label">Puissance</string>
+    <string name="energy_today_label">Aujourd\'hui</string>
+    <string name="energy_gauge_max_format">max %1$d W</string>
+
+    <!-- ===== PANEL HELPERS / SHARED ===== -->
+    <string name="panel_device_unavailable">Appareil indisponible</string>
+    <string name="side_panel_close_desc">Fermer le panneau</string>
+
+    <!-- ===== KEYPAD ===== -->
+    <string name="keypad_cancel">Annuler</string>
+    <string name="keypad_back_desc">Effacer</string>
+    <string name="keypad_confirm_desc">Valider</string>
+    <string name="keypad_key_desc_format">Touche %1$s</string>
+    <string name="slider_percent_desc_format">Curseur %1$s pour cent</string>
+
+    <!-- ===== ACCESSORY ===== -->
+    <string name="accessory_warning_desc">Attention</string>
+
+    <!-- ===== OPACITY PREVIEW ===== -->
+    <string name="opacity_preview_close_desc">Fermer</string>
+
+    <!-- ===== PLAYGROUND / DEV SCREEN ===== -->
+    <string name="playground_swatch_blue">Bleu</string>
+    <string name="playground_swatch_green">Vert</string>
+    <string name="playground_swatch_mint">Menthe</string>
+    <string name="playground_swatch_yellow">Jaune</string>
+    <string name="playground_swatch_red">Rouge</string>
+    <string name="playground_swatch_purple">Violet</string>
+    <string name="playground_swatch_gray">Gris</string>
+    <string name="playground_back_desc">Retour</string>
+    <string name="playground_title">Composants</string>
+    <string name="playground_subtitle">Banc d\'essai des contrôles</string>
+    <string name="playground_accent_color_label">Couleur d\'accent</string>
+    <string name="playground_section_vertical_slider">Curseur vertical</string>
+    <string name="playground_slider_from_bottom">Depuis le bas</string>
+    <string name="playground_slider_from_top">Depuis le haut</string>
+    <string name="playground_slider_disabled">Désactivé</string>
+    <string name="playground_section_gradient_slider">Curseur dégradé</string>
+    <string name="playground_slider_temperature">Température</string>
+    <string name="playground_section_selector">Sélecteur</string>
+    <string name="playground_selector_2_options">2 options</string>
+    <string name="playground_selector_auto">Auto</string>
+    <string name="playground_selector_manual">Manuel</string>
+    <string name="playground_selector_icon_stacked">Icône empilée</string>
+    <string name="playground_presence_home">Au domicile</string>
+    <string name="playground_presence_away">Absent</string>
+    <string name="playground_presence_off">Désactivée</string>
+    <string name="playground_selector_6_options">6 options</string>
+    <string name="playground_section_switch">Interrupteur</string>
+    <string name="playground_switch_on">Activé</string>
+    <string name="playground_switch_off">Désactivé</string>
+    <string name="playground_switch_icon_text">Icône + texte</string>
+    <string name="playground_switch_disabled">Désactivé</string>
+    <string name="playground_section_keypad">Clavier</string>
+    <string name="playground_keypad_active">Clavier actif</string>
+    <string name="playground_keypad_unlocked">Déverrouillé ✓</string>
+    <string name="playground_keypad_code_hint">Code : 1234</string>
+    <string name="playground_keypad_wrong_code_hint">Un mauvais code fait trembler les points</string>
+    <string name="playground_section_thermostat">Thermostat</string>
+    <string name="playground_thermo_mode_off">Éteint</string>
+    <string name="playground_thermo_mode_cool">Refroidir</string>
+    <string name="playground_thermo_mode_heat">Chauffer</string>
+    <string name="playground_thermo_mode_auto">Auto</string>
+    <string name="playground_section_vacuum">Aspirateur robot</string>
+    <string name="playground_vacuum_living_room">Salon</string>
+    <string name="playground_vacuum_kitchen">Cuisine</string>
+    <string name="playground_vacuum_bedroom">Chambre</string>
+    <string name="playground_vacuum_bathroom">Salle de bain</string>
+    <string name="playground_vacuum_name">emmy</string>
+    <string name="playground_vacuum_cleaning">Nettoyage</string>
+    <string name="playground_vacuum_paused">En pause</string>
+    <string name="playground_vacuum_preparing">Préparation</string>
+    <string name="playground_vacuum_in_progress">En cours</string>
+    <string name="playground_vacuum_queued">En file</string>
+    <string name="playground_section_accessories">Accessoires (HomeKit)</string>
+    <string name="playground_accessory_desk">Bureau</string>
+    <string name="playground_accessory_off">Éteinte</string>
+    <string name="playground_accessory_blinds">Volet</string>
+    <string name="playground_accessory_updating">Mise à jour…</string>
+    <string name="playground_accessory_lamp">Lampe salon</string>
+    <string name="playground_accessory_on">Allumée</string>
+    <string name="playground_accessory_plug_tv">Prise TV</string>
+    <string name="playground_accessory_active">Activée</string>
+    <string name="playground_accessory_inactive">Désactivée</string>
+    <string name="playground_accessory_plug2">Prise 2</string>
+    <string name="playground_accessory_no_response">Pas de réponse</string>
+
+    <!-- ===== TOAST MESSAGES ===== -->
+    <string name="toast_app_not_found_pkg_format">Application introuvable: %1$s</string>
+    <string name="toast_app_not_found_label_format">Application introuvable : %1$s</string>
+    <string name="toast_cannot_open_app_format">Impossible d\'ouvrir %1$s</string>
+    <string name="toast_choose_wallpaper">Choisir un fond d\'écran</string>
+    <string name="toast_permissions_ok">Permissions OK</string>
+    <string name="toast_shortcut_added_format">Raccourci ajouté : %1$s</string>
+
+    <!-- ===== NOTIFICATION ===== -->
+    <string name="notification_channel_name">Portal Launcher</string>
+    <string name="notification_content_title">Portal Launcher</string>
+    <string name="power_mode_always_on">Always on</string>
+    <string name="power_mode_follow_presence">Follow presence</string>
+
+    <!-- ===== PILL PRIORITY ENGINE (Dynamic Labels) ===== -->
+    <string name="presence_home">À la maison</string>
+    <string name="presence_away">Absent</string>
+    <string name="pill_group_presence">Présence</string>
+    <string name="pill_presence_nobody">Personne</string>
+    <string name="pill_presence_count_format">%1$d à la maison</string>
+    <string name="pill_group_energy">Énergie</string>
+    <string name="pill_group_scenes">Scènes</string>
+    <string name="pill_group_lights">Lumières</string>
+    <string name="pill_group_media">Médias</string>
+    <string name="pill_group_purifier">Purificateur</string>
+    <string name="pill_group_air_quality">Qualité de l\'air</string>
+    <string name="pill_group_temperatures">Températures</string>
+    <string name="pill_group_batteries">Batteries faibles</string>
+    <string name="pill_group_openings">Portes &amp; fenêtres</string>
+    <string name="pill_individual_air_quality">Qualité de l\'air</string>
+    <string name="pill_individual_security">Sécurité</string>
+    <string name="light_state_on">Allumée</string>
+    <string name="light_state_off">Éteinte</string>
+    <string name="opening_state_open">Ouverte</string>
+    <string name="opening_state_closed">Fermée</string>
+    <string name="pill_safety_alert">Alerte</string>
+    <string name="phase_none">Aucun</string>
+    <string name="phase_air_wash">Air wash</string>
+    <string name="phase_ai_rinse">AI rinse</string>
+    <string name="phase_ai_spin">AI spin</string>
+    <string name="phase_ai_wash">AI wash</string>
+    <string name="phase_cooling">Refroidissement</string>
+    <string name="phase_delay_wash">Lavage différé</string>
+    <string name="phase_drying">Séchage</string>
+    <string name="phase_finish">Terminé</string>
+    <string name="phase_pre_wash">Prélavage</string>
+    <string name="phase_rinse">Rinçage</string>
+    <string name="phase_spin">Essorage</string>
+    <string name="phase_wash">Lavage</string>
+    <string name="phase_weight_sensing">Pesée</string>
+    <string name="phase_wrinkle_prevent">Anti-froissage</string>
+    <string name="phase_freeze_protection">Hors gel</string>
+
+    <!-- ===== PILL SCENES COUNT (plurals) ===== -->
+    <plurals name="pill_scenes_count">
+        <item quantity="one">%1$d raccourci</item>
+        <item quantity="other">%1$d raccourcis</item>
+    </plurals>
+
+    <!-- ===== PILL LIGHTS STATE (plurals) ===== -->
+    <plurals name="pill_lights_state">
+        <item quantity="zero">Toutes éteintes</item>
+        <item quantity="one">%1$d allumée</item>
+        <item quantity="other">%1$d allumées</item>
+    </plurals>
+
+    <!-- ===== PILL MEDIA STATE (plurals) ===== -->
+    <plurals name="pill_media_state">
+        <item quantity="zero">Aucun média</item>
+        <item quantity="one">En pause</item>
+        <item quantity="other">%1$d en lecture</item>
+    </plurals>
+
+    <!-- ===== PILL PURIFIER STATE (plurals) ===== -->
+    <plurals name="pill_purifier_state">
+        <item quantity="one">En marche · %1$s</item>
+        <item quantity="other">Arrêté</item>
+    </plurals>
+
+    <!-- ===== PILL AIR QUALITY LABELS ===== -->
+    <string name="air_quality_bad">Mauvaise</string>
+    <string name="air_quality_medium">Moyenne</string>
+    <string name="air_quality_good">Bonne</string>
+
+    <!-- ===== PILL BATTERY STATE ===== -->
+    <string name="pill_battery_state_multi_format">%1$d appareils · min %2$s</string>
+
+    <!-- ===== PILL OPENINGS STATE ===== -->
+    <string name="pill_openings_all_closed">Toutes fermées</string>
+    <string name="pill_openings_one_open">1 ouverte</string>
+    <string name="pill_openings_count_format">%1$d ouvertes</string>
+
+    <!-- ===== PILL COVER STATE ===== -->
+    <string name="pill_cover_open_format">Ouvert · %1$s%%</string>
+    <string name="pill_cover_open">Ouvert</string>
+    <string name="pill_cover_closed">Fermé</string>
+    <string name="pill_cover_opening">Ouverture…</string>
+    <string name="pill_cover_closing">Fermeture…</string>
+
+    <!-- ===== PILL SWITCH / FAN STATE ===== -->
+    <string name="pill_switch_on">Allumé</string>
+    <string name="pill_switch_off">Éteint</string>
+    <string name="pill_fan_on_format">Marche · %1$s%%</string>
+    <string name="pill_fan_on">En marche</string>
+    <string name="pill_fan_off">Arrêté</string>
+
+    <!-- ===== PILL TEMPERATURE ===== -->
+    <string name="pill_temperature_range_format">Min %1$s · Max %2$s</string>
+
+    <!-- ===== PILL OPENING / LOCK STATES ===== -->
+    <string name="pill_opening_open">Ouverte</string>
+    <string name="pill_lock_locked">Verrouillée</string>
+    <string name="pill_lock_unlocked">Déverrouillée</string>
+    <string name="pill_lock_jammed">Bloquée</string>
+    <string name="pill_individual_energy_power">Puissance</string>
+    <string name="pill_individual_energy_today">Aujourd\'hui</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,522 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Keep existing -->
     <string name="app_name">Portal Launcher</string>
     <string name="accessibility_label">Portal Launcher Screen Control</string>
     <string name="accessibility_description">Permet a Portal Launcher d\'eteindre l\'ecran sur commande Home Assistant. Le service ne lit pas le contenu de l\'ecran.</string>
+
+    <!-- ===== SETUP WIZARD ===== -->
+    <string name="setup_welcome_title">Welcome</string>
+    <string name="setup_welcome_subtitle">Let\'s start by finding your home. Make sure Home Assistant is running on the same network.</string>
+    <string name="setup_scanning_network">Searching the network…</string>
+    <string name="setup_section_manual_address">OR ENTER THE ADDRESS</string>
+    <string name="setup_label_address">Address</string>
+    <string name="setup_placeholder_address">http://homeassistant.local:8123</string>
+    <string name="setup_button_continue">Continue</string>
+    <string name="setup_button_configure_later">Set up later</string>
+    <string name="setup_access_key_title">Your access key</string>
+    <string name="setup_access_key_subtitle">To let Portal read the state of your home, paste an access key created in Home Assistant.</string>
+    <string name="setup_section_access_key">ACCESS KEY</string>
+    <string name="setup_label_access_key">Access key</string>
+    <string name="setup_placeholder_paste_key">Paste your key here</string>
+    <string name="setup_label_where_to_find_key">Where to find my key?</string>
+    <string name="setup_label_connection">Connection</string>
+    <string name="setup_button_test_connection">Test connection</string>
+    <string name="setup_button_back">Back</string>
+    <string name="setup_done_title">All set!</string>
+    <string name="setup_done_subtitle">Portal will now display the state of your home.</string>
+    <string name="setup_button_start">Get started</string>
+    <string name="setup_access_key_help_step_1">1. Open Home Assistant → Settings → People</string>
+    <string name="setup_access_key_help_step_2">2. Select your user</string>
+    <string name="setup_access_key_help_step_3">3. Tap "Long-lived access tokens"</string>
+    <string name="setup_access_key_help_step_4">4. Create a token named "Portal"</string>
+    <string name="setup_access_key_help_step_5">5. Copy and paste it here</string>
+
+    <!-- ===== HOME CONNECTION PAGE ===== -->
+    <string name="home_connection_title">My Home</string>
+    <string name="home_connection_subtitle">Portal connects to your Home Assistant server to display the state of your home.</string>
+    <string name="home_connection_section_address">ADDRESS</string>
+    <string name="home_connection_ha_detected">Home Assistant detected</string>
+    <string name="home_connection_label_address">Address</string>
+    <string name="home_connection_placeholder_address">http://homeassistant.local:8123</string>
+    <string name="home_connection_label_scan_network">Search the network</string>
+    <string name="home_connection_scanning">Searching…</string>
+    <string name="home_connection_scan_found_format">%1$d found</string>
+    <string name="home_connection_section_access_key">ACCESS KEY</string>
+    <string name="home_connection_label_access_key">Access key</string>
+    <string name="home_connection_placeholder_paste_key">Paste your key here</string>
+    <string name="home_connection_label_key_help">Where to find my key?</string>
+    <string name="home_connection_section_status">CONNECTION STATUS</string>
+    <string name="home_connection_label_connection">Connection</string>
+    <string name="home_connection_section_mqtt">MQTT</string>
+    <string name="home_connection_label_mqtt_server">Server address</string>
+    <string name="home_connection_placeholder_mqtt_server">homeassistant.local</string>
+    <string name="home_connection_label_mqtt_port">Port</string>
+    <string name="home_connection_placeholder_mqtt_port">1883</string>
+    <string name="home_connection_toggle_mqtt_auth">Server requires a login</string>
+    <string name="home_connection_label_mqtt_username">Username</string>
+    <string name="home_connection_placeholder_username">Username</string>
+    <string name="home_connection_label_mqtt_password">Password</string>
+    <string name="home_connection_placeholder_password">Password</string>
+    <string name="home_connection_label_device_name">Name of this device</string>
+    <string name="home_connection_placeholder_device_name">Portal</string>
+    <string name="home_connection_label_mqtt_connection">MQTT connection</string>
+
+    <!-- ===== MAIN SETTINGS SCREEN ===== -->
+    <string name="settings_home_subtitle_not_configured">Not configured</string>
+    <string name="settings_home_subtitle_testing">Checking…</string>
+    <string name="settings_home_subtitle_connected">Connected</string>
+    <string name="settings_home_subtitle_error">Check connection</string>
+    <string name="settings_home_subtitle_default">Address, access key</string>
+    <string name="settings_tile_home_title">My Home</string>
+    <string name="settings_tile_pills_title">Displayed info</string>
+    <string name="settings_tile_pills_subtitle">What Portal shows at the top of the screen</string>
+    <string name="settings_tile_app_title">Application</string>
+    <string name="settings_tile_app_subtitle">Wallpaper, sleep, applications</string>
+    <string name="settings_tile_dev_title">Developer</string>
+    <string name="settings_tile_dev_subtitle">Advanced options</string>
+    <string name="settings_main_title">Portal Launcher</string>
+    <string name="settings_app_page_title">Application</string>
+    <string name="settings_app_section_language">LANGUAGE</string>
+    <string name="settings_app_label_language">Language</string>
+    <string name="language_page_title">Language</string>
+    <string name="language_system">System language</string>
+    <string name="language_english">English</string>
+    <string name="language_french">Français</string>
+    <string name="settings_app_section_tap_home">HOME SCREEN TAP</string>
+    <string name="settings_app_label_app_to_open">App to open</string>
+    <string name="settings_app_section_wallpaper">WALLPAPER</string>
+    <string name="settings_app_label_overlay_opacity">Overlay opacity</string>
+    <string name="settings_app_section_clock">CLOCK</string>
+    <string name="settings_app_label_clock_theme">Clock theme</string>
+    <string name="settings_app_section_app_grid">APP GRID</string>
+    <string name="settings_app_label_icon_size">Icon size</string>
+    <string name="settings_app_section_screen_sleep">SCREEN &amp; SLEEP</string>
+    <string name="settings_app_toggle_always_on">Always-on mode</string>
+    <string name="settings_app_toggle_auto_timeout">Auto screen off</string>
+    <string name="settings_app_label_timeout_delay">Timeout</string>
+    <string name="settings_app_section_auto_return">AUTO RETURN</string>
+    <string name="settings_app_toggle_auto_return">Return to home screen</string>
+    <string name="settings_app_label_auto_return_delay">Inactivity delay</string>
+    <string name="settings_dev_page_title">Developer</string>
+    <string name="settings_dev_section_debug">DEBUGGING</string>
+    <string name="settings_dev_toggle_keep_screen_on">Keep screen on (dev)</string>
+    <string name="settings_dev_section_system">SYSTEM</string>
+    <string name="settings_dev_label_permissions">Sensor / sound / brightness permissions</string>
+    <string name="settings_dev_rebooting">Rebooting…</string>
+    <string name="settings_dev_reboot">Reboot</string>
+
+    <!-- ===== PILL SETTINGS PAGE ===== -->
+    <string name="pills_page_title">Displayed info</string>
+    <string name="pills_page_description">Choose what Portal can display at the top of the screen. Disabled items are never shown even if detected.</string>
+    <string name="pills_loading">Loading from your home…</string>
+    <string name="pills_section_connection">CONNECTION</string>
+    <string name="pills_error_fallback">Error</string>
+    <string name="pills_retry">Retry</string>
+    <string name="pills_no_devices">No compatible devices detected. Check the connection in "My Home".</string>
+    <string name="pills_no_results_format">No results for \"%1$s\".</string>
+    <string name="pills_section_results">RESULTS</string>
+    <string name="pills_section_categories">CATEGORIES</string>
+    <string name="pills_category_count_format">%1$d of %2$d</string>
+    <string name="pills_button_refresh">Refresh list</string>
+    <string name="pills_section_detected">DETECTED ITEMS</string>
+    <string name="pills_bulk_hide_all">Hide all</string>
+    <string name="pills_bulk_show_all">Show all</string>
+    <string name="pills_extra_battery">battery</string>
+    <string name="pills_extra_cycle">cycle</string>
+    <string name="pills_extra_completion">est. finish</string>
+
+    <!-- ===== CLOCK THEME EDITOR ===== -->
+    <string name="clock_theme_label_font">Font</string>
+    <string name="clock_theme_label_weight">Weight</string>
+    <string name="clock_theme_label_size">Size</string>
+    <string name="clock_theme_label_letter_spacing">Spacing</string>
+    <string name="clock_theme_label_element_spacing">Element spacing</string>
+    <string name="clock_theme_label_color">Color</string>
+    <string name="clock_theme_label_format_24h">24-hour format</string>
+    <string name="clock_theme_close">Close</string>
+
+    <!-- ===== LAUNCHER HOME SCREEN ===== -->
+    <string name="clock_indoor_temp_format">Indoor %1$s–%2$s</string>
+    <string name="clock_outdoor_temp_format">Outdoor %1$s</string>
+    <string name="clock_collapse_pills">Hide info</string>
+    <string name="clock_expand_pills">Show more info</string>
+    <string name="clock_collapse_content_desc">Collapse</string>
+    <string name="clock_expand_content_desc">Expand</string>
+    <string name="clock_stale_banner_format">Offline — info frozen since %1$s</string>
+    <string name="header_hidden_apps_content_desc">Hidden apps (%1$d)</string>
+    <string name="header_settings_content_desc">Settings</string>
+    <string name="auto_return_pill_label">Auto close</string>
+    <string name="auto_return_cancel_desc">Cancel</string>
+    <string name="bg_mode_neutral">Neutral</string>
+    <string name="bg_mode_nature">Nature (Unsplash)</string>
+    <string name="bg_mode_custom">Custom photo</string>
+
+    <!-- ===== QUICK ACTIONS OVERLAY (Home Screen Long-Press) ===== -->
+    <string name="quick_actions_set_default_home">Set as default launcher</string>
+    <string name="quick_actions_add_widget">Add a widget</string>
+    <string name="quick_actions_wallpaper">Wallpaper</string>
+    <string name="quick_actions_settings">Settings</string>
+    <string name="quick_actions_playground">Components (test)</string>
+
+    <!-- ===== APP CONTEXT MENU ===== -->
+    <string name="context_menu_shortcuts_unavailable">Shortcuts unavailable — Portal is not the default launcher</string>
+    <string name="context_menu_set_default_home">Set Portal as default</string>
+    <string name="context_menu_width_stepper">Width</string>
+    <string name="context_menu_height_stepper">Height</string>
+    <string name="context_menu_remove_widget">Remove widget</string>
+    <string name="context_menu_rename">Rename</string>
+    <string name="context_menu_remove_shortcut">Remove shortcut</string>
+    <string name="context_menu_hide">Hide</string>
+    <string name="context_menu_app_info">App info</string>
+    <string name="context_menu_uninstall">Uninstall</string>
+    <string name="context_menu_rename_label">Display name</string>
+    <string name="context_menu_rename_placeholder">Original name</string>
+    <string name="context_menu_confirm">Confirm</string>
+
+    <!-- ===== HIDDEN APPS DIALOG ===== -->
+    <string name="hidden_apps_title">Hidden apps</string>
+    <string name="hidden_apps_empty">None</string>
+    <string name="hidden_apps_tap_to_restore">Tap to put back on the grid</string>
+
+    <!-- ===== WIDGET PICKER DIALOG ===== -->
+    <string name="widget_picker_title">Add a widget</string>
+    <string name="widget_picker_empty">No widgets available</string>
+    <string name="widget_picker_size_hint">Size in cells indicated</string>
+
+    <!-- ===== SETTINGS SHARED COMPONENTS ===== -->
+    <string name="connection_status_idle">Test</string>
+    <string name="connection_status_testing">Testing…</string>
+    <string name="connection_status_ok">Connected</string>
+    <string name="connection_status_error">Failed</string>
+    <string name="search_placeholder">Search…</string>
+    <string name="dialog_button_ok">OK</string>
+    <string name="subpage_back_desc">Back</string>
+    <string name="app_picker_title">Choose an app</string>
+    <string name="app_picker_empty">No apps found</string>
+    <string name="dialog_button_cancel">Cancel</string>
+    <string name="ha_discovery_title">Home Assistant on the network</string>
+    <string name="ha_discovery_scanning">Searching…</string>
+    <string name="ha_discovery_cancel">Cancel</string>
+
+    <!-- ===== WEATHER PANEL ===== -->
+    <string name="weather_close_desc">Close</string>
+    <string name="weather_panel_title">Weather</string>
+    <string name="weather_section_hourly">NEXT HOURS</string>
+    <string name="weather_section_daily">NEXT DAYS</string>
+
+    <!-- ===== AIR QUALITY PANEL ===== -->
+    <string name="air_quality_back_desc">Back</string>
+    <string name="air_quality_panel_title">Air quality</string>
+    <string name="air_quality_sensor_count">%1$d sensors</string>
+
+    <!-- ===== MEDIA PLAYER VIEW ===== -->
+    <string name="media_source_many_format">%1$s + %2$d others</string>
+    <string name="media_cover_desc_format">Cover of %1$s</string>
+    <string name="media_no_cover_desc">No cover</string>
+    <string name="media_previous_track_desc">Previous track</string>
+    <string name="media_pause_desc">Pause</string>
+    <string name="media_play_desc">Play</string>
+    <string name="media_next_track_desc">Next track</string>
+    <string name="media_volume_desc">Volume</string>
+    <string name="media_volume_single_format">Volume · %1$d%%</string>
+    <string name="media_volume_multi_format">Volumes · %1$d devices</string>
+    <string name="media_close_player_desc">Close player</string>
+    <string name="media_secondary_more_format">+ %1$d others</string>
+    <string name="media_secondary_more_active_format">+ %1$d other active streams</string>
+    <string name="media_volume_dialog_title">Volumes</string>
+    <string name="media_volume_dialog_close">Close</string>
+    <string name="media_group_dialog_title">Stream to</string>
+    <string name="media_group_dialog_subtitle_format">Select the devices to pair with %1$s</string>
+    <string name="media_group_leader_label">Main</string>
+    <string name="media_group_dialog_close">Close</string>
+    <string name="media_mini_previous_desc_format">Previous track in %1$s</string>
+    <string name="media_mini_pause_desc_format">Pause %1$s</string>
+    <string name="media_mini_play_desc_format">Play in %1$s</string>
+    <string name="media_mini_next_desc_format">Next track in %1$s</string>
+    <string name="media_vertical_previous_desc_format">Previous track in %1$s</string>
+    <string name="media_vertical_pause_desc_format">Pause %1$s</string>
+    <string name="media_vertical_play_desc_format">Play in %1$s</string>
+    <string name="media_vertical_next_desc_format">Next track in %1$s</string>
+
+    <!-- ===== LIGHT DETAIL PANEL ===== -->
+    <string name="light_white_channel_label">Built-in white channel</string>
+    <string name="light_colors_section">Colors</string>
+    <string name="light_whites_w_channel_label">Whites · channel W</string>
+    <string name="light_whites_label">Whites</string>
+    <string name="light_power_off">Turn off</string>
+    <string name="light_power_on">Turn on</string>
+    <string name="light_open_color_wheel_desc">Open color wheel</string>
+    <string name="light_color_active_desc">Active color</string>
+    <string name="light_color_apply_desc">Apply this color</string>
+    <string name="light_mode_brightness">Brightness</string>
+    <string name="light_mode_temperature">Temperature</string>
+    <string name="light_color_wheel_title">Color</string>
+    <string name="light_color_wheel_close_desc">Close</string>
+    <string name="light_color_wheel_semantics_format">Color wheel, hue %1$d degrees</string>
+
+    <!-- ===== ALARM PANEL ===== -->
+    <string name="alarm_disarm_prompt">Enter code to disarm</string>
+    <string name="alarm_arm_prompt">Enter code</string>
+    <string name="alarm_mode_away">Away</string>
+    <string name="alarm_mode_home">Home</string>
+    <string name="alarm_mode_night">Night</string>
+    <string name="alarm_mode_vacation">Vacation</string>
+    <string name="alarm_disarm_button">Disarm</string>
+
+    <!-- ===== COVER PANEL (Blinds) ===== -->
+    <string name="cover_state_open">Open</string>
+    <string name="cover_state_closed">Closed</string>
+    <string name="cover_state_opening">Opening…</string>
+    <string name="cover_state_closing">Closing…</string>
+    <string name="cover_button_open">Open</string>
+    <string name="cover_button_stop">Stop</string>
+    <string name="cover_button_close">Close</string>
+
+    <!-- ===== THERMOSTAT PANEL ===== -->
+    <string name="thermostat_current_temp_format">current %1$s</string>
+    <string name="hvac_mode_off">Off</string>
+    <string name="hvac_mode_heat">Heating</string>
+    <string name="hvac_mode_cool">Cooling</string>
+    <string name="hvac_mode_auto">Auto</string>
+    <string name="hvac_mode_dry">Dry</string>
+    <string name="hvac_mode_fan_only">Fan only</string>
+
+    <!-- ===== VACUUM PANEL ===== -->
+    <string name="vacuum_button_start">Start</string>
+    <string name="vacuum_button_pause">Pause</string>
+    <string name="vacuum_button_stop">Stop</string>
+    <string name="vacuum_button_dock">Dock</string>
+    <string name="vacuum_button_locate">Locate</string>
+    <string name="vacuum_detail_status">Status</string>
+    <string name="vacuum_detail_battery">Battery</string>
+    <string name="vacuum_mode_vacuum">Vacuum</string>
+    <string name="vacuum_mode_vacuum_and_mop">Vacuum + mop</string>
+    <string name="vacuum_mode_vacuum_then_mop">Vacuum then mop</string>
+    <string name="vacuum_mode_mop">Mop</string>
+    <string name="vacuum_pause_desc">Pause</string>
+    <string name="vacuum_start_desc">Start</string>
+
+    <!-- ===== LOCK PANEL ===== -->
+    <string name="lock_state_jammed">Jammed</string>
+    <string name="lock_state_locked">Locked</string>
+    <string name="lock_state_unlocked">Unlocked</string>
+
+    <!-- ===== SWITCH / FAN / PURIFIER ===== -->
+    <string name="switch_state_on">On</string>
+    <string name="switch_state_off">Off</string>
+    <string name="fan_state_on">Running</string>
+    <string name="fan_state_off">Stopped</string>
+    <string name="fan_speed_label">Speed</string>
+    <string name="fan_oscillation_label">Oscillation</string>
+    <string name="purifier_mode_auto">Auto</string>
+    <string name="purifier_mode_sleep">Sleep</string>
+    <string name="purifier_mode_manual">Manual</string>
+    <string name="purifier_mode_pet">Pets</string>
+    <string name="purifier_mode_off">Off</string>
+
+    <!-- ===== ENERGY PANEL ===== -->
+    <string name="energy_power_label">Power</string>
+    <string name="energy_today_label">Today</string>
+    <string name="energy_gauge_max_format">max %1$d W</string>
+
+    <!-- ===== PANEL HELPERS / SHARED ===== -->
+    <string name="panel_device_unavailable">Device unavailable</string>
+    <string name="side_panel_close_desc">Close panel</string>
+
+    <!-- ===== KEYPAD ===== -->
+    <string name="keypad_cancel">Cancel</string>
+    <string name="keypad_back_desc">Delete</string>
+    <string name="keypad_confirm_desc">Confirm</string>
+    <string name="keypad_key_desc_format">Key %1$s</string>
+    <string name="slider_percent_desc_format">Slider %1$s percent</string>
+
+    <!-- ===== ACCESSORY ===== -->
+    <string name="accessory_warning_desc">Warning</string>
+
+    <!-- ===== OPACITY PREVIEW ===== -->
+    <string name="opacity_preview_close_desc">Close</string>
+
+    <!-- ===== PLAYGROUND / DEV SCREEN ===== -->
+    <string name="playground_swatch_blue">Blue</string>
+    <string name="playground_swatch_green">Green</string>
+    <string name="playground_swatch_mint">Mint</string>
+    <string name="playground_swatch_yellow">Yellow</string>
+    <string name="playground_swatch_red">Red</string>
+    <string name="playground_swatch_purple">Purple</string>
+    <string name="playground_swatch_gray">Gray</string>
+    <string name="playground_back_desc">Back</string>
+    <string name="playground_title">Components</string>
+    <string name="playground_subtitle">Control test bench</string>
+    <string name="playground_accent_color_label">Accent color</string>
+    <string name="playground_section_vertical_slider">Vertical slider</string>
+    <string name="playground_slider_from_bottom">From bottom</string>
+    <string name="playground_slider_from_top">From top</string>
+    <string name="playground_slider_disabled">Disabled</string>
+    <string name="playground_section_gradient_slider">Gradient slider</string>
+    <string name="playground_slider_temperature">Temperature</string>
+    <string name="playground_section_selector">Selector</string>
+    <string name="playground_selector_2_options">2 options</string>
+    <string name="playground_selector_auto">Auto</string>
+    <string name="playground_selector_manual">Manual</string>
+    <string name="playground_selector_icon_stacked">Stacked icon</string>
+    <string name="playground_presence_home">At home</string>
+    <string name="playground_presence_away">Away</string>
+    <string name="playground_presence_off">Disabled</string>
+    <string name="playground_selector_6_options">6 options</string>
+    <string name="playground_section_switch">Switch</string>
+    <string name="playground_switch_on">On</string>
+    <string name="playground_switch_off">Off</string>
+    <string name="playground_switch_icon_text">Icon + text</string>
+    <string name="playground_switch_disabled">Disabled</string>
+    <string name="playground_section_keypad">Keypad</string>
+    <string name="playground_keypad_active">Active keypad</string>
+    <string name="playground_keypad_unlocked">Unlocked ✓</string>
+    <string name="playground_keypad_code_hint">Code: 1234</string>
+    <string name="playground_keypad_wrong_code_hint">A wrong code makes the dots shake</string>
+    <string name="playground_section_thermostat">Thermostat</string>
+    <string name="playground_thermo_mode_off">Off</string>
+    <string name="playground_thermo_mode_cool">Cool</string>
+    <string name="playground_thermo_mode_heat">Heat</string>
+    <string name="playground_thermo_mode_auto">Auto</string>
+    <string name="playground_section_vacuum">Robot vacuum</string>
+    <string name="playground_vacuum_living_room">Living room</string>
+    <string name="playground_vacuum_kitchen">Kitchen</string>
+    <string name="playground_vacuum_bedroom">Bedroom</string>
+    <string name="playground_vacuum_bathroom">Bathroom</string>
+    <string name="playground_vacuum_name">emmy</string>
+    <string name="playground_vacuum_cleaning">Cleaning</string>
+    <string name="playground_vacuum_paused">Paused</string>
+    <string name="playground_vacuum_preparing">Preparing</string>
+    <string name="playground_vacuum_in_progress">In progress</string>
+    <string name="playground_vacuum_queued">Queued</string>
+    <string name="playground_section_accessories">Accessories (HomeKit)</string>
+    <string name="playground_accessory_desk">Desk</string>
+    <string name="playground_accessory_off">Off</string>
+    <string name="playground_accessory_blinds">Blinds</string>
+    <string name="playground_accessory_updating">Updating…</string>
+    <string name="playground_accessory_lamp">Living room lamp</string>
+    <string name="playground_accessory_on">On</string>
+    <string name="playground_accessory_plug_tv">TV plug</string>
+    <string name="playground_accessory_active">Active</string>
+    <string name="playground_accessory_inactive">Inactive</string>
+    <string name="playground_accessory_plug2">Plug 2</string>
+    <string name="playground_accessory_no_response">No response</string>
+
+    <!-- ===== TOAST MESSAGES ===== -->
+    <string name="toast_app_not_found_pkg_format">App not found: %1$s</string>
+    <string name="toast_app_not_found_label_format">App not found: %1$s</string>
+    <string name="toast_cannot_open_app_format">Could not open %1$s</string>
+    <string name="toast_choose_wallpaper">Choose wallpaper</string>
+    <string name="toast_permissions_ok">Permissions OK</string>
+    <string name="toast_shortcut_added_format">Shortcut added: %1$s</string>
+
+    <!-- ===== NOTIFICATION ===== -->
+    <string name="notification_channel_name">Portal Launcher</string>
+    <string name="notification_content_title">Portal Launcher</string>
+    <string name="power_mode_always_on">Always on</string>
+    <string name="power_mode_follow_presence">Follow presence</string>
+
+    <!-- ===== PILL PRIORITY ENGINE (Dynamic Labels) ===== -->
+    <string name="presence_home">At home</string>
+    <string name="presence_away">Away</string>
+    <string name="pill_group_presence">Presence</string>
+    <string name="pill_presence_nobody">Nobody</string>
+    <string name="pill_presence_count_format">%1$d at home</string>
+    <string name="pill_group_energy">Energy</string>
+    <string name="pill_group_scenes">Scenes</string>
+    <string name="pill_group_lights">Lights</string>
+    <string name="pill_group_media">Media</string>
+    <string name="pill_group_purifier">Purifier</string>
+    <string name="pill_group_air_quality">Air quality</string>
+    <string name="pill_group_temperatures">Temperatures</string>
+    <string name="pill_group_batteries">Low batteries</string>
+    <string name="pill_group_openings">Doors &amp; windows</string>
+    <string name="pill_individual_air_quality">Air quality</string>
+    <string name="pill_individual_security">Security</string>
+    <string name="light_state_on">On</string>
+    <string name="light_state_off">Off</string>
+    <string name="opening_state_open">Open</string>
+    <string name="opening_state_closed">Closed</string>
+    <string name="pill_safety_alert">Alert</string>
+    <string name="phase_none">None</string>
+    <string name="phase_air_wash">Air wash</string>
+    <string name="phase_ai_rinse">AI rinse</string>
+    <string name="phase_ai_spin">AI spin</string>
+    <string name="phase_ai_wash">AI wash</string>
+    <string name="phase_cooling">Cooling</string>
+    <string name="phase_delay_wash">Delay wash</string>
+    <string name="phase_drying">Drying</string>
+    <string name="phase_finish">Finish</string>
+    <string name="phase_pre_wash">Pre-wash</string>
+    <string name="phase_rinse">Rinse</string>
+    <string name="phase_spin">Spin</string>
+    <string name="phase_wash">Wash</string>
+    <string name="phase_weight_sensing">Weight sensing</string>
+    <string name="phase_wrinkle_prevent">Wrinkle prevent</string>
+    <string name="phase_freeze_protection">Freeze protection</string>
+
+    <!-- ===== PILL SCENES COUNT (plurals) ===== -->
+    <plurals name="pill_scenes_count">
+        <item quantity="one">%1$d shortcut</item>
+        <item quantity="other">%1$d shortcuts</item>
+    </plurals>
+
+    <!-- ===== PILL LIGHTS STATE (plurals) ===== -->
+    <plurals name="pill_lights_state">
+        <item quantity="zero">All off</item>
+        <item quantity="one">%1$d on</item>
+        <item quantity="other">%1$d on</item>
+    </plurals>
+
+    <!-- ===== PILL MEDIA STATE (plurals) ===== -->
+    <plurals name="pill_media_state">
+        <item quantity="zero">No media</item>
+        <item quantity="one">Paused</item>
+        <item quantity="other">%1$d playing</item>
+    </plurals>
+
+    <!-- ===== PILL PURIFIER STATE (plurals) ===== -->
+    <plurals name="pill_purifier_state">
+        <item quantity="one">Running · %1$s</item>
+        <item quantity="other">Off</item>
+    </plurals>
+
+    <!-- ===== PILL AIR QUALITY LABELS ===== -->
+    <string name="air_quality_bad">Bad</string>
+    <string name="air_quality_medium">Medium</string>
+    <string name="air_quality_good">Good</string>
+
+    <!-- ===== PILL BATTERY STATE ===== -->
+    <string name="pill_battery_state_multi_format">%1$d devices · min %2$s</string>
+
+    <!-- ===== PILL OPENINGS STATE ===== -->
+    <string name="pill_openings_all_closed">All closed</string>
+    <string name="pill_openings_one_open">1 open</string>
+    <string name="pill_openings_count_format">%1$d open</string>
+
+    <!-- ===== PILL COVER STATE ===== -->
+    <string name="pill_cover_open_format">Open · %1$s%%</string>
+    <string name="pill_cover_open">Open</string>
+    <string name="pill_cover_closed">Closed</string>
+    <string name="pill_cover_opening">Opening…</string>
+    <string name="pill_cover_closing">Closing…</string>
+
+    <!-- ===== PILL SWITCH / FAN STATE ===== -->
+    <string name="pill_switch_on">On</string>
+    <string name="pill_switch_off">Off</string>
+    <string name="pill_fan_on_format">Running · %1$s%%</string>
+    <string name="pill_fan_on">Running</string>
+    <string name="pill_fan_off">Off</string>
+
+    <!-- ===== PILL TEMPERATURE ===== -->
+    <string name="pill_temperature_range_format">Min %1$s · Max %2$s</string>
+
+    <!-- ===== PILL OPENING / LOCK STATES ===== -->
+    <string name="pill_opening_open">Open</string>
+    <string name="pill_lock_locked">Locked</string>
+    <string name="pill_lock_unlocked">Unlocked</string>
+    <string name="pill_lock_jammed">Jammed</string>
+    <string name="pill_individual_energy_power">Power</string>
+    <string name="pill_individual_energy_today">Today</string>
 </resources>

--- a/app/src/test/java/com/iblu01/portallauncher/PillPriorityEngineTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/PillPriorityEngineTest.kt
@@ -1,15 +1,26 @@
 package com.iblu01.portallauncher
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import java.util.Locale
 
+@RunWith(RobolectricTestRunner::class)
 class PillPriorityEngineTest {
-    // Pin the locale so decimal formatting ("%.1f") is deterministic across dev machines.
-    @Before fun pinLocale() = Locale.setDefault(Locale.US)
+    private lateinit var engine: PillPriorityEngine
+    private lateinit var context: Context
+
+    @Before fun setUp() {
+        Locale.setDefault(Locale.US)
+        context = ApplicationProvider.getApplicationContext()
+        engine = PillPriorityEngine(context)
+    }
 
     private fun entity(id: String, state: String, deviceClass: String = "", changed: String = "2026-07-16T20:00:00Z") =
         HaEntity(id, state, JSONObject().put("friendly_name", id.substringAfter('.')).put("device_class", deviceClass), changed)
@@ -18,16 +29,16 @@ class PillPriorityEngineTest {
         val washer = entity("sensor.washer", "running")
         val door = entity("binary_sensor.front_door", "off", "door")
         val rules = listOf(PillRule("sensor.washer", PillKind.APPLIANCE, "Machine"), PillRule("binary_sensor.front_door", PillKind.OPENING, "Porte"))
-        val result = PillPriorityEngine.select(rules, mapOf(washer.entityId to washer, door.entityId to door))
+        val result = engine.select(rules, mapOf(washer.entityId to washer, door.entityId to door))
         assertEquals("sensor.washer", result.first().entityId)
-        assertEquals("Toutes fermées", result.last().value)
+        assertEquals("All closed", result.last().value)
     }
 
     @Test fun `danger wins over activity`() {
         val smoke = entity("binary_sensor.smoke", "on", "smoke")
         val washer = entity("sensor.washer", "running")
         val rules = listOf(PillRule(smoke.entityId, PillKind.SAFETY, "Fumée"), PillRule(washer.entityId, PillKind.APPLIANCE, "Machine"))
-        val result = PillPriorityEngine.select(rules, mapOf(smoke.entityId to smoke, washer.entityId to washer))
+        val result = engine.select(rules, mapOf(smoke.entityId to smoke, washer.entityId to washer))
         assertEquals(smoke.entityId, result.first().entityId)
         assertEquals("critical", result.first().state)
     }
@@ -35,7 +46,7 @@ class PillPriorityEngineTest {
     @Test fun `selection is limited to nine`() {
         val entities = (1..12).associate { i -> "sensor.task_$i" to entity("sensor.task_$i", "running") }
         val rules = entities.keys.map { PillRule(it, PillKind.APPLIANCE, it) }
-        assertEquals(9, PillPriorityEngine.select(rules, entities).size)
+        assertEquals(9, engine.select(rules, entities).size)
     }
 
     @Test fun `supported opening is classified`() {
@@ -68,7 +79,7 @@ class PillPriorityEngineTest {
         val rule = PillRule(state.entityId, PillKind.APPLIANCE, "Machine à laver", relatedEntityIds = listOf(cycle.entityId, completion.entityId))
         val states = listOf(state, cycle, completion).associateBy { it.entityId }
 
-        val chip = PillPriorityEngine.select(listOf(rule), states, nowMs = java.time.Instant.parse("2026-07-17T08:45:00Z").toEpochMilli()).single()
+        val chip = engine.select(listOf(rule), states, nowMs = java.time.Instant.parse("2026-07-17T08:45:00Z").toEpochMilli()).single()
 
         assertEquals("Reste 54 min", chip.value)
         assertTrue(chip.progress in 0.31f..0.33f)
@@ -77,7 +88,7 @@ class PillPriorityEngineTest {
     @Test fun `normal temperature remains as low priority fallback`() {
         val temperature = entity("sensor.salon_temperature", "21.4", "temperature")
         val rule = PillRule(temperature.entityId, PillKind.CLIMATE, "Salon")
-        val chip = PillPriorityEngine.select(listOf(rule), mapOf(temperature.entityId to temperature)).single()
+        val chip = engine.select(listOf(rule), mapOf(temperature.entityId to temperature)).single()
         assertEquals(2, chip.priority)
         assertEquals("ok", chip.state)
     }
@@ -98,11 +109,11 @@ class PillPriorityEngineTest {
             PillRule(kitchen.entityId, PillKind.OPENING, "Cuisine"),
             PillRule(terrace.entityId, PillKind.OPENING, "Terrasse", relatedEntityIds = listOf(battery.entityId)),
         )
-        val chip = PillPriorityEngine.select(rules, listOf(kitchen, terrace, battery).associateBy { it.entityId }).single()
-        assertEquals("Portes & fenêtres", chip.label)
-        assertEquals("1 ouverte", chip.value)
+        val chip = engine.select(rules, listOf(kitchen, terrace, battery).associateBy { it.entityId }).single()
+        assertEquals("Doors & windows", chip.label)
+        assertEquals("1 open", chip.value)
         assertTrue(!chip.value.contains("87"))
-        assertEquals(setOf("Ouverte", "Fermée"), chip.details.map { it.value }.toSet())
+        assertEquals(setOf("Open", "Closed"), chip.details.map { it.value }.toSet())
     }
 
     @Test fun `temperatures are grouped with min max and room details`() {
@@ -112,8 +123,8 @@ class PillPriorityEngineTest {
             PillRule(salon.entityId, PillKind.CLIMATE, "Salon Température"),
             PillRule(chambre.entityId, PillKind.CLIMATE, "Chambre Température"),
         )
-        val chip = PillPriorityEngine.select(rules, listOf(salon, chambre).associateBy { it.entityId }).single()
-        assertEquals("Températures", chip.label)
+        val chip = engine.select(rules, listOf(salon, chambre).associateBy { it.entityId }).single()
+        assertEquals("Temperatures", chip.label)
         assertEquals("Min 19.2° · Max 21.4°", chip.value)
         assertEquals(setOf("Salon", "Chambre"), chip.details.map { it.label }.toSet())
     }
@@ -125,9 +136,9 @@ class PillPriorityEngineTest {
             PillRule(alarm.entityId, PillKind.SAFETY, "Home Alarm"),
             PillRule(lock.entityId, PillKind.LOCK, "Serrure"),
         )
-        val chips = PillPriorityEngine.select(rules, listOf(alarm, lock).associateBy { it.entityId })
-        assertEquals(setOf("Sécurité", "Serrure"), chips.map { it.label }.toSet())
-        assertEquals(setOf("Désarmée", "Verrouillée"), chips.map { it.value }.toSet())
+        val chips = engine.select(rules, listOf(alarm, lock).associateBy { it.entityId })
+        assertEquals(setOf("Security", "Serrure"), chips.map { it.label }.toSet())
+        assertEquals(setOf("Désarmée", "Locked"), chips.map { it.value }.toSet())
     }
 
     @Test fun `lights are grouped into one pill`() {
@@ -137,19 +148,19 @@ class PillPriorityEngineTest {
             PillRule(salon.entityId, PillKind.LIGHTS, "Salon"),
             PillRule(cuisine.entityId, PillKind.LIGHTS, "Cuisine"),
         )
-        val chip = PillPriorityEngine.select(rules, listOf(salon, cuisine).associateBy { it.entityId }).single()
-        assertEquals("Lumières", chip.label)
-        assertEquals("1 allumée", chip.value)
-        assertEquals(setOf("Allumée", "Éteinte"), chip.details.map { it.value }.toSet())
+        val chip = engine.select(rules, listOf(salon, cuisine).associateBy { it.entityId }).single()
+        assertEquals("Lights", chip.label)
+        assertEquals("1 on", chip.value)
+        assertEquals(setOf("On", "Off"), chip.details.map { it.value }.toSet())
     }
 
     @Test fun `media players are grouped`() {
         val tv = entity("media_player.tv", "playing")
         val speaker = entity("media_player.speaker", "idle")
         val rules = listOf(PillRule(tv.entityId, PillKind.MEDIA, "TV"), PillRule(speaker.entityId, PillKind.MEDIA, "Enceinte"))
-        val chip = PillPriorityEngine.select(rules, listOf(tv, speaker).associateBy { it.entityId }).single()
-        assertEquals("Médias", chip.label)
-        assertEquals("En lecture", chip.value)
+        val chip = engine.select(rules, listOf(tv, speaker).associateBy { it.entityId }).single()
+        assertEquals("Media", chip.label)
+        assertEquals("Paused", chip.value)
     }
 
     private fun entityWith(id: String, state: String, attrs: JSONObject) =
@@ -165,22 +176,22 @@ class PillPriorityEngineTest {
 
     @Test fun `switch pill shows on off state`() {
         val sw = entity("switch.bureau", "on")
-        val chip = PillPriorityEngine.select(listOf(PillRule(sw.entityId, PillKind.SWITCH, "Bureau")), mapOf(sw.entityId to sw)).single()
-        assertEquals("Allumé", chip.value)
+        val chip = engine.select(listOf(PillRule(sw.entityId, PillKind.SWITCH, "Bureau")), mapOf(sw.entityId to sw)).single()
+        assertEquals("On", chip.value)
         assertEquals("active", chip.state)
         assertEquals(PillKind.SWITCH, chip.kind)
     }
 
     @Test fun `cover pill shows position when available`() {
         val cover = entityWith("cover.salon", "open", JSONObject().put("current_position", 60))
-        val chip = PillPriorityEngine.select(listOf(PillRule(cover.entityId, PillKind.COVER, "Salon")), mapOf(cover.entityId to cover)).single()
-        assertEquals("Ouvert · 60%", chip.value)
+        val chip = engine.select(listOf(PillRule(cover.entityId, PillKind.COVER, "Salon")), mapOf(cover.entityId to cover)).single()
+        assertEquals("Open · 60%", chip.value)
         assertEquals(PillKind.COVER, chip.kind)
     }
 
     @Test fun `thermostat pill shows target temperature`() {
         val climate = entityWith("climate.salon", "heat", JSONObject().put("temperature", 21.0).put("current_temperature", 19.5))
-        val chip = PillPriorityEngine.select(listOf(PillRule(climate.entityId, PillKind.THERMOSTAT, "Salon")), mapOf(climate.entityId to climate)).single()
+        val chip = engine.select(listOf(PillRule(climate.entityId, PillKind.THERMOSTAT, "Salon")), mapOf(climate.entityId to climate)).single()
         assertEquals("21°", chip.value)
         assertEquals(PillKind.THERMOSTAT, chip.kind)
         assertEquals("active", chip.state)

--- a/app/src/test/java/com/iblu01/portallauncher/PillRepositoryTransformTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/PillRepositoryTransformTest.kt
@@ -1,5 +1,7 @@
 package com.iblu01.portallauncher
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import com.iblu01.portallauncher.domain.model.HaSnapshot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,7 +30,8 @@ import org.robolectric.annotation.Config
 class PillRepositoryTransformTest {
 
     private val dispatcher = UnconfinedTestDispatcher()
-    private val repo = PillRepository()
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val repo = PillRepository(context)
 
     private fun player(id: String, title: String, state: String = "playing"): HaEntity =
         HaEntity(id, state, JSONObject().put("media_title", title), "2026-07-23T10:00:00Z")

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/AppContextMenuTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/AppContextMenuTest.kt
@@ -62,9 +62,9 @@ class AppContextMenuTest {
             )
         }
 
-        rule.onNodeWithText("Masquer").assertIsDisplayed()
-        rule.onNodeWithText("Infos de l’application").assertIsDisplayed()
-        rule.onNodeWithText("Désinstaller").assertIsDisplayed()
+        rule.onNodeWithText("Hide").assertIsDisplayed()
+        rule.onNodeWithText("App info").assertIsDisplayed()
+        rule.onNodeWithText("Uninstall").assertIsDisplayed()
         rule.onNodeWithText("Titres likés").performClick()
         rule.waitForIdle()
 
@@ -90,7 +90,7 @@ class AppContextMenuTest {
             )
         }
 
-        rule.onNodeWithText("Désinstaller").assertDoesNotExist()
+        rule.onNodeWithText("Uninstall").assertDoesNotExist()
     }
 
     @Test
@@ -114,10 +114,10 @@ class AppContextMenuTest {
         // `getShortcuts()` only works for the selected home app, so an empty list here is a role
         // problem, not an app without shortcuts.
         rule.onNodeWithText(
-            "Raccourcis indisponibles — Portal n’est pas le launcher par défaut"
+            "Shortcuts unavailable — Portal is not the default launcher"
         ).assertIsDisplayed()
         // And it is actionable, not just an explanation.
-        rule.onNodeWithText("Définir Portal par défaut").assertIsDisplayed()
+        rule.onNodeWithText("Set Portal as default").assertIsDisplayed()
     }
 
     @Test
@@ -140,7 +140,7 @@ class AppContextMenuTest {
             )
         }
 
-        rule.onNodeWithText("Définir Portal par défaut").performClick()
+        rule.onNodeWithText("Set Portal as default").performClick()
         rule.waitForIdle()
 
         assertEquals(1, homeSettings)
@@ -165,9 +165,9 @@ class AppContextMenuTest {
             )
         }
 
-        rule.onNodeWithText("Masquer").assertDoesNotExist()
-        rule.onNodeWithText("Désinstaller").assertDoesNotExist()
-        rule.onNodeWithText("Retirer le raccourci").performClick()
+        rule.onNodeWithText("Hide").assertDoesNotExist()
+        rule.onNodeWithText("Uninstall").assertDoesNotExist()
+        rule.onNodeWithText("Remove shortcut").performClick()
         rule.waitForIdle()
 
         assertEquals(1, removed)
@@ -205,17 +205,17 @@ class AppContextMenuTest {
             )
         }
 
-        rule.onNodeWithText("Largeur").assertIsDisplayed()
-        rule.onNodeWithText("Renommer").assertDoesNotExist()
-        rule.onNodeWithText("Masquer").assertDoesNotExist()
-        rule.onNodeWithText("Désinstaller").assertDoesNotExist()
+        rule.onNodeWithText("Width").assertIsDisplayed()
+        rule.onNodeWithText("Rename").assertDoesNotExist()
+        rule.onNodeWithText("Hide").assertDoesNotExist()
+        rule.onNodeWithText("Uninstall").assertDoesNotExist()
 
         // Two "+" buttons (width, height): the first grows the width.
         rule.onAllNodesWithText("+")[0].performClick()
         rule.waitForIdle()
         assertEquals(listOf(GridSpan(3, 1)), resizes)
 
-        rule.onNodeWithText("Retirer le widget").performClick()
+        rule.onNodeWithText("Remove widget").performClick()
         rule.waitForIdle()
         assertEquals(1, removed)
     }
@@ -274,10 +274,10 @@ class AppContextMenuTest {
             )
         }
 
-        rule.onNodeWithText("Renommer").performClick()
+        rule.onNodeWithText("Rename").performClick()
         rule.waitForIdle()
-        rule.onNodeWithText("Nom affiché").assertIsDisplayed()
-        rule.onNodeWithText("Valider").performClick()
+        rule.onNodeWithText("Display name").assertIsDisplayed()
+        rule.onNodeWithText("Confirm").performClick()
         rule.waitForIdle()
 
         assertEquals("Spotify", renamed)

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/LauncherHeaderActionsTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/LauncherHeaderActionsTest.kt
@@ -25,7 +25,7 @@ class LauncherHeaderActionsTest {
             LauncherHeaderActions(hiddenCount = 0, onShowHidden = {}, onSettings = { settings++ })
         }
 
-        rule.onNodeWithContentDescription("Réglages").performClick()
+        rule.onNodeWithContentDescription("Settings").performClick()
         rule.waitForIdle()
 
         assertEquals(1, settings)
@@ -39,8 +39,8 @@ class LauncherHeaderActionsTest {
         }
 
         // "Masquer" would be a one-way trip without this entry.
-        rule.onNodeWithContentDescription("Applications masquées (2)").assertIsDisplayed()
-        rule.onNodeWithContentDescription("Applications masquées (2)").performClick()
+        rule.onNodeWithContentDescription("Hidden apps (2)").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Hidden apps (2)").performClick()
         rule.waitForIdle()
 
         assertEquals(1, shown)
@@ -52,6 +52,6 @@ class LauncherHeaderActionsTest {
             LauncherHeaderActions(hiddenCount = 0, onShowHidden = {}, onSettings = {})
         }
 
-        rule.onNodeWithContentDescription("Applications masquées (0)").assertDoesNotExist()
+        rule.onNodeWithContentDescription("Hidden apps (0)").assertDoesNotExist()
     }
 }

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/QuickActionsOverlayTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/QuickActionsOverlayTest.kt
@@ -39,8 +39,8 @@ class QuickActionsOverlayTest {
             )
         }
 
-        rule.onNodeWithText("Fond d’écran").performClick()
-        rule.onNodeWithText("Réglages").performClick()
+        rule.onNodeWithText("Wallpaper").performClick()
+        rule.onNodeWithText("Settings").performClick()
         rule.waitForIdle()
 
         assertEquals(1, wallpaper)
@@ -61,8 +61,8 @@ class QuickActionsOverlayTest {
             )
         }
 
-        rule.onNodeWithText("Définir comme launcher par défaut").assertIsDisplayed()
-        rule.onNodeWithText("Définir comme launcher par défaut").performClick()
+        rule.onNodeWithText("Set as default launcher").assertIsDisplayed()
+        rule.onNodeWithText("Set as default launcher").performClick()
         rule.waitForIdle()
 
         assertEquals(1, homeSettings)
@@ -82,7 +82,7 @@ class QuickActionsOverlayTest {
 
         // Started off-row, in the panel's own padding: a row's tap detector consumes the down, so a
         // drag begun on a row can never become a swipe. The panel's tap swallow must not do that.
-        val row = rule.onNodeWithText("Réglages").getUnclippedBoundsInRoot()
+        val row = rule.onNodeWithText("Settings").getUnclippedBoundsInRoot()
         rule.onRoot().performTouchInput {
             val x = with(rule.density) { row.left.toPx() } + 4f
             val y = with(rule.density) { row.top.toPx() } - 4f
@@ -137,6 +137,6 @@ class QuickActionsOverlayTest {
             )
         }
 
-        rule.onNodeWithText("Définir comme launcher par défaut").assertDoesNotExist()
+        rule.onNodeWithText("Set as default launcher").assertDoesNotExist()
     }
 }

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/WidgetPickerDialogTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/WidgetPickerDialogTest.kt
@@ -53,13 +53,13 @@ class WidgetPickerDialogTest {
     fun `a device with no widgets says so instead of showing an empty panel`() {
         rule.setContent { WidgetPickerDialog(offers = emptyList(), onPick = {}, onDismiss = {}) }
 
-        rule.onNodeWithText("Aucun widget disponible").assertIsDisplayed()
+        rule.onNodeWithText("No widgets available").assertIsDisplayed()
     }
 
     @Test
     fun `no offers loaded yet means no dialog`() {
         rule.setContent { WidgetPickerDialog(offers = null, onPick = {}, onDismiss = {}) }
 
-        rule.onNodeWithText("Ajouter un widget").assertDoesNotExist()
+        rule.onNodeWithText("Add a widget").assertDoesNotExist()
     }
 }


### PR DESCRIPTION
## 0.0.3-beta

### Added
- **i18n / internationalization**: full translation system with English (default) and French. ~320 strings extracted from hardcoded values into string resources. Adding a new language only requires creating a new `values-XX/strings.xml` file — no code changes needed.

### Changed
- **iOS-style selected chip**: when a tray chip is selected (its panel is open), it now renders with a white background, dark text, and white border — matching the iOS Home app look. The colored icon circle retains its accent color.

### Technical
- All user-facing strings now use `stringResource(R.string.*)` (Compose) or `context.getString(R.string.*)` (non-Compose)
- Plurals support for dynamic counts
- `PillPriorityEngine` refactored from `object` to `class` with Context injection
- All 162 unit tests updated to assert against English string resources