### PR TITLE
fix: defer unused location permission prompts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,9 +10,6 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-
     <queries>
         <package android:name="io.homeassistant.companion.android" />
         <intent>

--- a/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
@@ -185,7 +185,6 @@ class LauncherActivity : ComponentActivity() {
                 )
             }
         }
-        requestLocationPermissionIfNeeded()
     }
 
     /**
@@ -365,15 +364,6 @@ class LauncherActivity : ComponentActivity() {
 
     private fun uninstallApp(packageName: String) {
         openFromLauncher(LauncherAppsFacade.uninstallIntent(packageName))
-    }
-
-    private fun requestLocationPermissionIfNeeded() {
-        if (
-            checkSelfPermission(android.Manifest.permission.ACCESS_COARSE_LOCATION) != android.content.pm.PackageManager.PERMISSION_GRANTED &&
-            checkSelfPermission(android.Manifest.permission.ACCESS_FINE_LOCATION) != android.content.pm.PackageManager.PERMISSION_GRANTED
-        ) {
-            requestPermissions(arrayOf(android.Manifest.permission.ACCESS_COARSE_LOCATION), 2)
-        }
     }
 
     private companion object {

--- a/app/src/main/java/com/iblu01/portallauncher/SettingsActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/SettingsActivity.kt
@@ -297,10 +297,7 @@ class SettingsActivity : ComponentActivity() {
     }
 
     private fun grantUsefulPermissions() {
-        val missing = listOf(
-            android.Manifest.permission.RECORD_AUDIO,
-            android.Manifest.permission.ACCESS_COARSE_LOCATION
-        ).filter {
+        val missing = listOf(android.Manifest.permission.RECORD_AUDIO).filter {
             checkSelfPermission(it) != PackageManager.PERMISSION_GRANTED
         }
         if (missing.isNotEmpty()) {

--- a/app/src/test/java/com/iblu01/portallauncher/LocationPermissionContractTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/LocationPermissionContractTest.kt
@@ -1,0 +1,25 @@
+package com.iblu01.portallauncher
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LocationPermissionContractTest {
+    @Test
+    fun `launcher does not declare location permissions`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val packageInfo = context.packageManager.getPackageInfo(
+            context.packageName,
+            PackageManager.GET_PERMISSIONS,
+        )
+        val requested = packageInfo.requestedPermissions.orEmpty().toSet()
+
+        assertFalse(requested.contains(android.Manifest.permission.ACCESS_COARSE_LOCATION))
+        assertFalse(requested.contains(android.Manifest.permission.ACCESS_FINE_LOCATION))
+    }
+}


### PR DESCRIPTION
## Summary

Portal currently asks for coarse location on every fresh launcher start and includes location in the Settings "grant useful permissions" flow, even though no current runtime feature consumes location.

This keeps permission scope honest by deferring location until a future feature has a concrete point-of-use request.

## Changes

- remove coarse and fine location declarations from the manifest;
- remove the automatic launcher-start location prompt;
- remove location from the Settings permission helper while preserving microphone, system-settings, and accessibility handling;
- add a Robolectric manifest contract test preventing accidental reintroduction.

## Verification

- `./gradlew test assembleDebug --no-daemon`
- 163 tests passed, 0 failures, 0 errors
- debug APK assembled successfully
- `git diff --check`
- production source scan: zero `ACCESS_COARSE_LOCATION`, `ACCESS_FINE_LOCATION`, or `requestLocationPermissionIfNeeded` references

## Scope

No location-backed behavior is removed because none is currently implemented. If a future feature needs location, it can add the minimum permission and request it at point of use with its own rationale.
