### PR TITLE
feat: add bounded external-app sessions over MQTT

### DIFF
--- a/app/src/main/java/com/iblu01/portallauncher/HaDiscovery.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/HaDiscovery.kt
@@ -146,6 +146,23 @@ object HaDiscovery {
         return """{"name":"IP Address","unique_id":"${deviceId}_ip","device":${device(deviceId, name)},"state_topic":"${ipStateTopic(deviceId)}","icon":"mdi:ip-network","entity_category":"diagnostic"}"""
     }
 
+    // --- Bounded external-app session discovery ---------------------------------------------
+    fun sessionDiscoveryTopic(deviceId: String) = "homeassistant/sensor/${deviceId}_app_session/config"
+    fun sessionStateTopic(deviceId: String) = "portal/$deviceId/session/state"
+    fun sessionEventTopic(deviceId: String) = "portal/$deviceId/session/event"
+    fun sessionCommandTopic(deviceId: String) = "portal/$deviceId/session/command"
+    fun sessionConfigPayload(deviceId: String, deviceName: String): String {
+        val name = deviceName.escape()
+        return """{"name":"App Session","unique_id":"${deviceId}_app_session","device":${device(deviceId, name)},"state_topic":"${sessionStateTopic(deviceId)}","value_template":"{{ value_json.lifecycle }}","expire_after":15,"icon":"mdi:application-cog","entity_category":"diagnostic"}"""
+    }
+
+    fun sessionEnabledDiscoveryTopic(deviceId: String) = "homeassistant/binary_sensor/${deviceId}_app_sessions_enabled/config"
+    fun sessionEnabledStateTopic(deviceId: String) = "portal/$deviceId/session/enabled"
+    fun sessionEnabledConfigPayload(deviceId: String, deviceName: String): String {
+        val name = deviceName.escape()
+        return """{"name":"App Sessions Enabled","unique_id":"${deviceId}_app_sessions_enabled","device":${device(deviceId, name)},"state_topic":"${sessionEnabledStateTopic(deviceId)}","payload_on":"ON","payload_off":"OFF","icon":"mdi:shield-lock","entity_category":"diagnostic"}"""
+    }
+
     fun commandTopics(deviceId: String) = listOf(
         screenCommandTopic(deviceId),
         micMuteCommandTopic(deviceId),
@@ -156,7 +173,8 @@ object HaDiscovery {
         screenTimeoutCommandTopic(deviceId),
         screenTimeoutMinutesCommandTopic(deviceId),
         powerModeCommandTopic(deviceId),
-        notificationCommandTopic(deviceId)
+        notificationCommandTopic(deviceId),
+        sessionCommandTopic(deviceId),
     )
 
     fun staleTopics(deviceId: String) = listOf(

--- a/app/src/main/java/com/iblu01/portallauncher/MqttBridgeService.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/MqttBridgeService.kt
@@ -24,9 +24,19 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions
 import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 import com.iblu01.portallauncher.photo.PhotoStatusSerializer
+import com.iblu01.portallauncher.session.SessionCoordinator
+import com.iblu01.portallauncher.session.SessionAllowlist
+import com.iblu01.portallauncher.session.SessionManager
+import com.iblu01.portallauncher.session.SessionMqttContract
+import com.iblu01.portallauncher.session.SessionResult
+import com.iblu01.portallauncher.session.SessionRuntime
+import com.iblu01.portallauncher.session.SessionSerializer
+import com.iblu01.portallauncher.session.RealSessionTimeSource
 import java.net.Inet4Address
 import java.net.NetworkInterface
 import java.util.concurrent.Executors
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 class MqttBridgeService : Service() {
@@ -69,7 +79,22 @@ class MqttBridgeService : Service() {
     private var soundMonitor: SoundMonitor? = null
     private var screenReceiver: BroadcastReceiver? = null
     private var audioReceiver: BroadcastReceiver? = null
-    private val deviceStateListener = DeviceStateHub.Listener { state -> publishDeviceState(state) }
+    @Volatile private var sessionCoordinator: SessionCoordinator? = null
+    private var sessionAllowlist: SessionAllowlist = SessionAllowlist.EMPTY
+    private var lastSessionsEnabled: Boolean? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val sessionTick = object : Runnable {
+        override fun run() {
+            if (running.get()) {
+                sessionCoordinator?.onDeviceState(DeviceStateHub.current.foregroundPackage)
+                mainHandler.postDelayed(this, 1_000L)
+            }
+        }
+    }
+    private val deviceStateListener = DeviceStateHub.Listener { state ->
+        publishDeviceState(state)
+        sessionCoordinator?.onDeviceState(state.foregroundPackage)
+    }
     @Volatile private var lastVolumePercent = -1
     @Volatile private var lastVolumeMuted = false
     @Volatile private var lastBrightnessPercent = -1
@@ -80,9 +105,13 @@ class MqttBridgeService : Service() {
         super.onCreate()
         createChannel()
         prefs = Prefs(this)
+        sessionAllowlist = prefs.appSessionAllowlist
+        sessionCoordinator = createSessionCoordinator().also { it.setEnabled(prefs.appSessionsEnabled) }
+        lastSessionsEnabled = prefs.appSessionsEnabled
         startForeground(NOTIF_ID, notification(getString(R.string.app_name)))
 
         DeviceStateHub.init(this)
+        DeviceStateHub.addListener(deviceStateListener)
         ScreenControl.enableAccessibility(this)
         sensorBridge = SensorBridge(this, ::publishRaw).also { it.start(prefs) }
         soundMonitor = SoundMonitor(this) { level ->
@@ -96,6 +125,7 @@ class MqttBridgeService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_RECONNECT) {
             Log.i(TAG, "Reconnect requested (broker config changed)")
+            refreshSessionConfiguration(prefs)
             Thread({
                 com.iblu01.portallauncher.ui.ConnectionStatus.connected = false
                 runCatching { mqtt?.disconnect(0) }
@@ -103,6 +133,7 @@ class MqttBridgeService : Service() {
             }, "portal-launcher-reconnect").also { it.isDaemon = true }.start()
         }
         if (running.compareAndSet(false, true)) {
+            mainHandler.post(sessionTick)
             Thread(::mqttLoop, "portal-launcher-mqtt").also { it.isDaemon = true }.start()
         }
         return START_STICKY
@@ -110,6 +141,8 @@ class MqttBridgeService : Service() {
 
     override fun onDestroy() {
         running.set(false)
+        mainHandler.removeCallbacks(sessionTick)
+        sessionCoordinator = null
         commands.shutdownNow()
         runCatching { mqtt?.disconnect(0) }
         sensorBridge?.stop()
@@ -169,6 +202,11 @@ class MqttBridgeService : Service() {
             setWill(HaDiscovery.screenStateTopic(p.deviceId), "OFF".toByteArray(), 1, true)
         })
         mqtt = client
+        if (!runOnMain { refreshSessionConfiguration(p, publishEnabledState = false) }) {
+            mqtt = null
+            runCatching { client.disconnect(0) }
+            throw IllegalStateException("session_config_apply_failed")
+        }
         com.iblu01.portallauncher.ui.ConnectionStatus.connected = true
         Log.i(TAG, "MQTT connected to ${p.brokerUri}")
 
@@ -178,7 +216,6 @@ class MqttBridgeService : Service() {
 
         publishDiscovery(client, p)
         publishInitialStates(p)
-        DeviceStateHub.addListener(deviceStateListener)
         updateNotification("Connected - ${p.brokerHost}")
 
         try {
@@ -189,7 +226,6 @@ class MqttBridgeService : Service() {
             }
         } finally {
             com.iblu01.portallauncher.ui.ConnectionStatus.connected = false
-            DeviceStateHub.removeListener(deviceStateListener)
             mqtt = null
             runCatching { client.disconnect(0) }
         }
@@ -219,6 +255,8 @@ class MqttBridgeService : Service() {
         pub(HaDiscovery.screenTimeoutMinutesDiscoveryTopic(p.deviceId), HaDiscovery.screenTimeoutMinutesConfigPayload(p.deviceId, p.deviceName))
         pub(HaDiscovery.powerModeDiscoveryTopic(p.deviceId), HaDiscovery.powerModeConfigPayload(p.deviceId, p.deviceName))
         pub(HaDiscovery.photoStatusDiscoveryTopic(p.deviceId), HaDiscovery.photoStatusConfigPayload(p.deviceId, p.deviceName))
+        pub(HaDiscovery.sessionDiscoveryTopic(p.deviceId), HaDiscovery.sessionConfigPayload(p.deviceId, p.deviceName))
+        pub(HaDiscovery.sessionEnabledDiscoveryTopic(p.deviceId), HaDiscovery.sessionEnabledConfigPayload(p.deviceId, p.deviceName))
     }
 
     private fun publishInitialStates(p: Prefs) {
@@ -232,6 +270,8 @@ class MqttBridgeService : Service() {
         publishBrightnessState(p)
         publishPowerState(p)
         publishPhotoStatus(p)
+        publishSessionsEnabledState(p)
+        sessionCoordinator?.publishCurrentState()
     }
 
     private fun pollChangedStates(p: Prefs) {
@@ -242,6 +282,8 @@ class MqttBridgeService : Service() {
         val bright = currentBrightnessPercent()
         if (bright != lastBrightnessPercent) publishBrightnessState(p)
         publishPhotoStatus(p)
+        mainHandler.post { refreshSessionConfiguration(p) }
+        sessionCoordinator?.publishCurrentState()
     }
 
     private fun publishPhotoStatus(p: Prefs) {
@@ -262,6 +304,7 @@ class MqttBridgeService : Service() {
 
     private fun handleMessage(topic: String, payload: String, p: Prefs) {
         when (topic) {
+            HaDiscovery.sessionCommandTopic(p.deviceId) -> sessionCoordinator?.onCommand(payload)
             HaDiscovery.screenCommandTopic(p.deviceId) -> when (payload.uppercase()) {
                 "ON" -> ScreenControl.wake(this)
                 "OFF" -> ScreenControl.sleep(this)
@@ -409,6 +452,91 @@ class MqttBridgeService : Service() {
             1,
             retained = true
         )
+    }
+
+    private fun publishSessionsEnabledState(p: Prefs) {
+        publishRaw(
+            HaDiscovery.sessionEnabledStateTopic(p.deviceId),
+            if (p.appSessionsEnabled) "ON" else "OFF",
+            1,
+            retained = true,
+        )
+    }
+
+    private fun refreshSessionConfiguration(p: Prefs, publishEnabledState: Boolean = true) {
+        val configuredAllowlist = p.appSessionAllowlist
+        if (configuredAllowlist != sessionAllowlist) {
+            sessionCoordinator?.setEnabled(false)
+            sessionAllowlist = configuredAllowlist
+            sessionCoordinator = createSessionCoordinator()
+            lastSessionsEnabled = null
+        }
+        if (lastSessionsEnabled != p.appSessionsEnabled) {
+            lastSessionsEnabled = p.appSessionsEnabled
+            sessionCoordinator?.setEnabled(p.appSessionsEnabled)
+            if (publishEnabledState) publishSessionsEnabledState(p)
+        }
+    }
+
+    private fun createSessionCoordinator(): SessionCoordinator {
+        val allowlist = sessionAllowlist
+        val manager = SessionManager(
+            timeSource = RealSessionTimeSource,
+            allowlist = allowlist,
+            launcherPackage = packageName,
+        )
+        val runtime = object : SessionRuntime {
+            override fun publishEvent(result: SessionResult) {
+                runCatching {
+                    mqtt?.publish(
+                        HaDiscovery.sessionEventTopic(prefs.deviceId),
+                        SessionMqttContract.eventMessage(SessionSerializer.toJson(result)),
+                    )
+                }
+            }
+
+            override fun publishState(result: SessionResult) {
+                runCatching {
+                    mqtt?.publish(
+                        HaDiscovery.sessionStateTopic(prefs.deviceId),
+                        SessionMqttContract.stateMessage(SessionSerializer.toJson(result)),
+                    )
+                }
+            }
+
+            override fun launchApp(packageName: String): Boolean {
+                if (allowlist.classificationFor(packageName) == null) return false
+                val intent = packageManager.getLaunchIntentForPackage(packageName) ?: return false
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                return runOnMain {
+                    startActivity(intent)
+                    DeviceStateHub.noteLaunchingApp(packageName, this@MqttBridgeService)
+                }
+            }
+
+            override fun returnToLauncher(): Boolean = runOnMain {
+                startActivity(
+                    Intent(this@MqttBridgeService, LauncherActivity::class.java).addFlags(
+                        Intent.FLAG_ACTIVITY_NEW_TASK or
+                            Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                            Intent.FLAG_ACTIVITY_SINGLE_TOP,
+                    )
+                )
+                SleepScheduler.apply(this@MqttBridgeService)
+            }
+        }
+        return SessionCoordinator(manager, allowlist, RealSessionTimeSource, runtime)
+    }
+
+    private fun runOnMain(action: () -> Unit): Boolean {
+        if (Looper.myLooper() == Looper.getMainLooper()) return runCatching(action).isSuccess
+        val task = FutureTask { runCatching(action).isSuccess }
+        if (!mainHandler.post(task)) return false
+        return runCatching { task.get(5, TimeUnit.SECONDS) }.getOrElse {
+            mainHandler.removeCallbacks(task)
+            task.cancel(false)
+            false
+        }
     }
 
     private fun publishDeviceState(state: DeviceState) {

--- a/app/src/main/java/com/iblu01/portallauncher/MqttBridgeService.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/MqttBridgeService.kt
@@ -86,7 +86,8 @@ class MqttBridgeService : Service() {
     private val sessionTick = object : Runnable {
         override fun run() {
             if (running.get()) {
-                sessionCoordinator?.onDeviceState(DeviceStateHub.current.foregroundPackage)
+                sessionCoordinator?.takeIf { it.hasActiveSession }
+                    ?.onDeviceState(DeviceStateHub.current.foregroundPackage)
                 mainHandler.postDelayed(this, 1_000L)
             }
         }
@@ -202,7 +203,7 @@ class MqttBridgeService : Service() {
             setWill(HaDiscovery.screenStateTopic(p.deviceId), "OFF".toByteArray(), 1, true)
         })
         mqtt = client
-        if (!runOnMain { refreshSessionConfiguration(p, publishEnabledState = false) }) {
+        if (!runConfigurationOnMain { refreshSessionConfiguration(p, publishEnabledState = false) }) {
             mqtt = null
             runCatching { client.disconnect(0) }
             throw IllegalStateException("session_config_apply_failed")
@@ -508,13 +509,13 @@ class MqttBridgeService : Service() {
                 if (allowlist.classificationFor(packageName) == null) return false
                 val intent = packageManager.getLaunchIntentForPackage(packageName) ?: return false
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                return runOnMain {
+                return runCatching {
                     startActivity(intent)
                     DeviceStateHub.noteLaunchingApp(packageName, this@MqttBridgeService)
-                }
+                }.isSuccess
             }
 
-            override fun returnToLauncher(): Boolean = runOnMain {
+            override fun returnToLauncher(): Boolean = runCatching {
                 startActivity(
                     Intent(this@MqttBridgeService, LauncherActivity::class.java).addFlags(
                         Intent.FLAG_ACTIVITY_NEW_TASK or
@@ -523,12 +524,13 @@ class MqttBridgeService : Service() {
                     )
                 )
                 SleepScheduler.apply(this@MqttBridgeService)
-            }
+            }.isSuccess
         }
         return SessionCoordinator(manager, allowlist, RealSessionTimeSource, runtime)
     }
 
-    private fun runOnMain(action: () -> Unit): Boolean {
+    /** Serialize local configuration replacement with main-thread settings callbacks. */
+    private fun runConfigurationOnMain(action: () -> Unit): Boolean {
         if (Looper.myLooper() == Looper.getMainLooper()) return runCatching(action).isSuccess
         val task = FutureTask { runCatching(action).isSuccess }
         if (!mainHandler.post(task)) return false

--- a/app/src/main/java/com/iblu01/portallauncher/Prefs.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/Prefs.kt
@@ -6,6 +6,8 @@ import android.provider.Settings
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.iblu01.portallauncher.session.SessionAllowlist
+import com.iblu01.portallauncher.session.SessionAllowlistCodec
 import com.iblu01.portallauncher.ui.theme.ClockFont
 import com.iblu01.portallauncher.ui.theme.ClockTheme
 import com.iblu01.portallauncher.ui.theme.ClockTint
@@ -236,7 +238,17 @@ class Prefs(private val context: Context) {
         get() = sp.getInt("auto_return_delay_seconds", 10)
         set(value) = sp.edit().putInt("auto_return_delay_seconds", value.coerceIn(5, 60)).apply()
 
+    /** Local kill switch for the bounded external-app session feature. Defaults off (fail-closed). */
+    var appSessionsEnabled: Boolean
+        get() = sp.getBoolean("app_sessions_enabled", false)
+        set(value) = sp.edit().putBoolean("app_sessions_enabled", value).apply()
 
+    /** Classified package allowlist, configured only from local app settings. Empty by default. */
+    var appSessionAllowlist: SessionAllowlist
+        get() = SessionAllowlistCodec.decode(sp.getStringSet("app_session_allowlist", emptySet()))
+        set(value) = sp.edit()
+            .putStringSet("app_session_allowlist", SessionAllowlistCodec.encode(value))
+            .apply()
 
     // --- Launcher grid (see ui.apps.LauncherLayoutStore) --------------------------------------
     /**

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionAllowlist.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionAllowlist.kt
@@ -1,0 +1,42 @@
+package com.iblu01.portallauncher.session
+
+/**
+ * Classification assigned to an allowed package.
+ *
+ * Each class carries a local default duration and a hard maximum duration. The default is used when
+ * a `start` command omits `duration_s`; the max is enforced regardless of whether the duration came
+ * from the command or the default.
+ */
+enum class AppClassification(
+    val defaultDurationSeconds: Int,
+    val maxDurationSeconds: Int,
+) {
+    HOME(defaultDurationSeconds = 60, maxDurationSeconds = 300),
+    MEDIA(defaultDurationSeconds = 30, maxDurationSeconds = 120),
+    UTILITY(defaultDurationSeconds = 30, maxDurationSeconds = 60),
+    COMMUNICATION(defaultDurationSeconds = 30, maxDurationSeconds = 60),
+}
+
+/**
+ * Local package allowlist. Each entry maps a package name to a classification that supplies the
+ * default and maximum durations. The parser rejects unknown packages, so the system fails closed.
+ *
+ * [DEFAULT] is only an optional seed for convenience. Production configurations should build their
+ * own [SessionAllowlist] from local storage or configuration so the set of launchable packages is
+ * not hard-coded and can differ per device.
+ */
+class SessionAllowlist(private val entries: Map<String, AppClassification>) {
+
+    fun classificationFor(packageName: String): AppClassification? = entries[packageName]
+
+    companion object {
+        val DEFAULT = SessionAllowlist(
+            mapOf(
+                "io.homeassistant.companion.android" to AppClassification.HOME,
+                "com.google.android.youtube" to AppClassification.MEDIA,
+                "com.android.chrome" to AppClassification.UTILITY,
+                "com.whatsapp" to AppClassification.COMMUNICATION,
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionAllowlist.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionAllowlist.kt
@@ -21,22 +21,21 @@ enum class AppClassification(
  * Local package allowlist. Each entry maps a package name to a classification that supplies the
  * default and maximum durations. The parser rejects unknown packages, so the system fails closed.
  *
- * [DEFAULT] is only an optional seed for convenience. Production configurations should build their
- * own [SessionAllowlist] from local storage or configuration so the set of launchable packages is
- * not hard-coded and can differ per device.
+ * Runtime configuration starts from [EMPTY] and is populated only through local device settings.
  */
 class SessionAllowlist(private val entries: Map<String, AppClassification>) {
 
     fun classificationFor(packageName: String): AppClassification? = entries[packageName]
 
+    /** Exposes a read-only view of the configured entries for persistence and UI editing. */
+    fun toMap(): Map<String, AppClassification> = entries
+
+    override fun equals(other: Any?): Boolean =
+        other is SessionAllowlist && other.entries == entries
+
+    override fun hashCode(): Int = entries.hashCode()
+
     companion object {
-        val DEFAULT = SessionAllowlist(
-            mapOf(
-                "io.homeassistant.companion.android" to AppClassification.HOME,
-                "com.google.android.youtube" to AppClassification.MEDIA,
-                "com.android.chrome" to AppClassification.UTILITY,
-                "com.whatsapp" to AppClassification.COMMUNICATION,
-            )
-        )
+        val EMPTY = SessionAllowlist(emptyMap())
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionAllowlistCodec.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionAllowlistCodec.kt
@@ -1,0 +1,32 @@
+package com.iblu01.portallauncher.session
+
+/** Strict local persistence codec for the classified package allowlist. */
+object SessionAllowlistCodec {
+    const val MAX_ENTRIES = 32
+    private val packageRegex = Regex("^[a-zA-Z][a-zA-Z0-9._-]{0,127}$")
+
+    fun encode(allowlist: SessionAllowlist): Set<String> = allowlist.toMap()
+        .entries
+        .asSequence()
+        .filter { packageRegex.matches(it.key) }
+        .sortedBy { it.key }
+        .take(MAX_ENTRIES)
+        .map { "${it.key}|${it.value.name}" }
+        .toSet()
+
+    fun decode(values: Set<String>?): SessionAllowlist {
+        if (values.isNullOrEmpty()) return SessionAllowlist(emptyMap())
+        val entries = linkedMapOf<String, AppClassification>()
+        values.asSequence().sorted().take(MAX_ENTRIES).forEach { encoded ->
+            val separator = encoded.lastIndexOf('|')
+            if (separator <= 0 || separator == encoded.lastIndex) return@forEach
+            val packageName = encoded.substring(0, separator)
+            if (!packageRegex.matches(packageName)) return@forEach
+            val classification = runCatching {
+                AppClassification.valueOf(encoded.substring(separator + 1))
+            }.getOrNull() ?: return@forEach
+            entries[packageName] = classification
+        }
+        return SessionAllowlist(entries)
+    }
+}

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionCommand.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionCommand.kt
@@ -62,6 +62,9 @@ data class SessionCommand(
     val durationSeconds: Int,
     val expiresAtMs: Long,
     val reason: String?,
+    /** Raw optional client fields used for idempotency; derived clock values are not compared. */
+    val requestedDurationSeconds: Int? = if (action == SessionAction.START) durationSeconds else null,
+    val requestedExpiresAtSeconds: Long? = if (action == SessionAction.START) expiresAtMs / 1000 else null,
 )
 
 /**

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionCommand.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionCommand.kt
@@ -48,6 +48,8 @@ enum class SessionRejectionCode {
     PACKAGE_MISMATCH,
     SESSION_ALREADY_ENDING,
     REQUEST_ID_CONFLICT,
+    LAUNCH_FAILED,
+    RETURN_TO_LAUNCHER_FAILED,
 }
 
 /**

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionCommand.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionCommand.kt
@@ -1,0 +1,104 @@
+package com.iblu01.portallauncher.session
+
+enum class SessionAction {
+    START,
+    END,
+    CANCEL,
+}
+
+enum class SessionLifecycle {
+    ACCEPTED,
+    REJECTED,
+    LAUNCHING,
+    ACTIVE,
+    ENDING,
+    COMPLETED,
+    FAILED,
+    EXPIRED,
+}
+
+/**
+ * Machine-readable, bounded rejection/reason codes for every fail-closed path.
+ *
+ * The user-provided `reason` field is kept separately in [SessionResult.reason] and is never the
+ * operational error text. Codes are emitted by the parser and manager and serialized back to MQTT
+ * as `code` when the lifecycle is [REJECTED].
+ */
+enum class SessionRejectionCode {
+    PAYLOAD_TOO_LARGE,
+    INVALID_JSON,
+    UNKNOWN_SCHEMA_VERSION,
+    UNKNOWN_FIELDS,
+    MALFORMED_REQUEST_ID,
+    UNKNOWN_ACTION,
+    MALFORMED_PACKAGE,
+    UNKNOWN_PACKAGE,
+    MALFORMED_REASON,
+    DURATION_OUT_OF_RANGE,
+    DURATION_EXCEEDS_MAX,
+    EXPIRES_AT_INVALID,
+    EXPIRES_AT_IN_THE_PAST,
+    EXPIRES_AT_EXCEEDS_MAX,
+    END_COMMAND_WITH_TEMPORAL_FIELDS,
+    RATE_LIMITED,
+    KILL_SWITCH_DISABLED,
+    SESSION_ALREADY_ACTIVE,
+    EXPIRED_BEFORE_LAUNCH,
+    NO_ACTIVE_SESSION,
+    PACKAGE_MISMATCH,
+    SESSION_ALREADY_ENDING,
+    REQUEST_ID_CONFLICT,
+}
+
+/**
+ * A validated, bounded session command. All fields are non-nullable where required by the schema.
+ */
+data class SessionCommand(
+    val requestId: String,
+    val action: SessionAction,
+    val packageName: String,
+    val durationSeconds: Int,
+    val expiresAtMs: Long,
+    val reason: String?,
+)
+
+/**
+ * A state/event payload emitted by the session manager.
+ *
+ * [reason] is the sanitized, user-provided reason from the command, if any. [code] is only present
+ * for [REJECTED] results and is the machine-readable rejection cause; operational strings are never
+ * exposed here.
+ */
+data class SessionResult(
+    val lifecycle: SessionLifecycle,
+    val requestId: String,
+    val packageName: String?,
+    val expiresAtMs: Long?,
+    val reason: String?,
+    val code: SessionRejectionCode? = null,
+)
+
+/**
+ * A side effect the manager asks the runtime to perform.
+ */
+sealed class SessionSideEffect {
+    data class LaunchApp(val packageName: String) : SessionSideEffect()
+    data object ReturnToLauncher : SessionSideEffect()
+}
+
+/**
+ * One state change together with any side effects that must happen for it.
+ */
+data class SessionTransition(
+    val result: SessionResult,
+    val sideEffects: List<SessionSideEffect> = emptyList(),
+)
+
+/**
+ * Runtime interface for launching/returning from an external session. The manager keeps this pure:
+ * it only returns [SessionSideEffect] values; the caller executes them.
+ */
+interface SessionLauncher {
+    fun launchApp(packageName: String)
+    fun returnToLauncher()
+}

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionCommandParser.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionCommandParser.kt
@@ -141,7 +141,7 @@ object SessionCommandParser {
         val classification = allowlist.classificationFor(packageName)
             ?: return ParseResult.Invalid(SessionRejectionCode.UNKNOWN_PACKAGE)
 
-        val requestedDuration = if (obj.has("duration_s")) {
+        val rawRequestedDuration = if (obj.has("duration_s")) {
             when (val raw = obj.opt("duration_s")) {
                 is Int, is Long -> {
                     val value = (raw as Number).toInt()
@@ -151,22 +151,24 @@ object SessionCommandParser {
                 else -> return ParseResult.Invalid(SessionRejectionCode.DURATION_OUT_OF_RANGE)
             }
         } else {
-            classification.defaultDurationSeconds
+            null
         }
+        val requestedDuration = rawRequestedDuration ?: classification.defaultDurationSeconds
 
         if (requestedDuration > classification.maxDurationSeconds) {
             return ParseResult.Invalid(SessionRejectionCode.DURATION_EXCEEDS_MAX)
         }
         val effectiveDuration = requestedDuration.coerceAtMost(classification.maxDurationSeconds)
 
-        val requestedExpiresAt = if (obj.has("expires_at")) {
+        val rawRequestedExpiresAt = if (obj.has("expires_at")) {
             when (val raw = obj.opt("expires_at")) {
                 is Int, is Long -> (raw as Number).toLong()
                 else -> return ParseResult.Invalid(SessionRejectionCode.EXPIRES_AT_INVALID)
             }
         } else {
-            nowSeconds + effectiveDuration
+            null
         }
+        val requestedExpiresAt = rawRequestedExpiresAt ?: (nowSeconds + effectiveDuration)
 
         if (requestedExpiresAt <= nowSeconds) {
             return ParseResult.Invalid(SessionRejectionCode.EXPIRES_AT_IN_THE_PAST)
@@ -185,6 +187,8 @@ object SessionCommandParser {
                 durationSeconds = effectiveDuration,
                 expiresAtMs = expiresAtMs,
                 reason = reason,
+                requestedDurationSeconds = rawRequestedDuration,
+                requestedExpiresAtSeconds = rawRequestedExpiresAt,
             )
         )
     }

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionCommandParser.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionCommandParser.kt
@@ -1,0 +1,196 @@
+package com.iblu01.portallauncher.session
+
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Parses a session command from the MQTT `portal/<deviceId>/session/command` topic.
+ *
+ * The parser is strict and fail-closed:
+ * - only the bounded schema fields are accepted,
+ * - unknown or missing fields are rejected,
+ * - the package must be in the local allowlist with a known classification,
+ * - durations and expiry are bounded by the classification defaults/maxima,
+ * - commands that are already expired are rejected before any side effect,
+ * - integer fields are accepted only as JSON integers; strings and floats are rejected.
+ */
+object SessionCommandParser {
+    const val SCHEMA_VERSION = 1
+    const val MAX_PAYLOAD_BYTES = 2048
+    private const val MAX_REQUEST_ID_LEN = 64
+    private const val MAX_REASON_LEN = 120
+
+    // Reasonable package-name grammar; avoids control chars and spaces.
+    private val PACKAGE_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9._-]{0,127}$")
+    private val REQUEST_ID_REGEX = Regex("^[A-Za-z0-9_-]{1,64}$")
+
+    private val ALLOWED_KEYS = setOf(
+        "schema_version",
+        "request_id",
+        "action",
+        "package",
+        "duration_s",
+        "expires_at",
+        "reason",
+    )
+
+    sealed class ParseResult {
+        data class Valid(val command: SessionCommand) : ParseResult()
+        data class Invalid(val code: SessionRejectionCode) : ParseResult()
+    }
+
+    fun parse(payload: String, nowMs: Long, allowlist: SessionAllowlist): ParseResult {
+        if (payload.toByteArray().size > MAX_PAYLOAD_BYTES) {
+            return ParseResult.Invalid(SessionRejectionCode.PAYLOAD_TOO_LARGE)
+        }
+
+        val obj = try {
+            JSONObject(payload)
+        } catch (_: JSONException) {
+            return ParseResult.Invalid(SessionRejectionCode.INVALID_JSON)
+        }
+
+        val extra = obj.keys().asSequence().toSet() - ALLOWED_KEYS
+        if (extra.isNotEmpty()) {
+            return ParseResult.Invalid(SessionRejectionCode.UNKNOWN_FIELDS)
+        }
+
+        if (!obj.has("schema_version")) {
+            return ParseResult.Invalid(SessionRejectionCode.UNKNOWN_SCHEMA_VERSION)
+        }
+        when (val raw = obj.opt("schema_version")) {
+            is Int, is Long -> if ((raw as Number).toInt() != SCHEMA_VERSION) {
+                return ParseResult.Invalid(SessionRejectionCode.UNKNOWN_SCHEMA_VERSION)
+            }
+            else -> return ParseResult.Invalid(SessionRejectionCode.UNKNOWN_SCHEMA_VERSION)
+        }
+
+        val requestId = when (val raw = obj.opt("request_id")) {
+            is String -> if (raw.isBlank() || !REQUEST_ID_REGEX.matches(raw)) {
+                return ParseResult.Invalid(SessionRejectionCode.MALFORMED_REQUEST_ID)
+            } else {
+                raw
+            }
+            else -> return ParseResult.Invalid(SessionRejectionCode.MALFORMED_REQUEST_ID)
+        }
+
+        val action = when (val raw = obj.opt("action")) {
+            is String -> when (raw.lowercase()) {
+                "start" -> SessionAction.START
+                "end" -> SessionAction.END
+                "cancel" -> SessionAction.CANCEL
+                else -> return ParseResult.Invalid(SessionRejectionCode.UNKNOWN_ACTION)
+            }
+            else -> return ParseResult.Invalid(SessionRejectionCode.UNKNOWN_ACTION)
+        }
+
+        val packageName = when (val raw = obj.opt("package")) {
+            is String -> if (raw.isBlank() || !PACKAGE_REGEX.matches(raw)) {
+                return ParseResult.Invalid(SessionRejectionCode.MALFORMED_PACKAGE)
+            } else {
+                raw
+            }
+            else -> return ParseResult.Invalid(SessionRejectionCode.MALFORMED_PACKAGE)
+        }
+
+        val reason = when (val raw = obj.opt("reason")) {
+            null, JSONObject.NULL -> null
+            is String -> sanitizeReason(raw)
+            else -> return ParseResult.Invalid(SessionRejectionCode.MALFORMED_REASON)
+        }
+
+        val nowSeconds = nowMs / 1000
+
+        return when (action) {
+            SessionAction.START -> parseStart(
+                obj = obj,
+                requestId = requestId,
+                packageName = packageName,
+                reason = reason,
+                nowSeconds = nowSeconds,
+                nowMs = nowMs,
+                allowlist = allowlist,
+            )
+            SessionAction.END, SessionAction.CANCEL -> {
+                if (obj.has("duration_s") || obj.has("expires_at")) {
+                    return ParseResult.Invalid(SessionRejectionCode.END_COMMAND_WITH_TEMPORAL_FIELDS)
+                }
+                ParseResult.Valid(
+                    SessionCommand(
+                        requestId = requestId,
+                        action = action,
+                        packageName = packageName,
+                        durationSeconds = 0,
+                        expiresAtMs = 0L,
+                        reason = reason,
+                    )
+                )
+            }
+        }
+    }
+
+    private fun parseStart(
+        obj: JSONObject,
+        requestId: String,
+        packageName: String,
+        reason: String?,
+        nowSeconds: Long,
+        nowMs: Long,
+        allowlist: SessionAllowlist,
+    ): ParseResult {
+        val classification = allowlist.classificationFor(packageName)
+            ?: return ParseResult.Invalid(SessionRejectionCode.UNKNOWN_PACKAGE)
+
+        val requestedDuration = if (obj.has("duration_s")) {
+            when (val raw = obj.opt("duration_s")) {
+                is Int, is Long -> {
+                    val value = (raw as Number).toInt()
+                    if (value <= 0) return ParseResult.Invalid(SessionRejectionCode.DURATION_OUT_OF_RANGE)
+                    value
+                }
+                else -> return ParseResult.Invalid(SessionRejectionCode.DURATION_OUT_OF_RANGE)
+            }
+        } else {
+            classification.defaultDurationSeconds
+        }
+
+        if (requestedDuration > classification.maxDurationSeconds) {
+            return ParseResult.Invalid(SessionRejectionCode.DURATION_EXCEEDS_MAX)
+        }
+        val effectiveDuration = requestedDuration.coerceAtMost(classification.maxDurationSeconds)
+
+        val requestedExpiresAt = if (obj.has("expires_at")) {
+            when (val raw = obj.opt("expires_at")) {
+                is Int, is Long -> (raw as Number).toLong()
+                else -> return ParseResult.Invalid(SessionRejectionCode.EXPIRES_AT_INVALID)
+            }
+        } else {
+            nowSeconds + effectiveDuration
+        }
+
+        if (requestedExpiresAt <= nowSeconds) {
+            return ParseResult.Invalid(SessionRejectionCode.EXPIRES_AT_IN_THE_PAST)
+        }
+        if (requestedExpiresAt > nowSeconds + classification.maxDurationSeconds) {
+            return ParseResult.Invalid(SessionRejectionCode.EXPIRES_AT_EXCEEDS_MAX)
+        }
+
+        val expiresAtMs = requestedExpiresAt * 1000
+
+        return ParseResult.Valid(
+            SessionCommand(
+                requestId = requestId,
+                action = SessionAction.START,
+                packageName = packageName,
+                durationSeconds = effectiveDuration,
+                expiresAtMs = expiresAtMs,
+                reason = reason,
+            )
+        )
+    }
+
+    private fun sanitizeReason(value: String): String = value
+        .filter { it.code >= 32 || it == '\t' }
+        .trim()
+        .take(MAX_REASON_LEN)
+}

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionCoordinator.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionCoordinator.kt
@@ -21,6 +21,9 @@ class SessionCoordinator(
     @Volatile
     private var latestState: SessionResult = SessionSerializer.idleState()
 
+    val hasActiveSession: Boolean
+        get() = manager.activeSession != null
+
     /** Publishes current state after MQTT connects; a fresh process naturally reports idle. */
     @Synchronized
     fun publishCurrentState() {

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionCoordinator.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionCoordinator.kt
@@ -1,0 +1,99 @@
+package com.iblu01.portallauncher.session
+
+/** Runtime boundary used by [SessionCoordinator]. Android and MQTT stay behind this interface. */
+interface SessionRuntime {
+    fun publishEvent(result: SessionResult)
+    fun publishState(result: SessionResult)
+    fun launchApp(packageName: String): Boolean
+    fun returnToLauncher(): Boolean
+}
+
+/**
+ * Coordinates strict command parsing, the pure session state machine, MQTT publication, and
+ * exactly-once runtime side effects.
+ */
+class SessionCoordinator(
+    private val manager: SessionManager,
+    private val allowlist: SessionAllowlist,
+    private val timeSource: SessionTimeSource,
+    private val runtime: SessionRuntime,
+) {
+    @Volatile
+    private var latestState: SessionResult = SessionSerializer.idleState()
+
+    /** Publishes current state after MQTT connects; a fresh process naturally reports idle. */
+    @Synchronized
+    fun publishCurrentState() {
+        runtime.publishState(latestState)
+    }
+
+    @Synchronized
+    fun setEnabled(enabled: Boolean) {
+        apply(manager.setSessionsEnabled(enabled))
+    }
+
+    /** Empty retained-command clears are ignored rather than parsed as commands. */
+    @Synchronized
+    fun onCommand(payload: String): Boolean {
+        if (payload.isBlank()) return false
+        when (val parsed = SessionCommandParser.parse(payload, timeSource.now(), allowlist)) {
+            is SessionCommandParser.ParseResult.Valid -> apply(manager.process(parsed.command))
+            is SessionCommandParser.ParseResult.Invalid -> publish(
+                SessionResult(
+                    lifecycle = SessionLifecycle.REJECTED,
+                    requestId = "",
+                    packageName = null,
+                    expiresAtMs = null,
+                    reason = null,
+                    code = parsed.code,
+                )
+            )
+        }
+        return true
+    }
+
+    @Synchronized
+    fun onDeviceState(foregroundPackage: String?) {
+        apply(manager.onDeviceState(foregroundPackage))
+    }
+
+    private fun apply(transitions: List<SessionTransition>) {
+        transitions.forEach { transition ->
+            publish(transition.result)
+            transition.sideEffects.forEach { effect ->
+                val failure = when (effect) {
+                    is SessionSideEffect.LaunchApp -> {
+                        if (runtime.launchApp(effect.packageName)) null
+                        else SessionRejectionCode.LAUNCH_FAILED
+                    }
+                    SessionSideEffect.ReturnToLauncher -> {
+                        if (runtime.returnToLauncher()) {
+                            manager.onReturnToLauncher().forEach { publish(it.result) }
+                            null
+                        } else SessionRejectionCode.RETURN_TO_LAUNCHER_FAILED
+                    }
+                }
+                if (failure != null) {
+                    val failed = manager.failActive(failure)
+                    if (failed.isEmpty()) {
+                        publish(
+                            transition.result.copy(
+                                lifecycle = SessionLifecycle.FAILED,
+                                expiresAtMs = null,
+                                code = failure,
+                            )
+                        )
+                    } else {
+                        failed.forEach { publish(it.result) }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun publish(result: SessionResult) {
+        latestState = result
+        runtime.publishEvent(result)
+        runtime.publishState(result)
+    }
+}

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionManager.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionManager.kt
@@ -337,8 +337,8 @@ class SessionManager(
         a.requestId == b.requestId &&
             a.action == b.action &&
             a.packageName == b.packageName &&
-            a.durationSeconds == b.durationSeconds &&
-            a.expiresAtMs == b.expiresAtMs &&
+            a.requestedDurationSeconds == b.requestedDurationSeconds &&
+            a.requestedExpiresAtSeconds == b.requestedExpiresAtSeconds &&
             a.reason == b.reason
 
     private fun isActiveLifecycle(lifecycle: SessionLifecycle): Boolean =

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionManager.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionManager.kt
@@ -1,0 +1,336 @@
+package com.iblu01.portallauncher.session
+
+import java.util.LinkedHashMap
+
+/**
+ * Pure, in-memory state machine for bounded external-app sessions.
+ *
+ * Responsibilities:
+ * - enforce one session at a time,
+ * - enforce the local kill switch,
+ * - drive the lifecycle (accepted → launching → active → ending → completed),
+ * - handle expiry and cancellation,
+ * - replay results for duplicate [request_id] without side effects,
+ * - ask the runtime to perform [SessionSideEffect] via returned transitions.
+ *
+ * The manager does not touch Android APIs, Context or MQTT directly. It is instantiated once per
+ * process; a restart loses any incomplete session intentionally.
+ */
+class SessionManager(
+    private val timeSource: SessionTimeSource,
+    private val allowlist: SessionAllowlist,
+    private val launcherPackage: String,
+    private val rateLimitMs: Long = 200L,
+    private val idempotencyTtlMs: Long = 5 * 60_000L,
+    private val maxIdempotencyEntries: Int = 100,
+) {
+
+    private data class CurrentSession(
+        val command: SessionCommand,
+        val classification: AppClassification,
+        val startedAtMs: Long,
+        var lifecycle: SessionLifecycle,
+        var endingCommand: SessionCommand? = null,
+    )
+
+    private data class ResultRecord(
+        val command: SessionCommand,
+        val result: SessionResult,
+        val recordedAtMs: Long,
+    )
+
+    private val lock = Object()
+
+    @Volatile
+    private var currentSession: CurrentSession? = null
+    private val results = LinkedHashMap<String, ResultRecord>()
+    @Volatile
+    private var sessionsEnabled: Boolean = false
+    private var lastCommandAtMs: Long = 0L
+
+    /**
+     * Toggles the local kill switch. Disabling an active session forces it to end.
+     */
+    fun setSessionsEnabled(enabled: Boolean): List<SessionTransition> = synchronized(lock) {
+        sessionsEnabled = enabled
+        if (!enabled) {
+            val session = currentSession ?: return@synchronized emptyList<SessionTransition>()
+            killActiveSession(session, timeSource.now())
+        } else {
+            emptyList()
+        }
+    }
+
+    fun process(command: SessionCommand): List<SessionTransition> = synchronized(lock) {
+        val now = timeSource.now()
+        cleanIdempotency(now)
+
+        val existing = results[command.requestId]
+        if (existing != null) {
+            return if (commandsMatch(existing.command, command)) {
+                listOf(SessionTransition(existing.result, emptyList()))
+            } else {
+                // Preserve the original request-ID binding; conflicts are never cached over it.
+                listOf(rejected(command, SessionRejectionCode.REQUEST_ID_CONFLICT))
+            }
+        }
+
+        if (now - lastCommandAtMs < rateLimitMs) {
+            return rememberLast(listOf(rejected(command, SessionRejectionCode.RATE_LIMITED)), command, now)
+        }
+        lastCommandAtMs = now
+
+        when (command.action) {
+            SessionAction.START -> start(command, now)
+            SessionAction.END, SessionAction.CANCEL -> endOrCancel(command, now)
+        }
+    }
+
+    /**
+     * Should be called on every foreground-package change and periodically. It transitions
+     * launching → active when the requested app reaches the foreground, and ending → completed
+     * when the launcher returns to the foreground.
+     */
+    fun onDeviceState(
+        foregroundPackage: String?,
+        nowMs: Long = timeSource.now(),
+    ): List<SessionTransition> = synchronized(lock) {
+        val transitions = mutableListOf<SessionTransition>()
+        val session = currentSession ?: return transitions
+
+        if (nowMs >= session.command.expiresAtMs) {
+            transitions += expire(session, nowMs)
+            return transitions
+        }
+
+        when (session.lifecycle) {
+            SessionLifecycle.LAUNCHING -> {
+                if (foregroundPackage == session.command.packageName) {
+                    session.lifecycle = SessionLifecycle.ACTIVE
+                    val result = SessionResult(
+                        lifecycle = SessionLifecycle.ACTIVE,
+                        requestId = session.command.requestId,
+                        packageName = session.command.packageName,
+                        expiresAtMs = session.command.expiresAtMs,
+                        reason = session.command.reason,
+                    )
+                    rememberResult(session.command, result, nowMs)
+                    session.endingCommand?.let {
+                        rememberResult(it, result.copy(requestId = it.requestId, reason = it.reason), nowMs)
+                    }
+                    transitions += SessionTransition(result, emptyList())
+                }
+            }
+            SessionLifecycle.ENDING -> {
+                if (foregroundPackage == launcherPackage || foregroundPackage == null) {
+                    currentSession = null
+                    val result = SessionResult(
+                        lifecycle = SessionLifecycle.COMPLETED,
+                        requestId = session.command.requestId,
+                        packageName = session.command.packageName,
+                        expiresAtMs = null,
+                        reason = session.command.reason,
+                    )
+                    rememberResult(session.command, result, nowMs)
+                    session.endingCommand?.let {
+                        rememberResult(it, result.copy(requestId = it.requestId, reason = it.reason), nowMs)
+                    }
+                    transitions += SessionTransition(result, emptyList())
+                }
+            }
+            else -> Unit
+        }
+        transitions
+    }
+
+    /**
+     * Called by the runtime once it has initiated a return to the launcher. Mirrors the transition
+     * in [onDeviceState] but does not require a foreground-package report.
+     */
+    fun onReturnToLauncher(nowMs: Long = timeSource.now()): List<SessionTransition> = synchronized(lock) {
+        val session = currentSession ?: return emptyList()
+        if (session.lifecycle != SessionLifecycle.ENDING) return emptyList()
+        currentSession = null
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.COMPLETED,
+            requestId = session.command.requestId,
+            packageName = session.command.packageName,
+            expiresAtMs = null,
+            reason = session.command.reason,
+        )
+        rememberResult(session.command, result, nowMs)
+        session.endingCommand?.let {
+            rememberResult(it, result.copy(requestId = it.requestId, reason = it.reason), nowMs)
+        }
+        return listOf(SessionTransition(result, emptyList()))
+    }
+
+    val isEnabled: Boolean get() = synchronized(lock) { sessionsEnabled }
+
+    val activeSession: SessionResult? get() = synchronized(lock) {
+        currentSession?.let {
+            SessionResult(
+                lifecycle = it.lifecycle,
+                requestId = it.command.requestId,
+                packageName = it.command.packageName,
+                expiresAtMs = it.command.expiresAtMs,
+                reason = it.command.reason,
+            )
+        }
+    }
+
+    private fun start(command: SessionCommand, nowMs: Long): List<SessionTransition> {
+        if (!sessionsEnabled) {
+            return rememberLast(listOf(rejected(command, SessionRejectionCode.KILL_SWITCH_DISABLED)), command, nowMs)
+        }
+        if (currentSession != null) {
+            return rememberLast(listOf(rejected(command, SessionRejectionCode.SESSION_ALREADY_ACTIVE)), command, nowMs)
+        }
+        val classification = allowlist.classificationFor(command.packageName)
+            ?: return rememberLast(listOf(rejected(command, SessionRejectionCode.UNKNOWN_PACKAGE)), command, nowMs)
+        if (command.expiresAtMs <= nowMs) {
+            return rememberLast(listOf(rejected(command, SessionRejectionCode.EXPIRED_BEFORE_LAUNCH)), command, nowMs)
+        }
+
+        val session = CurrentSession(
+            command = command,
+            classification = classification,
+            startedAtMs = nowMs,
+            lifecycle = SessionLifecycle.ACCEPTED,
+        )
+        currentSession = session
+        session.lifecycle = SessionLifecycle.LAUNCHING
+
+        val accepted = SessionTransition(
+            SessionResult(
+                lifecycle = SessionLifecycle.ACCEPTED,
+                requestId = command.requestId,
+                packageName = command.packageName,
+                expiresAtMs = command.expiresAtMs,
+                reason = command.reason,
+            ),
+            emptyList(),
+        )
+        val launching = SessionTransition(
+            SessionResult(
+                lifecycle = SessionLifecycle.LAUNCHING,
+                requestId = command.requestId,
+                packageName = command.packageName,
+                expiresAtMs = command.expiresAtMs,
+                reason = command.reason,
+            ),
+            sideEffects = listOf(SessionSideEffect.LaunchApp(command.packageName)),
+        )
+        return rememberLast(listOf(accepted, launching), command, nowMs)
+    }
+
+    private fun endOrCancel(command: SessionCommand, nowMs: Long): List<SessionTransition> {
+        val session = currentSession
+        if (session == null) {
+            return rememberLast(listOf(rejected(command, SessionRejectionCode.NO_ACTIVE_SESSION)), command, nowMs)
+        }
+        if (session.lifecycle == SessionLifecycle.ENDING) {
+            return rememberLast(listOf(rejected(command, SessionRejectionCode.SESSION_ALREADY_ENDING)), command, nowMs)
+        }
+        if (!isActiveLifecycle(session.lifecycle)) {
+            return rememberLast(listOf(rejected(command, SessionRejectionCode.NO_ACTIVE_SESSION)), command, nowMs)
+        }
+        if (session.command.packageName != command.packageName) {
+            return rememberLast(listOf(rejected(command, SessionRejectionCode.PACKAGE_MISMATCH)), command, nowMs)
+        }
+
+        session.lifecycle = SessionLifecycle.ENDING
+        session.endingCommand = command
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.ENDING,
+            requestId = command.requestId,
+            packageName = session.command.packageName,
+            expiresAtMs = session.command.expiresAtMs,
+            reason = command.reason,
+        )
+        rememberResult(
+            session.command,
+            result.copy(requestId = session.command.requestId, reason = session.command.reason),
+            nowMs,
+        )
+        rememberResult(command, result, nowMs)
+        return listOf(SessionTransition(result, listOf(SessionSideEffect.ReturnToLauncher)))
+    }
+
+    private fun expire(session: CurrentSession, nowMs: Long): List<SessionTransition> {
+        currentSession = null
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.EXPIRED,
+            requestId = session.command.requestId,
+            packageName = session.command.packageName,
+            expiresAtMs = session.command.expiresAtMs,
+            reason = null,
+        )
+        rememberResult(session.command, result, nowMs)
+        return listOf(
+            SessionTransition(
+                result,
+                sideEffects = if (session.lifecycle == SessionLifecycle.LAUNCHING || session.lifecycle == SessionLifecycle.ACTIVE) {
+                    listOf(SessionSideEffect.ReturnToLauncher)
+                } else {
+                    emptyList()
+                },
+            ),
+        )
+    }
+
+    private fun killActiveSession(session: CurrentSession, nowMs: Long): List<SessionTransition> {
+        session.lifecycle = SessionLifecycle.ENDING
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.ENDING,
+            requestId = session.command.requestId,
+            packageName = session.command.packageName,
+            expiresAtMs = session.command.expiresAtMs,
+            reason = session.command.reason,
+        )
+        rememberResult(session.command, result, nowMs)
+        return listOf(SessionTransition(result, listOf(SessionSideEffect.ReturnToLauncher)))
+    }
+
+    private fun cleanIdempotency(nowMs: Long) {
+        val cutoff = nowMs - idempotencyTtlMs
+        results.entries.removeAll { it.value.recordedAtMs < cutoff }
+        while (results.size > maxIdempotencyEntries) {
+            results.remove(results.keys.first())
+        }
+    }
+
+    private fun rememberLast(transitions: List<SessionTransition>, command: SessionCommand, nowMs: Long): List<SessionTransition> {
+        transitions.lastOrNull()?.let { rememberResult(command, it.result, nowMs) }
+        return transitions
+    }
+
+    private fun rememberResult(command: SessionCommand, result: SessionResult, nowMs: Long) {
+        results[command.requestId] = ResultRecord(command, result, nowMs)
+    }
+
+    private fun commandsMatch(a: SessionCommand, b: SessionCommand): Boolean =
+        a.requestId == b.requestId &&
+            a.action == b.action &&
+            a.packageName == b.packageName &&
+            a.durationSeconds == b.durationSeconds &&
+            a.expiresAtMs == b.expiresAtMs &&
+            a.reason == b.reason
+
+    private fun isActiveLifecycle(lifecycle: SessionLifecycle): Boolean =
+        lifecycle == SessionLifecycle.ACCEPTED ||
+            lifecycle == SessionLifecycle.LAUNCHING ||
+            lifecycle == SessionLifecycle.ACTIVE
+
+    private fun rejected(command: SessionCommand, code: SessionRejectionCode): SessionTransition = SessionTransition(
+        SessionResult(
+            lifecycle = SessionLifecycle.REJECTED,
+            requestId = command.requestId,
+            packageName = command.packageName,
+            expiresAtMs = command.expiresAtMs,
+            reason = command.reason,
+            code = code,
+        ),
+        emptyList(),
+    )
+}

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionManager.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionManager.kt
@@ -98,7 +98,9 @@ class SessionManager(
         val transitions = mutableListOf<SessionTransition>()
         val session = currentSession ?: return transitions
 
-        if (nowMs >= session.command.expiresAtMs) {
+        // Once return has begun, completion/failure owns the terminal outcome. Do not overwrite an
+        // ENDING session with EXPIRED while Portal is coming back to the foreground.
+        if (session.lifecycle != SessionLifecycle.ENDING && nowMs >= session.command.expiresAtMs) {
             transitions += expire(session, nowMs)
             return transitions
         }
@@ -163,6 +165,28 @@ class SessionManager(
             rememberResult(it, result.copy(requestId = it.requestId, reason = it.reason), nowMs)
         }
         return listOf(SessionTransition(result, emptyList()))
+    }
+
+    /** Ends the current session after a bounded runtime-side failure. */
+    fun failActive(
+        code: SessionRejectionCode,
+        nowMs: Long = timeSource.now(),
+    ): List<SessionTransition> = synchronized(lock) {
+        val session = currentSession ?: return emptyList()
+        currentSession = null
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.FAILED,
+            requestId = session.command.requestId,
+            packageName = session.command.packageName,
+            expiresAtMs = null,
+            reason = session.command.reason,
+            code = code,
+        )
+        rememberResult(session.command, result, nowMs)
+        session.endingCommand?.let {
+            rememberResult(it, result.copy(requestId = it.requestId, reason = it.reason), nowMs)
+        }
+        listOf(SessionTransition(result))
     }
 
     val isEnabled: Boolean get() = synchronized(lock) { sessionsEnabled }

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionMqttContract.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionMqttContract.kt
@@ -1,0 +1,32 @@
+package com.iblu01.portallauncher.session
+
+import org.eclipse.paho.client.mqttv3.MqttMessage
+
+/**
+ * MQTT envelope rules for the app-session topics.
+ *
+ * - command topic: QoS 1, non-retained for incoming commands. The broker clear-message is retained so
+ *   a stale retained command cannot be replayed after a reconnect.
+ * - event topic: QoS 1, never retained (transient events).
+ * - state topic: QoS 1, always retained (last-known state).
+ */
+object SessionMqttContract {
+    const val COMMAND_QOS = 1
+    const val EVENT_QOS = 1
+    const val STATE_QOS = 1
+
+    fun commandClearMessage(): MqttMessage = MqttMessage(ByteArray(0)).apply {
+        qos = COMMAND_QOS
+        isRetained = true
+    }
+
+    fun eventMessage(payload: String): MqttMessage = MqttMessage(payload.toByteArray()).apply {
+        qos = EVENT_QOS
+        isRetained = false
+    }
+
+    fun stateMessage(payload: String): MqttMessage = MqttMessage(payload.toByteArray()).apply {
+        qos = STATE_QOS
+        isRetained = true
+    }
+}

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionSerializer.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionSerializer.kt
@@ -1,0 +1,45 @@
+package com.iblu01.portallauncher.session
+
+import org.json.JSONObject
+
+/**
+ * Serializes session results to the sanitized event/state JSON.
+ *
+ * Only the bounded fields are emitted: schema_version, lifecycle, request_id, package,
+ * expires_at (epoch seconds), reason, and code. `null` values are written as JSON `null` so consumers
+ * see a stable schema even when no session is active.
+ */
+object SessionSerializer {
+    private const val SCHEMA_VERSION = 1
+    private const val MAX_REASON_LEN = 120
+
+    fun toJson(result: SessionResult): String {
+        val obj = JSONObject()
+        obj.put("schema_version", SCHEMA_VERSION)
+        obj.put("lifecycle", result.lifecycle.name.lowercase())
+        obj.put("request_id", result.requestId.ifEmpty { JSONObject.NULL })
+        obj.put("package", result.packageName ?: JSONObject.NULL)
+        obj.put("expires_at", result.expiresAtMs?.let { it / 1000 } ?: JSONObject.NULL)
+        obj.put("reason", result.reason?.let { sanitizeReason(it) } ?: JSONObject.NULL)
+        obj.put("code", result.code?.name?.lowercase() ?: JSONObject.NULL)
+        return obj.toString()
+    }
+
+    private fun sanitizeReason(value: String): String = value
+        .filter { it.code >= 32 || it == '\t' }
+        .trim()
+        .take(MAX_REASON_LEN)
+
+    /**
+     * The payload to publish when no session is active after a restart. The lifecycle is
+     * `completed` because a restart intentionally ends any incomplete session and never resumes it.
+     */
+    fun idleState(): SessionResult = SessionResult(
+        lifecycle = SessionLifecycle.COMPLETED,
+        requestId = "",
+        packageName = null,
+        expiresAtMs = null,
+        reason = null,
+        code = null,
+    )
+}

--- a/app/src/main/java/com/iblu01/portallauncher/session/SessionTimeSource.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/session/SessionTimeSource.kt
@@ -1,0 +1,12 @@
+package com.iblu01.portallauncher.session
+
+/**
+ * Abstraction over wall-clock time so the session manager can be tested deterministically.
+ */
+interface SessionTimeSource {
+    fun now(): Long
+}
+
+object RealSessionTimeSource : SessionTimeSource {
+    override fun now(): Long = System.currentTimeMillis()
+}

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
@@ -74,6 +74,10 @@ import com.iblu01.portallauncher.HaEntity
 import com.iblu01.portallauncher.PillRule
 import com.iblu01.portallauncher.PillCandidate
 import com.iblu01.portallauncher.AutoReturnUiState
+import com.iblu01.portallauncher.MqttBridgeService
+import com.iblu01.portallauncher.session.AppClassification
+import com.iblu01.portallauncher.session.SessionAllowlist
+import com.iblu01.portallauncher.session.SessionAllowlistCodec
 import com.iblu01.portallauncher.ui.components.AppEntry
 import com.iblu01.portallauncher.ui.components.AppPickerDialog
 import com.iblu01.portallauncher.ui.components.AutoReturnOverlay
@@ -206,8 +210,12 @@ fun SettingsScreen(
     var autoReturnEnabled by remember { mutableStateOf(prefs.autoReturnEnabled) }
     var autoReturnDelay by remember { mutableStateOf(prefs.autoReturnDelaySeconds.toFloat()) }
     var gridScale by remember { mutableStateOf(prefs.gridScale) }
+    var appSessionsEnabled by remember { mutableStateOf(prefs.appSessionsEnabled) }
+    var sessionAllowlist by remember { mutableStateOf(prefs.appSessionAllowlist.toMap()) }
+    val context = LocalContext.current
 
     var showAppPicker by remember { mutableStateOf(false) }
+    var showSessionAppPicker by remember { mutableStateOf(false) }
 
     val save = {
         callbacks.onSave(
@@ -253,6 +261,22 @@ fun SettingsScreen(
             selectedPackage = haPackage,
             onDismiss = { showAppPicker = false },
             onAppSelected = { app -> haPackage = app.packageName; showAppPicker = false }
+        )
+    }
+    if (showSessionAppPicker) {
+        AppPickerDialog(
+            apps = installedApps,
+            selectedPackage = "",
+            onDismiss = { showSessionAppPicker = false },
+            onAppSelected = { app ->
+                val updated = sessionAllowlist + (app.packageName to AppClassification.UTILITY)
+                if (updated.size <= SessionAllowlistCodec.MAX_ENTRIES) {
+                    sessionAllowlist = updated
+                    prefs.appSessionAllowlist = SessionAllowlist(updated)
+                    MqttBridgeService.reconnect(context)
+                }
+                showSessionAppPicker = false
+            }
         )
     }
 
@@ -313,6 +337,32 @@ fun SettingsScreen(
                 onAutoReturnEnabledChange = { autoReturnEnabled = it; prefs.autoReturnEnabled = it },
                 autoReturnDelay = autoReturnDelay,
                 onAutoReturnDelayChange = { autoReturnDelay = it; prefs.autoReturnDelaySeconds = it.toInt() },
+                appSessionsEnabled = appSessionsEnabled,
+                onAppSessionsEnabledChange = {
+                    appSessionsEnabled = it
+                    prefs.appSessionsEnabled = it
+                    MqttBridgeService.reconnect(context)
+                },
+                sessionAllowlist = sessionAllowlist,
+                onAddSessionApp = { showSessionAppPicker = true },
+                onCycleSessionClassification = { packageName ->
+                    val current = sessionAllowlist[packageName] ?: AppClassification.UTILITY
+                    val next = when (current) {
+                        AppClassification.HOME -> AppClassification.MEDIA
+                        AppClassification.MEDIA -> AppClassification.UTILITY
+                        AppClassification.UTILITY -> AppClassification.COMMUNICATION
+                        AppClassification.COMMUNICATION -> AppClassification.HOME
+                    }
+                    val updated = sessionAllowlist + (packageName to next)
+                    sessionAllowlist = updated
+                    prefs.appSessionAllowlist = SessionAllowlist(updated)
+                    MqttBridgeService.reconnect(context)
+                },
+                onClearSessionApps = {
+                    sessionAllowlist = emptyMap()
+                    prefs.appSessionAllowlist = SessionAllowlist(emptyMap())
+                    MqttBridgeService.reconnect(context)
+                },
                 gridScale = gridScale,
                 onGridScaleChange = { gridScale = it; prefs.gridScale = it },
                 onBack = { currentPage = SettingsPage.MAIN },
@@ -441,6 +491,11 @@ private fun AppPage(
     timeoutMinutes: Float, onTimeoutMinutesChange: (Float) -> Unit,
     autoReturnEnabled: Boolean, onAutoReturnEnabledChange: (Boolean) -> Unit,
     autoReturnDelay: Float, onAutoReturnDelayChange: (Float) -> Unit,
+    appSessionsEnabled: Boolean, onAppSessionsEnabledChange: (Boolean) -> Unit,
+    sessionAllowlist: Map<String, AppClassification>,
+    onAddSessionApp: () -> Unit,
+    onCycleSessionClassification: (String) -> Unit,
+    onClearSessionApps: () -> Unit,
     gridScale: Float = 1f, onGridScaleChange: (Float) -> Unit = {},
     onBack: () -> Unit,
     showBack: Boolean = true,
@@ -556,6 +611,48 @@ private fun AppPage(
                 label = stringResource(R.string.settings_app_label_app_to_open),
                 value = currentAppLabel.ifBlank { haPackage },
                 onClick = onShowAppPicker,
+            )
+        }
+
+        SettingsSection(title = stringResource(R.string.settings_app_section_sessions)) {
+            SettingsToggle(
+                label = stringResource(R.string.settings_app_sessions_enabled),
+                checked = appSessionsEnabled,
+                onCheckedChange = onAppSessionsEnabledChange,
+            )
+            SettingsDivider()
+            if (sessionAllowlist.isEmpty()) {
+                SettingsRow(
+                    label = stringResource(R.string.settings_app_sessions_empty),
+                    value = "",
+                    onClick = onAddSessionApp,
+                )
+            } else {
+                Text(
+                    text = stringResource(R.string.settings_app_sessions_cycle_hint),
+                    style = AppleTypography.bodySmall,
+                    color = AppleColors.secondary,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                sessionAllowlist.toSortedMap().forEach { (packageName, classification) ->
+                    SettingsRow(
+                        label = packageName,
+                        value = classification.name.lowercase(),
+                        onClick = { onCycleSessionClassification(packageName) },
+                    )
+                }
+                SettingsDivider()
+                SettingsRow(
+                    label = stringResource(R.string.settings_app_sessions_clear),
+                    value = "",
+                    onClick = onClearSessionApps,
+                )
+            }
+            SettingsDivider()
+            SettingsRow(
+                label = stringResource(R.string.settings_app_sessions_add),
+                value = "",
+                onClick = onAddSessionApp,
             )
         }
 

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
@@ -156,6 +156,8 @@ private enum class SettingsPage { MAIN, HOME, PILLS, APPLICATION, DEVELOPER, SET
 /** Best-effort host extraction used to pre-fill the MQTT broker from the HA address. */
 private fun hostOf(url: String): String = runCatching { URL(url.trim()).host }.getOrDefault("")
 
+internal fun shouldShowAppSessions(mqttHost: String): Boolean = mqttHost.isNotBlank()
+
 private data class TileDef(
     val page: SettingsPage,
     val icon: ImageVector,
@@ -216,6 +218,7 @@ fun SettingsScreen(
 
     var showAppPicker by remember { mutableStateOf(false) }
     var showSessionAppPicker by remember { mutableStateOf(false) }
+    var sessionClassificationTarget by remember { mutableStateOf<String?>(null) }
 
     val save = {
         callbacks.onSave(
@@ -269,14 +272,26 @@ fun SettingsScreen(
             selectedPackage = "",
             onDismiss = { showSessionAppPicker = false },
             onAppSelected = { app ->
-                val updated = sessionAllowlist + (app.packageName to AppClassification.UTILITY)
+                showSessionAppPicker = false
+                sessionClassificationTarget = app.packageName
+            }
+        )
+    }
+    sessionClassificationTarget?.let { packageName ->
+        val appLabel = installedApps.firstOrNull { it.packageName == packageName }?.label ?: packageName
+        SessionClassificationDialog(
+            appLabel = appLabel,
+            current = sessionAllowlist[packageName],
+            onDismiss = { sessionClassificationTarget = null },
+            onSelected = { classification ->
+                val updated = sessionAllowlist + (packageName to classification)
                 if (updated.size <= SessionAllowlistCodec.MAX_ENTRIES) {
                     sessionAllowlist = updated
                     prefs.appSessionAllowlist = SessionAllowlist(updated)
                     MqttBridgeService.reconnect(context)
                 }
-                showSessionAppPicker = false
-            }
+                sessionClassificationTarget = null
+            },
         )
     }
 
@@ -338,6 +353,8 @@ fun SettingsScreen(
                 autoReturnDelay = autoReturnDelay,
                 onAutoReturnDelayChange = { autoReturnDelay = it; prefs.autoReturnDelaySeconds = it.toInt() },
                 appSessionsEnabled = appSessionsEnabled,
+                mqttConfigured = shouldShowAppSessions(host),
+                installedApps = installedApps,
                 onAppSessionsEnabledChange = {
                     appSessionsEnabled = it
                     prefs.appSessionsEnabled = it
@@ -345,19 +362,7 @@ fun SettingsScreen(
                 },
                 sessionAllowlist = sessionAllowlist,
                 onAddSessionApp = { showSessionAppPicker = true },
-                onCycleSessionClassification = { packageName ->
-                    val current = sessionAllowlist[packageName] ?: AppClassification.UTILITY
-                    val next = when (current) {
-                        AppClassification.HOME -> AppClassification.MEDIA
-                        AppClassification.MEDIA -> AppClassification.UTILITY
-                        AppClassification.UTILITY -> AppClassification.COMMUNICATION
-                        AppClassification.COMMUNICATION -> AppClassification.HOME
-                    }
-                    val updated = sessionAllowlist + (packageName to next)
-                    sessionAllowlist = updated
-                    prefs.appSessionAllowlist = SessionAllowlist(updated)
-                    MqttBridgeService.reconnect(context)
-                },
+                onSelectSessionClassification = { sessionClassificationTarget = it },
                 onClearSessionApps = {
                     sessionAllowlist = emptyMap()
                     prefs.appSessionAllowlist = SessionAllowlist(emptyMap())
@@ -492,9 +497,11 @@ private fun AppPage(
     autoReturnEnabled: Boolean, onAutoReturnEnabledChange: (Boolean) -> Unit,
     autoReturnDelay: Float, onAutoReturnDelayChange: (Float) -> Unit,
     appSessionsEnabled: Boolean, onAppSessionsEnabledChange: (Boolean) -> Unit,
+    mqttConfigured: Boolean,
+    installedApps: List<AppEntry>,
     sessionAllowlist: Map<String, AppClassification>,
     onAddSessionApp: () -> Unit,
-    onCycleSessionClassification: (String) -> Unit,
+    onSelectSessionClassification: (String) -> Unit,
     onClearSessionApps: () -> Unit,
     gridScale: Float = 1f, onGridScaleChange: (Float) -> Unit = {},
     onBack: () -> Unit,
@@ -614,7 +621,7 @@ private fun AppPage(
             )
         }
 
-        SettingsSection(title = stringResource(R.string.settings_app_section_sessions)) {
+        if (mqttConfigured) SettingsSection(title = stringResource(R.string.settings_app_section_sessions)) {
             SettingsToggle(
                 label = stringResource(R.string.settings_app_sessions_enabled),
                 checked = appSessionsEnabled,
@@ -628,17 +635,18 @@ private fun AppPage(
                     onClick = onAddSessionApp,
                 )
             } else {
-                Text(
-                    text = stringResource(R.string.settings_app_sessions_cycle_hint),
-                    style = AppleTypography.bodySmall,
-                    color = AppleColors.secondary,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                )
                 sessionAllowlist.toSortedMap().forEach { (packageName, classification) ->
+                    val appLabel = installedApps.firstOrNull { it.packageName == packageName }?.label
+                        ?: packageName
                     SettingsRow(
-                        label = packageName,
-                        value = classification.name.lowercase(),
-                        onClick = { onCycleSessionClassification(packageName) },
+                        label = appLabel,
+                        value = stringResource(
+                            R.string.settings_app_sessions_classification_value,
+                            stringResource(classification.labelRes()),
+                            classification.defaultDurationSeconds,
+                            classification.maxDurationSeconds,
+                        ),
+                        onClick = { onSelectSessionClassification(packageName) },
                     )
                 }
                 SettingsDivider()
@@ -842,6 +850,63 @@ private fun AppPage(
         }
 
     }
+}
+
+private fun AppClassification.labelRes(): Int = when (this) {
+    AppClassification.HOME -> R.string.settings_app_sessions_class_home
+    AppClassification.MEDIA -> R.string.settings_app_sessions_class_media
+    AppClassification.UTILITY -> R.string.settings_app_sessions_class_utility
+    AppClassification.COMMUNICATION -> R.string.settings_app_sessions_class_communication
+}
+
+@Composable
+private fun SessionClassificationDialog(
+    appLabel: String,
+    current: AppClassification?,
+    onDismiss: () -> Unit,
+    onSelected: (AppClassification) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_app_sessions_choose_class, appLabel)) },
+        text = {
+            Column {
+                AppClassification.entries.forEach { classification ->
+                    TextButton(
+                        onClick = { onSelected(classification) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                text = if (classification == current) {
+                                    "✓ ${stringResource(classification.labelRes())}"
+                                } else {
+                                    stringResource(classification.labelRes())
+                                },
+                                color = AppleColors.primary,
+                                style = AppleTypography.titleMedium,
+                            )
+                            Text(
+                                text = stringResource(
+                                    R.string.settings_app_sessions_duration_consequence,
+                                    classification.defaultDurationSeconds,
+                                    classification.maxDurationSeconds,
+                                ),
+                                color = AppleColors.secondary,
+                                style = AppleTypography.bodySmall,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_app_sessions_cancel))
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -437,6 +437,12 @@
     <string name="notification_content_title">Portal Launcher</string>
     <string name="power_mode_always_on">Always on</string>
     <string name="power_mode_follow_presence">Follow presence</string>
+    <string name="settings_app_section_sessions">Sessions d’applications externes</string>
+    <string name="settings_app_sessions_enabled">Autoriser les sessions MQTT limitées</string>
+    <string name="settings_app_sessions_add">Ajouter une application autorisée</string>
+    <string name="settings_app_sessions_empty">Aucune application autorisée</string>
+    <string name="settings_app_sessions_clear">Effacer les applications autorisées</string>
+    <string name="settings_app_sessions_cycle_hint">Touchez une application pour changer sa classification</string>
 
     <!-- ===== PILL PRIORITY ENGINE (Dynamic Labels) ===== -->
     <string name="presence_home">À la maison</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -443,6 +443,14 @@
     <string name="settings_app_sessions_empty">Aucune application autorisée</string>
     <string name="settings_app_sessions_clear">Effacer les applications autorisées</string>
     <string name="settings_app_sessions_cycle_hint">Touchez une application pour changer sa classification</string>
+    <string name="settings_app_sessions_choose_class">Choisir le type de session pour %1$s</string>
+    <string name="settings_app_sessions_class_home">Accueil</string>
+    <string name="settings_app_sessions_class_media">Média</string>
+    <string name="settings_app_sessions_class_utility">Utilitaire</string>
+    <string name="settings_app_sessions_class_communication">Communication</string>
+    <string name="settings_app_sessions_classification_value">%1$s · %2$d s par défaut · %3$d s max.</string>
+    <string name="settings_app_sessions_duration_consequence">%1$d s par défaut · %2$d s maximum</string>
+    <string name="settings_app_sessions_cancel">Annuler</string>
 
     <!-- ===== PILL PRIORITY ENGINE (Dynamic Labels) ===== -->
     <string name="presence_home">À la maison</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,6 +448,14 @@
     <string name="settings_app_sessions_empty">No apps allowed</string>
     <string name="settings_app_sessions_clear">Clear allowed apps</string>
     <string name="settings_app_sessions_cycle_hint">Tap an app to change its classification</string>
+    <string name="settings_app_sessions_choose_class">Choose session type for %1$s</string>
+    <string name="settings_app_sessions_class_home">Home</string>
+    <string name="settings_app_sessions_class_media">Media</string>
+    <string name="settings_app_sessions_class_utility">Utility</string>
+    <string name="settings_app_sessions_class_communication">Communication</string>
+    <string name="settings_app_sessions_classification_value">%1$s · %2$d s default · %3$d s max</string>
+    <string name="settings_app_sessions_duration_consequence">%1$d s default · %2$d s maximum</string>
+    <string name="settings_app_sessions_cancel">Cancel</string>
 
     <!-- ===== PILL PRIORITY ENGINE (Dynamic Labels) ===== -->
     <string name="presence_home">At home</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -442,6 +442,12 @@
     <string name="notification_content_title">Portal Launcher</string>
     <string name="power_mode_always_on">Always on</string>
     <string name="power_mode_follow_presence">Follow presence</string>
+    <string name="settings_app_section_sessions">External app sessions</string>
+    <string name="settings_app_sessions_enabled">Allow bounded MQTT app sessions</string>
+    <string name="settings_app_sessions_add">Add allowed app</string>
+    <string name="settings_app_sessions_empty">No apps allowed</string>
+    <string name="settings_app_sessions_clear">Clear allowed apps</string>
+    <string name="settings_app_sessions_cycle_hint">Tap an app to change its classification</string>
 
     <!-- ===== PILL PRIORITY ENGINE (Dynamic Labels) ===== -->
     <string name="presence_home">At home</string>

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionAllowlistCodecTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionAllowlistCodecTest.kt
@@ -1,0 +1,46 @@
+package com.iblu01.portallauncher.session
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SessionAllowlistCodecTest {
+    @Test fun `round trip preserves classified entries`() {
+        val original = SessionAllowlist(
+            mapOf(
+                "com.example.home" to AppClassification.HOME,
+                "com.example.media" to AppClassification.MEDIA,
+            )
+        )
+        assertEquals(original, SessionAllowlistCodec.decode(SessionAllowlistCodec.encode(original)))
+    }
+
+    @Test fun `empty storage is fail closed`() {
+        val decoded = SessionAllowlistCodec.decode(null)
+        assertNull(decoded.classificationFor("com.google.android.youtube"))
+    }
+
+    @Test fun `malformed entries are ignored`() {
+        val decoded = SessionAllowlistCodec.decode(
+            setOf(
+                "bad package|HOME",
+                "com.example.app|NOT_A_CLASS",
+                "com.example.valid|UTILITY",
+                "missing-separator",
+            )
+        )
+        assertEquals(AppClassification.UTILITY, decoded.classificationFor("com.example.valid"))
+        assertNull(decoded.classificationFor("bad package"))
+        assertNull(decoded.classificationFor("com.example.app"))
+    }
+
+    @Test fun `storage is capped at thirty two entries`() {
+        val stored = (1..40).map { "com.example.app$it|UTILITY" }.toSet()
+        assertEquals(32, SessionAllowlistCodec.decode(stored).toMap().size)
+    }
+
+    @Test fun `encoding is capped at thirty two entries`() {
+        val entries = (1..40).associate { "com.example.app$it" to AppClassification.UTILITY }
+        assertEquals(32, SessionAllowlistCodec.encode(SessionAllowlist(entries)).size)
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionAllowlistTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionAllowlistTest.kt
@@ -6,11 +6,9 @@ import org.junit.Test
 
 class SessionAllowlistTest {
 
-    @Test fun `DEFAULT seed contains known packages`() {
-        assertEquals(AppClassification.HOME, SessionAllowlist.DEFAULT.classificationFor("io.homeassistant.companion.android"))
-        assertEquals(AppClassification.MEDIA, SessionAllowlist.DEFAULT.classificationFor("com.google.android.youtube"))
-        assertEquals(AppClassification.UTILITY, SessionAllowlist.DEFAULT.classificationFor("com.android.chrome"))
-        assertEquals(AppClassification.COMMUNICATION, SessionAllowlist.DEFAULT.classificationFor("com.whatsapp"))
+    @Test fun `EMPTY defaults fail closed`() {
+        assertNull(SessionAllowlist.EMPTY.classificationFor("io.homeassistant.companion.android"))
+        assertNull(SessionAllowlist.EMPTY.classificationFor("com.google.android.youtube"))
     }
 
     @Test fun `custom entries override default behavior`() {
@@ -37,7 +35,7 @@ class SessionAllowlistTest {
     }
 
     @Test fun `unknown package returns null`() {
-        assertNull(SessionAllowlist.DEFAULT.classificationFor("com.not.in.list"))
+        assertNull(SessionAllowlist.EMPTY.classificationFor("com.not.in.list"))
     }
 
     @Test fun `empty allowlist rejects everything`() {

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionAllowlistTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionAllowlistTest.kt
@@ -1,0 +1,47 @@
+package com.iblu01.portallauncher.session
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SessionAllowlistTest {
+
+    @Test fun `DEFAULT seed contains known packages`() {
+        assertEquals(AppClassification.HOME, SessionAllowlist.DEFAULT.classificationFor("io.homeassistant.companion.android"))
+        assertEquals(AppClassification.MEDIA, SessionAllowlist.DEFAULT.classificationFor("com.google.android.youtube"))
+        assertEquals(AppClassification.UTILITY, SessionAllowlist.DEFAULT.classificationFor("com.android.chrome"))
+        assertEquals(AppClassification.COMMUNICATION, SessionAllowlist.DEFAULT.classificationFor("com.whatsapp"))
+    }
+
+    @Test fun `custom entries override default behavior`() {
+        val custom = SessionAllowlist(
+            mapOf(
+                "com.local.app" to AppClassification.HOME,
+                "com.local.video" to AppClassification.MEDIA,
+            )
+        )
+        assertEquals(AppClassification.HOME, custom.classificationFor("com.local.app"))
+        assertEquals(AppClassification.MEDIA, custom.classificationFor("com.local.video"))
+        assertNull(custom.classificationFor("com.google.android.youtube"))
+    }
+
+    @Test fun `classification exposes default and max durations`() {
+        assertEquals(60, AppClassification.HOME.defaultDurationSeconds)
+        assertEquals(300, AppClassification.HOME.maxDurationSeconds)
+        assertEquals(30, AppClassification.MEDIA.defaultDurationSeconds)
+        assertEquals(120, AppClassification.MEDIA.maxDurationSeconds)
+        assertEquals(30, AppClassification.UTILITY.defaultDurationSeconds)
+        assertEquals(60, AppClassification.UTILITY.maxDurationSeconds)
+        assertEquals(30, AppClassification.COMMUNICATION.defaultDurationSeconds)
+        assertEquals(60, AppClassification.COMMUNICATION.maxDurationSeconds)
+    }
+
+    @Test fun `unknown package returns null`() {
+        assertNull(SessionAllowlist.DEFAULT.classificationFor("com.not.in.list"))
+    }
+
+    @Test fun `empty allowlist rejects everything`() {
+        val empty = SessionAllowlist(emptyMap())
+        assertNull(empty.classificationFor("io.homeassistant.companion.android"))
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionCommandParserTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionCommandParserTest.kt
@@ -55,17 +55,21 @@ class SessionCommandParserTest {
         assertEquals("com.example.app", it.packageName)
         assertEquals(AppClassification.HOME.defaultDurationSeconds, it.durationSeconds)
         assertEquals((nowMs() / 1000 + AppClassification.HOME.defaultDurationSeconds) * 1000, it.expiresAtMs)
+        assertEquals(null, it.requestedDurationSeconds)
+        assertEquals(null, it.requestedExpiresAtSeconds)
         assertEquals(null, it.reason)
     }
 
     @Test fun `start with explicit duration`() = assertValidCommand(validStart(duration = 45)) {
         assertEquals(45, it.durationSeconds)
+        assertEquals(45, it.requestedDurationSeconds)
         assertEquals((nowMs() / 1000 + 45) * 1000, it.expiresAtMs)
     }
 
     @Test fun `start with explicit expires_at`() = assertValidCommand(validStart(expiresAt = 1100)) {
         assertEquals(AppClassification.HOME.defaultDurationSeconds, it.durationSeconds)
         assertEquals(1100L * 1000, it.expiresAtMs)
+        assertEquals(1100L, it.requestedExpiresAtSeconds)
     }
 
     @Test fun `start with reason is sanitized and bounded`() = assertValidCommand(

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionCommandParserTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionCommandParserTest.kt
@@ -1,0 +1,417 @@
+package com.iblu01.portallauncher.session
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionCommandParserTest {
+
+    private val allowlist = SessionAllowlist(
+        mapOf(
+            "com.example.app" to AppClassification.HOME,
+            "com.media.player" to AppClassification.MEDIA,
+            "com.util.tool" to AppClassification.UTILITY,
+        )
+    )
+
+    private fun nowMs() = 1_000_000L // epoch seconds = 1000
+
+    private fun validStart(
+        requestId: String = "req-1",
+        packageName: String = "com.example.app",
+        duration: Int? = null,
+        expiresAt: Int? = null,
+        reason: String? = null,
+    ): String {
+        val obj = JSONObject()
+        obj.put("schema_version", 1)
+        obj.put("request_id", requestId)
+        obj.put("action", "start")
+        obj.put("package", packageName)
+        if (duration != null) obj.put("duration_s", duration)
+        if (expiresAt != null) obj.put("expires_at", expiresAt)
+        if (reason != null) obj.put("reason", reason)
+        return obj.toString()
+    }
+
+    private fun assertCode(payload: String, code: SessionRejectionCode) {
+        val result = SessionCommandParser.parse(payload, nowMs(), allowlist)
+        assertTrue("expected Invalid but got $result", result is SessionCommandParser.ParseResult.Invalid)
+        assertEquals(code, (result as SessionCommandParser.ParseResult.Invalid).code)
+    }
+
+    private fun assertValidCommand(payload: String, assertion: (SessionCommand) -> Unit) {
+        val result = SessionCommandParser.parse(payload, nowMs(), allowlist)
+        assertTrue("expected Valid but got $result", result is SessionCommandParser.ParseResult.Valid)
+        assertion((result as SessionCommandParser.ParseResult.Valid).command)
+    }
+
+    // --- happy path --------------------------------------------------------
+
+    @Test fun `start with default duration uses classification default`() = assertValidCommand(validStart()) {
+        assertEquals("req-1", it.requestId)
+        assertEquals(SessionAction.START, it.action)
+        assertEquals("com.example.app", it.packageName)
+        assertEquals(AppClassification.HOME.defaultDurationSeconds, it.durationSeconds)
+        assertEquals((nowMs() / 1000 + AppClassification.HOME.defaultDurationSeconds) * 1000, it.expiresAtMs)
+        assertEquals(null, it.reason)
+    }
+
+    @Test fun `start with explicit duration`() = assertValidCommand(validStart(duration = 45)) {
+        assertEquals(45, it.durationSeconds)
+        assertEquals((nowMs() / 1000 + 45) * 1000, it.expiresAtMs)
+    }
+
+    @Test fun `start with explicit expires_at`() = assertValidCommand(validStart(expiresAt = 1100)) {
+        assertEquals(AppClassification.HOME.defaultDurationSeconds, it.durationSeconds)
+        assertEquals(1100L * 1000, it.expiresAtMs)
+    }
+
+    @Test fun `start with reason is sanitized and bounded`() = assertValidCommand(
+        validStart(reason = "  user reason  ")
+    ) {
+        assertEquals("user reason", it.reason)
+    }
+
+    @Test fun `end command is valid without temporal fields`() {
+        val payload = JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "end")
+            put("package", "com.example.app")
+        }.toString()
+        assertValidCommand(payload) {
+            assertEquals(SessionAction.END, it.action)
+            assertEquals(0, it.durationSeconds)
+            assertEquals(0L, it.expiresAtMs)
+        }
+    }
+
+    @Test fun `cancel command is valid without temporal fields`() {
+        val payload = JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "cancel")
+            put("package", "com.example.app")
+        }.toString()
+        assertValidCommand(payload) {
+            assertEquals(SessionAction.CANCEL, it.action)
+        }
+    }
+
+    // --- payload size ------------------------------------------------------
+
+    @Test fun `payload exceeding byte cap is rejected`() {
+        val hugeReason = "a".repeat(SessionCommandParser.MAX_PAYLOAD_BYTES + 1)
+        val payload = validStart(reason = hugeReason)
+        assertCode(payload, SessionRejectionCode.PAYLOAD_TOO_LARGE)
+    }
+
+    // --- JSON / schema -----------------------------------------------------
+
+    @Test fun `invalid JSON is rejected`() = assertCode("{ not json", SessionRejectionCode.INVALID_JSON)
+
+    @Test fun `missing schema_version is rejected`() = assertCode(
+        JSONObject().apply { put("request_id", "req-1"); put("action", "start"); put("package", "com.example.app") }.toString(),
+        SessionRejectionCode.UNKNOWN_SCHEMA_VERSION
+    )
+
+    @Test fun `wrong schema_version is rejected`() = assertCode(
+        validStart(requestId = "req-1").replace("\"schema_version\":1", "\"schema_version\":2"),
+        SessionRejectionCode.UNKNOWN_SCHEMA_VERSION
+    )
+
+    @Test fun `string schema_version is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", "1")
+            put("request_id", "req-1")
+            put("action", "start")
+            put("package", "com.example.app")
+        }.toString(),
+        SessionRejectionCode.UNKNOWN_SCHEMA_VERSION
+    )
+
+    @Test fun `unknown fields are rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "start")
+            put("package", "com.example.app")
+            put("extra", "value")
+        }.toString(),
+        SessionRejectionCode.UNKNOWN_FIELDS
+    )
+
+    // --- request_id --------------------------------------------------------
+
+    @Test fun `missing request_id is rejected`() = assertCode(
+        JSONObject().apply { put("schema_version", 1); put("action", "start"); put("package", "com.example.app") }.toString(),
+        SessionRejectionCode.MALFORMED_REQUEST_ID
+    )
+
+    @Test fun `blank request_id is rejected`() = assertCode(
+        validStart(requestId = "  "),
+        SessionRejectionCode.MALFORMED_REQUEST_ID
+    )
+
+    @Test fun `request_id with spaces is rejected`() = assertCode(
+        validStart(requestId = "req 1"),
+        SessionRejectionCode.MALFORMED_REQUEST_ID
+    )
+
+    @Test fun `request_id with control char is rejected`() = assertCode(
+        validStart(requestId = "req\u00001"),
+        SessionRejectionCode.MALFORMED_REQUEST_ID
+    )
+
+    @Test fun `request_id longer than 64 is rejected`() = assertCode(
+        validStart(requestId = "a".repeat(65)),
+        SessionRejectionCode.MALFORMED_REQUEST_ID
+    )
+
+    @Test fun `numeric request_id is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", 123)
+            put("action", "start")
+            put("package", "com.example.app")
+        }.toString(),
+        SessionRejectionCode.MALFORMED_REQUEST_ID
+    )
+
+    // --- action ------------------------------------------------------------
+
+    @Test fun `missing action is rejected`() = assertCode(
+        JSONObject().apply { put("schema_version", 1); put("request_id", "req-1"); put("package", "com.example.app") }.toString(),
+        SessionRejectionCode.UNKNOWN_ACTION
+    )
+
+    @Test fun `unknown action is rejected`() = assertCode(
+        validStart().replace("\"action\":\"start\"", "\"action\":\"pause\""),
+        SessionRejectionCode.UNKNOWN_ACTION
+    )
+
+    @Test fun `numeric action is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", 1)
+            put("package", "com.example.app")
+        }.toString(),
+        SessionRejectionCode.UNKNOWN_ACTION
+    )
+
+    // --- package -----------------------------------------------------------
+
+    @Test fun `missing package is rejected`() = assertCode(
+        JSONObject().apply { put("schema_version", 1); put("request_id", "req-1"); put("action", "start") }.toString(),
+        SessionRejectionCode.MALFORMED_PACKAGE
+    )
+
+    @Test fun `blank package is rejected`() = assertCode(
+        validStart(packageName = "  "),
+        SessionRejectionCode.MALFORMED_PACKAGE
+    )
+
+    @Test fun `package with space is rejected`() = assertCode(
+        validStart(packageName = "com.example.app name"),
+        SessionRejectionCode.MALFORMED_PACKAGE
+    )
+
+    @Test fun `package starting with digit is rejected`() = assertCode(
+        validStart(packageName = "1com.example.app"),
+        SessionRejectionCode.MALFORMED_PACKAGE
+    )
+
+    @Test fun `package with control char is rejected`() = assertCode(
+        validStart(packageName = "com.example\u0000app"),
+        SessionRejectionCode.MALFORMED_PACKAGE
+    )
+
+    @Test fun `package longer than 128 is rejected`() = assertCode(
+        validStart(packageName = "com." + "a".repeat(130)),
+        SessionRejectionCode.MALFORMED_PACKAGE
+    )
+
+    @Test fun `numeric package is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "start")
+            put("package", 123)
+        }.toString(),
+        SessionRejectionCode.MALFORMED_PACKAGE
+    )
+
+    @Test fun `unknown package is rejected`() = assertCode(
+        validStart(packageName = "com.unknown.app"),
+        SessionRejectionCode.UNKNOWN_PACKAGE
+    )
+
+    // --- duration / expiry type handling -----------------------------------
+
+    @Test fun `string duration is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "start")
+            put("package", "com.example.app")
+            put("duration_s", "60")
+        }.toString(),
+        SessionRejectionCode.DURATION_OUT_OF_RANGE
+    )
+
+    @Test fun `float duration is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "start")
+            put("package", "com.example.app")
+            put("duration_s", 60.5)
+        }.toString(),
+        SessionRejectionCode.DURATION_OUT_OF_RANGE
+    )
+
+    @Test fun `zero duration is rejected`() = assertCode(
+        validStart(duration = 0),
+        SessionRejectionCode.DURATION_OUT_OF_RANGE
+    )
+
+    @Test fun `negative duration is rejected`() = assertCode(
+        validStart(duration = -1),
+        SessionRejectionCode.DURATION_OUT_OF_RANGE
+    )
+
+    @Test fun `duration exceeding classification max is rejected`() = assertCode(
+        validStart(duration = AppClassification.HOME.maxDurationSeconds + 1),
+        SessionRejectionCode.DURATION_EXCEEDS_MAX
+    )
+
+    @Test fun `duration at classification max is accepted`() = assertValidCommand(
+        validStart(duration = AppClassification.HOME.maxDurationSeconds)
+    ) {
+        assertEquals(AppClassification.HOME.maxDurationSeconds, it.durationSeconds)
+    }
+
+    @Test fun `string expires_at is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "start")
+            put("package", "com.example.app")
+            put("expires_at", "1234")
+        }.toString(),
+        SessionRejectionCode.EXPIRES_AT_INVALID
+    )
+
+    @Test fun `float expires_at is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "start")
+            put("package", "com.example.app")
+            put("expires_at", 1234.5)
+        }.toString(),
+        SessionRejectionCode.EXPIRES_AT_INVALID
+    )
+
+    @Test fun `expires_at in the past is rejected`() = assertCode(
+        validStart(expiresAt = 500),
+        SessionRejectionCode.EXPIRES_AT_IN_THE_PAST
+    )
+
+    @Test fun `expires_at now is rejected`() = assertCode(
+        validStart(expiresAt = 1000),
+        SessionRejectionCode.EXPIRES_AT_IN_THE_PAST
+    )
+
+    @Test fun `expires_at beyond classification max is rejected`() = assertCode(
+        validStart(expiresAt = 1000 + AppClassification.HOME.maxDurationSeconds + 1),
+        SessionRejectionCode.EXPIRES_AT_EXCEEDS_MAX
+    )
+
+    @Test fun `default duration plus now is bounded by classification max`() = assertValidCommand(
+        validStart(packageName = "com.media.player") // default 30, max 120
+    ) {
+        assertEquals(AppClassification.MEDIA.defaultDurationSeconds, it.durationSeconds)
+    }
+
+    // --- end/cancel grammar ------------------------------------------------
+
+    @Test fun `end with duration_s is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "end")
+            put("package", "com.example.app")
+            put("duration_s", 60)
+        }.toString(),
+        SessionRejectionCode.END_COMMAND_WITH_TEMPORAL_FIELDS
+    )
+
+    @Test fun `cancel with expires_at is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "cancel")
+            put("package", "com.example.app")
+            put("expires_at", 1234)
+        }.toString(),
+        SessionRejectionCode.END_COMMAND_WITH_TEMPORAL_FIELDS
+    )
+
+    // --- reason ------------------------------------------------------------
+
+    @Test fun `reason longer than 120 chars is truncated`() = assertValidCommand(
+        validStart(reason = "a".repeat(200))
+    ) {
+        assertEquals("a".repeat(120), it.reason)
+    }
+
+    @Test fun `reason with control chars is sanitized`() = assertValidCommand(
+        validStart(reason = "hello\u0000world\nline")
+    ) {
+        assertEquals("helloworldline", it.reason)
+    }
+
+    @Test fun `reason keeps tabs and printable chars`() = assertValidCommand(
+        validStart(reason = "tab\there")
+    ) {
+        assertEquals("tab\there", it.reason)
+    }
+
+    @Test fun `non string reason is rejected`() = assertCode(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "start")
+            put("package", "com.example.app")
+            put("reason", 42)
+        }.toString(),
+        SessionRejectionCode.MALFORMED_REASON
+    )
+
+    @Test fun `json null reason is treated as absent`() = assertValidCommand(
+        JSONObject().apply {
+            put("schema_version", 1)
+            put("request_id", "req-1")
+            put("action", "start")
+            put("package", "com.example.app")
+            put("reason", JSONObject.NULL)
+        }.toString()
+    ) {
+        assertEquals(null, it.reason)
+    }
+
+    // --- classification specific defaults/max ------------------------------
+
+    @Test fun `utility classification has lower max`() = assertCode(
+        validStart(packageName = "com.util.tool", duration = 120),
+        SessionRejectionCode.DURATION_EXCEEDS_MAX
+    )
+
+    @Test fun `media default duration`() = assertValidCommand(validStart(packageName = "com.media.player")) {
+        assertEquals(AppClassification.MEDIA.defaultDurationSeconds, it.durationSeconds)
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionCoordinatorTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionCoordinatorTest.kt
@@ -1,0 +1,175 @@
+package com.iblu01.portallauncher.session
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionCoordinatorTest {
+    private val allowlist = SessionAllowlist(mapOf("com.example.app" to AppClassification.HOME))
+
+    private class Runtime : SessionRuntime {
+        val events = mutableListOf<SessionResult>()
+        val states = mutableListOf<SessionResult>()
+        var launchCalls = 0
+        var returnCalls = 0
+        var launchSucceeds = true
+        var returnSucceeds = true
+
+        override fun publishEvent(result: SessionResult) { events += result }
+        override fun publishState(result: SessionResult) { states += result }
+        override fun launchApp(packageName: String): Boolean {
+            launchCalls++
+            return launchSucceeds
+        }
+        override fun returnToLauncher(): Boolean {
+            returnCalls++
+            return returnSucceeds
+        }
+    }
+
+    private data class Fixture(
+        val time: TestTimeSource,
+        val manager: SessionManager,
+        val runtime: Runtime,
+        val coordinator: SessionCoordinator,
+    )
+
+    private fun fixture(enabled: Boolean = true): Fixture {
+        val time = TestTimeSource(1_000_000L)
+        val manager = SessionManager(time, allowlist, "com.iblu01.portallauncher", rateLimitMs = 0)
+        val runtime = Runtime()
+        val coordinator = SessionCoordinator(manager, allowlist, time, runtime)
+        coordinator.setEnabled(enabled)
+        return Fixture(time, manager, runtime, coordinator)
+    }
+
+    private fun startJson(requestId: String = "req-1", expiresAt: Long = 1060) =
+        """{"schema_version":1,"request_id":"$requestId","action":"start","package":"com.example.app","duration_s":60,"expires_at":$expiresAt}"""
+
+    private fun endJson(requestId: String = "req-end") =
+        """{"schema_version":1,"request_id":"$requestId","action":"end","package":"com.example.app"}"""
+
+    @Test fun `empty retained clear is ignored`() {
+        val f = fixture()
+        assertFalse(f.coordinator.onCommand("  "))
+        assertTrue(f.runtime.events.isEmpty())
+        assertTrue(f.runtime.states.isEmpty())
+        assertEquals(0, f.runtime.launchCalls)
+    }
+
+    @Test fun `valid start publishes transitions and launches exactly once`() {
+        val f = fixture()
+        assertTrue(f.coordinator.onCommand(startJson()))
+        assertEquals(listOf(SessionLifecycle.ACCEPTED, SessionLifecycle.LAUNCHING), f.runtime.events.map { it.lifecycle })
+        assertEquals(2, f.runtime.states.size)
+        assertEquals(1, f.runtime.launchCalls)
+
+        f.coordinator.onCommand(startJson())
+        assertEquals(1, f.runtime.launchCalls)
+    }
+
+    @Test fun `invalid command is rejected without side effects`() {
+        val f = fixture()
+        f.coordinator.onCommand("not-json")
+        assertEquals(SessionLifecycle.REJECTED, f.runtime.states.last().lifecycle)
+        assertEquals(SessionRejectionCode.INVALID_JSON, f.runtime.states.last().code)
+        assertEquals(0, f.runtime.launchCalls)
+    }
+
+    @Test fun `launch failure publishes failed and clears active session`() {
+        val f = fixture()
+        f.runtime.launchSucceeds = false
+        f.coordinator.onCommand(startJson())
+        assertEquals(SessionLifecycle.FAILED, f.runtime.states.last().lifecycle)
+        assertEquals(SessionRejectionCode.LAUNCH_FAILED, f.runtime.states.last().code)
+        assertNull(f.manager.activeSession)
+    }
+
+    @Test fun `expiry returns once`() {
+        val f = fixture()
+        f.coordinator.onCommand(startJson(expiresAt = 1005))
+        f.coordinator.onDeviceState("com.example.app")
+        f.time.advance(6_000L)
+        f.coordinator.onDeviceState("com.example.app")
+        f.coordinator.onDeviceState("com.example.app")
+        assertEquals(1, f.runtime.returnCalls)
+        assertEquals(SessionLifecycle.EXPIRED, f.runtime.events.last().lifecycle)
+    }
+
+    @Test fun `local disable ends active session`() {
+        val f = fixture()
+        f.coordinator.onCommand(startJson())
+        f.coordinator.onDeviceState("com.example.app")
+        f.coordinator.setEnabled(false)
+        assertEquals(1, f.runtime.returnCalls)
+        assertEquals(SessionLifecycle.COMPLETED, f.runtime.states.last().lifecycle)
+    }
+
+    @Test fun `successful end returns once and completes without foreground callback`() {
+        val f = fixture()
+        f.coordinator.onCommand(startJson())
+        f.coordinator.onDeviceState("com.example.app")
+        f.coordinator.onCommand(endJson())
+        assertEquals(1, f.runtime.returnCalls)
+        assertEquals(SessionLifecycle.COMPLETED, f.runtime.states.last().lifecycle)
+        assertNull(f.manager.activeSession)
+    }
+
+    @Test fun `disabling with no active session has no side effects`() {
+        val f = fixture()
+        f.coordinator.setEnabled(false)
+        assertEquals(0, f.runtime.returnCalls)
+        assertTrue(f.runtime.events.isEmpty())
+    }
+
+    @Test fun `return failure publishes bounded failed status`() {
+        val f = fixture()
+        f.runtime.returnSucceeds = false
+        f.coordinator.onCommand(startJson(expiresAt = 1005))
+        f.coordinator.onDeviceState("com.example.app")
+        f.time.advance(6_000L)
+        f.coordinator.onDeviceState("com.example.app")
+        assertEquals(SessionLifecycle.FAILED, f.runtime.states.last().lifecycle)
+        assertEquals(SessionRejectionCode.RETURN_TO_LAUNCHER_FAILED, f.runtime.states.last().code)
+    }
+
+    @Test fun `restart publishes retained-state payload only`() {
+        val f = fixture()
+        f.coordinator.publishCurrentState()
+        assertTrue(f.runtime.events.isEmpty())
+        assertEquals(1, f.runtime.states.size)
+        assertEquals(SessionLifecycle.COMPLETED, f.runtime.states.single().lifecycle)
+        assertEquals("", f.runtime.states.single().requestId)
+    }
+
+    @Test fun `mqtt reconnect republishes active state without relaunching`() {
+        val f = fixture()
+        f.coordinator.onCommand(startJson())
+        f.coordinator.onDeviceState("com.example.app")
+        f.runtime.events.clear()
+        f.runtime.states.clear()
+
+        f.coordinator.publishCurrentState()
+
+        assertTrue(f.runtime.events.isEmpty())
+        assertEquals(SessionLifecycle.ACTIVE, f.runtime.states.single().lifecycle)
+        assertEquals(1, f.runtime.launchCalls)
+    }
+
+    @Test fun `mqtt reconnect republishes expiry reached while disconnected`() {
+        val f = fixture()
+        f.coordinator.onCommand(startJson(expiresAt = 1005))
+        f.coordinator.onDeviceState("com.example.app")
+        f.time.advance(6_000L)
+        f.coordinator.onDeviceState("com.example.app")
+        f.runtime.events.clear()
+        f.runtime.states.clear()
+
+        f.coordinator.publishCurrentState()
+
+        assertEquals(SessionLifecycle.EXPIRED, f.runtime.states.single().lifecycle)
+        assertEquals(1, f.runtime.returnCalls)
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionCoordinatorTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionCoordinatorTest.kt
@@ -51,6 +51,9 @@ class SessionCoordinatorTest {
     private fun endJson(requestId: String = "req-end") =
         """{"schema_version":1,"request_id":"$requestId","action":"end","package":"com.example.app"}"""
 
+    private fun defaultStartJson(requestId: String = "req-default") =
+        """{"schema_version":1,"request_id":"$requestId","action":"start","package":"com.example.app"}"""
+
     @Test fun `empty retained clear is ignored`() {
         val f = fixture()
         assertFalse(f.coordinator.onCommand("  "))
@@ -68,6 +71,28 @@ class SessionCoordinatorTest {
 
         f.coordinator.onCommand(startJson())
         assertEquals(1, f.runtime.launchCalls)
+    }
+
+    @Test fun `qos replay with derived expiry is idempotent after clock advances`() {
+        val f = fixture()
+        f.coordinator.onCommand(defaultStartJson())
+        f.time.advance(1_500L)
+        f.coordinator.onCommand(defaultStartJson())
+
+        assertEquals(1, f.runtime.launchCalls)
+        assertEquals(SessionLifecycle.LAUNCHING, f.runtime.states.last().lifecycle)
+        assertEquals(null, f.runtime.states.last().code)
+    }
+
+    @Test fun `same request id with different requested temporal fields conflicts`() {
+        val f = fixture()
+        f.coordinator.onCommand(defaultStartJson())
+        f.coordinator.onCommand(
+            """{"schema_version":1,"request_id":"req-default","action":"start","package":"com.example.app","duration_s":60}"""
+        )
+
+        assertEquals(1, f.runtime.launchCalls)
+        assertEquals(SessionRejectionCode.REQUEST_ID_CONFLICT, f.runtime.states.last().code)
     }
 
     @Test fun `invalid command is rejected without side effects`() {

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionDiscoveryContractTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionDiscoveryContractTest.kt
@@ -1,0 +1,34 @@
+package com.iblu01.portallauncher.session
+
+import com.iblu01.portallauncher.HaDiscovery
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionDiscoveryContractTest {
+    @Test fun `session command is subscribed but enabled status is read only`() {
+        val deviceId = "portal-test"
+        val topics = HaDiscovery.commandTopics(deviceId)
+        assertTrue(topics.contains(HaDiscovery.sessionCommandTopic(deviceId)))
+        assertFalse(topics.any { it.contains("session/enabled") || it.contains("kill_switch") })
+    }
+
+    @Test fun `enabled discovery payload has no command topic`() {
+        val payload = HaDiscovery.sessionEnabledConfigPayload("portal-test", "Portal")
+        assertFalse(payload.contains("binary_sensor")) // topic owns the component type
+        assertTrue(payload.contains("state_topic"))
+        assertFalse(payload.contains("command_topic"))
+    }
+
+    @Test fun `session diagnostic is read only and expires after heartbeat loss`() {
+        val payload = HaDiscovery.sessionConfigPayload("portal-test", "Portal")
+        assertFalse(payload.contains("command_topic"))
+        assertTrue(payload.contains("\"expire_after\":15"))
+        assertEquals("portal/portal-test/session/state", HaDiscovery.sessionStateTopic("portal-test"))
+    }
+
+    @Test fun `enabled discovery uses binary sensor component`() {
+        assertTrue(HaDiscovery.sessionEnabledDiscoveryTopic("portal-test").startsWith("homeassistant/binary_sensor/"))
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionManagerTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionManagerTest.kt
@@ -1,0 +1,434 @@
+package com.iblu01.portallauncher.session
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionManagerTest {
+
+    private val allowlist = SessionAllowlist(
+        mapOf(
+            "com.example.app" to AppClassification.HOME,
+            "com.media.player" to AppClassification.MEDIA,
+        )
+    )
+    private val launcherPackage = "com.iblu01.portallauncher"
+
+    private fun manager(
+        enabled: Boolean = false,
+        rateLimitMs: Long = 0L,
+    ) = TestFixture(enabled, rateLimitMs)
+
+    private inner class TestFixture(
+        enabled: Boolean = false,
+        rateLimitMs: Long = 0L,
+    ) {
+        val timeSource = TestTimeSource(1_000_000L)
+        val manager = SessionManager(
+            timeSource = timeSource,
+            allowlist = allowlist,
+            launcherPackage = launcherPackage,
+            rateLimitMs = rateLimitMs,
+        )
+
+        init {
+            if (enabled) manager.setSessionsEnabled(true)
+        }
+
+        fun start(
+            requestId: String = "req-1",
+            packageName: String = "com.example.app",
+            durationSeconds: Int = 60,
+            expiresAtMs: Long = timeSource.now() + 60_000L,
+            reason: String? = null,
+        ) = SessionCommand(requestId, SessionAction.START, packageName, durationSeconds, expiresAtMs, reason)
+
+        fun end(
+            requestId: String = "req-2",
+            packageName: String = "com.example.app",
+            reason: String? = null,
+        ) = SessionCommand(requestId, SessionAction.END, packageName, 0, 0L, reason)
+
+        fun cancel(
+            requestId: String = "req-2",
+            packageName: String = "com.example.app",
+            reason: String? = null,
+        ) = SessionCommand(requestId, SessionAction.CANCEL, packageName, 0, 0L, reason)
+    }
+
+    // --- lifecycle / basics ------------------------------------------------
+
+    @Test fun `fresh manager has no active session and is disabled`() {
+        val f = manager()
+        assertNull(f.manager.activeSession)
+        assertEquals(false, f.manager.isEnabled)
+    }
+
+    @Test fun `start rejected when kill switch disabled`() {
+        val f = manager()
+        val transitions = f.manager.process(f.start())
+        assertEquals(1, transitions.size)
+        assertEquals(SessionLifecycle.REJECTED, transitions[0].result.lifecycle)
+        assertEquals(SessionRejectionCode.KILL_SWITCH_DISABLED, transitions[0].result.code)
+        assertEquals(0, transitions[0].sideEffects.size)
+    }
+
+    @Test fun `start accepted and launches when kill switch enabled`() {
+        val f = manager(enabled = true)
+        val transitions = f.manager.process(f.start())
+        assertEquals(2, transitions.size)
+        assertEquals(SessionLifecycle.ACCEPTED, transitions[0].result.lifecycle)
+        assertEquals(SessionLifecycle.LAUNCHING, transitions[1].result.lifecycle)
+        assertEquals(1, transitions[1].sideEffects.size)
+        assertTrue(transitions[1].sideEffects[0] is SessionSideEffect.LaunchApp)
+        assertNotNull(f.manager.activeSession)
+    }
+
+    @Test fun `only one active session is allowed`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        val second = f.manager.process(f.start(requestId = "req-2"))
+        assertEquals(1, second.size)
+        assertEquals(SessionLifecycle.REJECTED, second[0].result.lifecycle)
+        assertEquals(SessionRejectionCode.SESSION_ALREADY_ACTIVE, second[0].result.code)
+    }
+
+    @Test fun `end transitions to ending and returns to launcher`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        val end = f.manager.process(f.end(requestId = "req-2"))
+        assertEquals(1, end.size)
+        assertEquals(SessionLifecycle.ENDING, end[0].result.lifecycle)
+        assertEquals(1, end[0].sideEffects.size)
+        assertTrue(end[0].sideEffects[0] is SessionSideEffect.ReturnToLauncher)
+    }
+
+    @Test fun `cancel works like end`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        val cancel = f.manager.process(f.cancel(requestId = "req-2"))
+        assertEquals(1, cancel.size)
+        assertEquals(SessionLifecycle.ENDING, cancel[0].result.lifecycle)
+    }
+
+    @Test fun `end with mismatched package is rejected`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1", packageName = "com.example.app"))
+        val end = f.manager.process(f.end(requestId = "req-2", packageName = "com.media.player"))
+        assertEquals(SessionRejectionCode.PACKAGE_MISMATCH, end[0].result.code)
+    }
+
+    @Test fun `end with no active session is rejected`() {
+        val f = manager(enabled = true)
+        val end = f.manager.process(f.end())
+        assertEquals(SessionRejectionCode.NO_ACTIVE_SESSION, end[0].result.code)
+    }
+
+    @Test fun `end when already ending is rejected`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        f.manager.process(f.end(requestId = "req-2"))
+        val again = f.manager.process(f.end(requestId = "req-3"))
+        assertEquals(SessionRejectionCode.SESSION_ALREADY_ENDING, again[0].result.code)
+    }
+
+    // --- device state transitions ------------------------------------------
+
+    @Test fun `launching becomes active when foreground matches`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1", packageName = "com.example.app"))
+        val transitions = f.manager.onDeviceState("com.example.app")
+        assertEquals(1, transitions.size)
+        assertEquals(SessionLifecycle.ACTIVE, transitions[0].result.lifecycle)
+        assertEquals(SessionLifecycle.ACTIVE, f.manager.activeSession?.lifecycle)
+    }
+
+    @Test fun `ending becomes completed when launcher returns to foreground`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1", packageName = "com.example.app"))
+        f.manager.onDeviceState("com.example.app")
+        f.manager.process(f.end(requestId = "req-2"))
+        val transitions = f.manager.onDeviceState(launcherPackage)
+        assertEquals(1, transitions.size)
+        assertEquals(SessionLifecycle.COMPLETED, transitions[0].result.lifecycle)
+        assertNull(f.manager.activeSession)
+    }
+
+    @Test fun `onReturnToLauncher completes an ending session`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        f.manager.onDeviceState("com.example.app")
+        f.manager.process(f.end(requestId = "req-2"))
+        val transitions = f.manager.onReturnToLauncher()
+        assertEquals(1, transitions.size)
+        assertEquals(SessionLifecycle.COMPLETED, transitions[0].result.lifecycle)
+        assertNull(f.manager.activeSession)
+    }
+
+    // --- expiry ------------------------------------------------------------
+
+    @Test fun `expired session emits exactly one return side effect`() {
+        val f = manager(enabled = true)
+        val startTime = f.timeSource.now()
+        f.manager.process(f.start(requestId = "req-1", expiresAtMs = startTime + 5_000L))
+        f.manager.onDeviceState("com.example.app") // ACTIVE
+
+        f.timeSource.advance(6_000L)
+        val transitions = f.manager.onDeviceState("com.example.app")
+        assertEquals(1, transitions.size)
+        assertEquals(SessionLifecycle.EXPIRED, transitions[0].result.lifecycle)
+        assertEquals(1, transitions[0].sideEffects.size)
+        assertTrue(transitions[0].sideEffects[0] is SessionSideEffect.ReturnToLauncher)
+        assertNull(f.manager.activeSession)
+
+        // A second poll after expiry must not emit another side effect.
+        val again = f.manager.onDeviceState("com.example.app")
+        assertEquals(0, again.size)
+    }
+
+    @Test fun `expiry while launching still returns to launcher`() {
+        val f = manager(enabled = true)
+        val startTime = f.timeSource.now()
+        f.manager.process(f.start(requestId = "req-1", expiresAtMs = startTime + 5_000L))
+        // never reaches foreground
+        f.timeSource.advance(6_000L)
+        val transitions = f.manager.onDeviceState(null)
+        assertEquals(SessionLifecycle.EXPIRED, transitions[0].result.lifecycle)
+        assertEquals(1, transitions[0].sideEffects.size)
+        assertTrue(transitions[0].sideEffects[0] is SessionSideEffect.ReturnToLauncher)
+    }
+
+    @Test fun `expired start command is rejected`() {
+        val f = manager(enabled = true)
+        val start = f.start(expiresAtMs = f.timeSource.now() - 1_000L)
+        val transitions = f.manager.process(start)
+        assertEquals(SessionRejectionCode.EXPIRED_BEFORE_LAUNCH, transitions[0].result.code)
+    }
+
+    // --- idempotency -------------------------------------------------------
+
+    @Test fun `duplicate accepted start returns latest result without side effects`() {
+        val f = manager(enabled = true)
+        val cmd = f.start(requestId = "req-1")
+        f.manager.process(cmd)
+        f.manager.onDeviceState("com.example.app") // ACTIVE
+
+        val duplicate = f.manager.process(cmd)
+        assertEquals(1, duplicate.size)
+        assertEquals(SessionLifecycle.ACTIVE, duplicate[0].result.lifecycle)
+        assertEquals(0, duplicate[0].sideEffects.size)
+    }
+
+    @Test fun `duplicate after completed returns completed`() {
+        val f = manager(enabled = true)
+        val cmd = f.start(requestId = "req-1")
+        f.manager.process(cmd)
+        f.manager.onDeviceState("com.example.app")
+        f.manager.process(f.end(requestId = "req-2"))
+        f.manager.onDeviceState(launcherPackage)
+
+        val duplicate = f.manager.process(cmd)
+        assertEquals(1, duplicate.size)
+        assertEquals(SessionLifecycle.COMPLETED, duplicate[0].result.lifecycle)
+        assertEquals(0, duplicate[0].sideEffects.size)
+    }
+
+    @Test fun `duplicate after expired returns expired`() {
+        val f = manager(enabled = true)
+        val cmd = f.start(requestId = "req-1", expiresAtMs = f.timeSource.now() + 5_000L)
+        f.manager.process(cmd)
+        f.manager.onDeviceState("com.example.app")
+        f.timeSource.advance(6_000L)
+        f.manager.onDeviceState("com.example.app")
+
+        val duplicate = f.manager.process(cmd)
+        assertEquals(1, duplicate.size)
+        assertEquals(SessionLifecycle.EXPIRED, duplicate[0].result.lifecycle)
+        assertEquals(0, duplicate[0].sideEffects.size)
+    }
+
+    @Test fun `duplicate rejected command replays the rejection`() {
+        val f = manager(enabled = true)
+        val cmd = f.start(requestId = "req-1", packageName = "com.unknown.app")
+        val first = f.manager.process(cmd)
+        assertEquals(SessionRejectionCode.UNKNOWN_PACKAGE, first[0].result.code)
+
+        val duplicate = f.manager.process(cmd)
+        assertEquals(1, duplicate.size)
+        assertEquals(SessionLifecycle.REJECTED, duplicate[0].result.lifecycle)
+        assertEquals(SessionRejectionCode.UNKNOWN_PACKAGE, duplicate[0].result.code)
+        assertEquals(0, duplicate[0].sideEffects.size)
+    }
+
+    @Test fun `conflicting duplicate with same request_id is rejected`() {
+        val f = manager(enabled = true)
+        val cmd1 = f.start(requestId = "req-1", packageName = "com.example.app", durationSeconds = 60)
+        val cmd2 = f.start(requestId = "req-1", packageName = "com.example.app", durationSeconds = 90)
+        f.manager.process(cmd1)
+        val conflict = f.manager.process(cmd2)
+        assertEquals(1, conflict.size)
+        assertEquals(SessionLifecycle.REJECTED, conflict[0].result.lifecycle)
+        assertEquals(SessionRejectionCode.REQUEST_ID_CONFLICT, conflict[0].result.code)
+    }
+
+    @Test fun `conflicting duplicate does not overwrite original request binding`() {
+        val f = manager(enabled = true)
+        val original = f.start(requestId = "req-1", durationSeconds = 60)
+        val conflict = f.start(requestId = "req-1", durationSeconds = 90)
+        f.manager.process(original)
+
+        assertEquals(
+            SessionRejectionCode.REQUEST_ID_CONFLICT,
+            f.manager.process(conflict)[0].result.code,
+        )
+
+        val replay = f.manager.process(original)
+        assertEquals(SessionLifecycle.LAUNCHING, replay[0].result.lifecycle)
+        assertEquals("req-1", replay[0].result.requestId)
+        assertEquals(0, replay[0].sideEffects.size)
+    }
+
+    @Test fun `conflicting duplicate compares all command fields including reason`() {
+        val f = manager(enabled = true)
+        val cmd1 = f.start(requestId = "req-1", reason = "first")
+        val cmd2 = f.start(requestId = "req-1", reason = "second")
+        f.manager.process(cmd1)
+        val conflict = f.manager.process(cmd2)
+        assertEquals(SessionRejectionCode.REQUEST_ID_CONFLICT, conflict[0].result.code)
+    }
+
+    @Test fun `conflicting duplicate with different expiry is rejected`() {
+        val f = manager(enabled = true)
+        val cmd1 = f.start(requestId = "req-1", expiresAtMs = f.timeSource.now() + 60_000L)
+        val cmd2 = f.start(requestId = "req-1", expiresAtMs = f.timeSource.now() + 120_000L)
+        f.manager.process(cmd1)
+        val conflict = f.manager.process(cmd2)
+        assertEquals(SessionRejectionCode.REQUEST_ID_CONFLICT, conflict[0].result.code)
+    }
+
+    @Test fun `identical duplicate with different request_id is treated as new command`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        val second = f.manager.process(f.start(requestId = "req-2"))
+        assertEquals(SessionRejectionCode.SESSION_ALREADY_ACTIVE, second[0].result.code)
+    }
+
+    // --- rate limit --------------------------------------------------------
+
+    @Test fun `rate limit rejects new commands within window`() {
+        val f = manager(enabled = true, rateLimitMs = 200L)
+        f.manager.process(f.start(requestId = "req-1"))
+        val rapid = f.manager.process(f.start(requestId = "req-2"))
+        assertEquals(SessionRejectionCode.RATE_LIMITED, rapid[0].result.code)
+    }
+
+    @Test fun `rate limit window allows command after interval`() {
+        val f = manager(enabled = true, rateLimitMs = 200L)
+        f.manager.process(f.start(requestId = "req-1"))
+        f.timeSource.advance(250L)
+        val next = f.manager.process(f.start(requestId = "req-2"))
+        assertEquals(SessionRejectionCode.SESSION_ALREADY_ACTIVE, next[0].result.code)
+    }
+
+    @Test fun `duplicate replay is checked before rate limit`() {
+        val f = manager(enabled = true, rateLimitMs = 200L)
+        val cmd = f.start(requestId = "req-1")
+        f.manager.process(cmd)
+        f.manager.onDeviceState("com.example.app")
+        // Within rate limit window but duplicate
+        val duplicate = f.manager.process(cmd)
+        assertEquals(SessionLifecycle.ACTIVE, duplicate[0].result.lifecycle)
+        assertEquals(0, duplicate[0].sideEffects.size)
+    }
+
+    @Test fun `rate limited result is idempotent`() {
+        val f = manager(enabled = true, rateLimitMs = 200L)
+        f.manager.process(f.start(requestId = "req-1"))
+        val rapidCommand = f.start(requestId = "req-2")
+        val rapid = f.manager.process(rapidCommand)
+        assertEquals(SessionRejectionCode.RATE_LIMITED, rapid[0].result.code)
+
+        f.timeSource.advance(10_000L) // well past the rate limit
+        val duplicate = f.manager.process(rapidCommand)
+        assertEquals(SessionRejectionCode.RATE_LIMITED, duplicate[0].result.code)
+        assertEquals(0, duplicate[0].sideEffects.size)
+    }
+
+    // --- kill switch -------------------------------------------------------
+
+    @Test fun `kill switch disabled ends active session`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        f.manager.onDeviceState("com.example.app")
+        val transitions = f.manager.setSessionsEnabled(false)
+        assertEquals(1, transitions.size)
+        assertEquals(SessionLifecycle.ENDING, transitions[0].result.lifecycle)
+        assertEquals(1, transitions[0].sideEffects.size)
+        assertTrue(transitions[0].sideEffects[0] is SessionSideEffect.ReturnToLauncher)
+    }
+
+    @Test fun `kill switch disabled rejects new commands`() {
+        val f = manager(enabled = true)
+        f.manager.setSessionsEnabled(false)
+        val start = f.manager.process(f.start())
+        assertEquals(SessionRejectionCode.KILL_SWITCH_DISABLED, start[0].result.code)
+    }
+
+    // --- restart -----------------------------------------------------------
+
+    @Test fun `restart returns idle completed state and does not resume`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        f.manager.onDeviceState("com.example.app")
+
+        // A fresh manager instance represents a restart.
+        val restarted = SessionManager(
+            timeSource = f.timeSource,
+            allowlist = allowlist,
+            launcherPackage = launcherPackage,
+        )
+        assertNull(restarted.activeSession)
+        val idle = SessionSerializer.idleState()
+        assertEquals(SessionLifecycle.COMPLETED, idle.lifecycle)
+        assertEquals("", idle.requestId)
+        assertNull(idle.packageName)
+    }
+
+    // --- side effect sanity ------------------------------------------------
+
+    @Test fun `duplicate replay does not re-emit launch side effect`() {
+        val f = manager(enabled = true)
+        val cmd = f.start(requestId = "req-1")
+        f.manager.process(cmd)
+        val duplicate = f.manager.process(cmd)
+        assertEquals(0, duplicate[0].sideEffects.size)
+    }
+
+    @Test fun `duplicate end does not re-emit return side effect`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        f.manager.onDeviceState("com.example.app")
+        val end = f.end(requestId = "req-2")
+        f.manager.process(end)
+        val duplicate = f.manager.process(end)
+        assertEquals(SessionLifecycle.ENDING, duplicate[0].result.lifecycle)
+        assertEquals(0, duplicate[0].sideEffects.size)
+    }
+
+    @Test fun `completed end replay preserves end request id`() {
+        val f = manager(enabled = true)
+        f.manager.process(f.start(requestId = "req-1"))
+        f.manager.onDeviceState("com.example.app")
+        val end = f.end(requestId = "req-2", reason = "done")
+        f.manager.process(end)
+        f.manager.onReturnToLauncher()
+
+        val duplicate = f.manager.process(end)
+        assertEquals(SessionLifecycle.COMPLETED, duplicate[0].result.lifecycle)
+        assertEquals("req-2", duplicate[0].result.requestId)
+        assertEquals("done", duplicate[0].result.reason)
+        assertEquals(0, duplicate[0].sideEffects.size)
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionManagerTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionManagerTest.kt
@@ -167,6 +167,18 @@ class SessionManagerTest {
         assertNull(f.manager.activeSession)
     }
 
+    @Test fun `ending is not overwritten by expiry while launcher return is pending`() {
+        val f = manager(enabled = true)
+        val expires = f.timeSource.now() + 5_000L
+        f.manager.process(f.start(requestId = "req-1", expiresAtMs = expires))
+        f.manager.onDeviceState("com.example.app")
+        f.manager.process(f.end(requestId = "req-2"))
+        f.timeSource.advance(6_000L)
+        assertTrue(f.manager.onDeviceState("com.example.app").isEmpty())
+        assertEquals(SessionLifecycle.ENDING, f.manager.activeSession?.lifecycle)
+        assertEquals(SessionLifecycle.COMPLETED, f.manager.onReturnToLauncher().single().result.lifecycle)
+    }
+
     // --- expiry ------------------------------------------------------------
 
     @Test fun `expired session emits exactly one return side effect`() {

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionMqttContractTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionMqttContractTest.kt
@@ -1,0 +1,39 @@
+package com.iblu01.portallauncher.session
+
+import org.eclipse.paho.client.mqttv3.MqttMessage
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionMqttContractTest {
+
+    @Test fun `command clear message is retained with QoS 1 and empty payload`() {
+        val msg = SessionMqttContract.commandClearMessage()
+        assertEquals(1, msg.qos)
+        assertTrue(msg.isRetained)
+        assertEquals(0, msg.payload.size)
+    }
+
+    @Test fun `event message is non retained with QoS 1`() {
+        val payload = """{"lifecycle":"active"}"""
+        val msg = SessionMqttContract.eventMessage(payload)
+        assertEquals(1, msg.qos)
+        assertFalse(msg.isRetained)
+        assertArrayEquals(payload.toByteArray(), msg.payload)
+    }
+
+    @Test fun `state message is retained with QoS 1`() {
+        val payload = """{"lifecycle":"completed"}"""
+        val msg = SessionMqttContract.stateMessage(payload)
+        assertEquals(1, msg.qos)
+        assertTrue(msg.isRetained)
+        assertArrayEquals(payload.toByteArray(), msg.payload)
+    }
+
+    @Test fun `clear message has zero length payload`() {
+        val msg = SessionMqttContract.commandClearMessage()
+        assertEquals(0, MqttMessage(msg.payload).payload.size)
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionSerializerTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionSerializerTest.kt
@@ -1,0 +1,117 @@
+package com.iblu01.portallauncher.session
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionSerializerTest {
+
+    private fun json(result: SessionResult): JSONObject {
+        return JSONObject(SessionSerializer.toJson(result))
+    }
+
+    @Test fun `emits schema version and lifecycle`() {
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.ACTIVE,
+            requestId = "req-1",
+            packageName = "com.example.app",
+            expiresAtMs = 1200_000L,
+            reason = "user reason",
+        )
+        val obj = json(result)
+        assertEquals(1, obj.getInt("schema_version"))
+        assertEquals("active", obj.getString("lifecycle"))
+        assertEquals("req-1", obj.getString("request_id"))
+        assertEquals("com.example.app", obj.getString("package"))
+        assertEquals(1200L, obj.getLong("expires_at"))
+        assertEquals("user reason", obj.getString("reason"))
+        assertTrue(obj.isNull("code"))
+    }
+
+    @Test fun `emits rejection code for rejected results`() {
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.REJECTED,
+            requestId = "req-1",
+            packageName = "com.example.app",
+            expiresAtMs = 1200_000L,
+            reason = "user reason",
+            code = SessionRejectionCode.KILL_SWITCH_DISABLED,
+        )
+        val obj = json(result)
+        assertEquals("kill_switch_disabled", obj.getString("code"))
+        assertEquals("rejected", obj.getString("lifecycle"))
+    }
+
+    @Test fun `null fields are emitted as JSON null`() {
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.COMPLETED,
+            requestId = "",
+            packageName = null,
+            expiresAtMs = null,
+            reason = null,
+        )
+        val obj = json(result)
+        assertTrue(obj.isNull("package"))
+        assertTrue(obj.isNull("expires_at"))
+        assertTrue(obj.isNull("reason"))
+        assertTrue(obj.isNull("code"))
+    }
+
+    @Test fun `reason is bounded and sanitized`() {
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.ACTIVE,
+            requestId = "req-1",
+            packageName = "com.example.app",
+            expiresAtMs = 1200_000L,
+            reason = "hello\u0000world".repeat(20),
+        )
+        val obj = json(result)
+        val emitted = obj.getString("reason")
+        assertEquals(120, emitted.length)
+        assertFalse(emitted.contains("\u0000"))
+    }
+
+    @Test fun `idle state has completed lifecycle and no identifiers`() {
+        val idle = SessionSerializer.idleState()
+        assertEquals(SessionLifecycle.COMPLETED, idle.lifecycle)
+        assertEquals("", idle.requestId)
+        assertNull(idle.packageName)
+        assertNull(idle.expiresAtMs)
+        assertNull(idle.reason)
+        assertNull(idle.code)
+    }
+
+    @Test fun `no extra fields are emitted`() {
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.ENDING,
+            requestId = "req-1",
+            packageName = "com.example.app",
+            expiresAtMs = 1200_000L,
+            reason = null,
+        )
+        val obj = json(result)
+        assertEquals(7, obj.length())
+        assertTrue(obj.has("schema_version"))
+        assertTrue(obj.has("lifecycle"))
+        assertTrue(obj.has("request_id"))
+        assertTrue(obj.has("package"))
+        assertTrue(obj.has("expires_at"))
+        assertTrue(obj.has("reason"))
+        assertTrue(obj.has("code"))
+    }
+
+    @Test fun `expires_at is serialized as epoch seconds`() {
+        val result = SessionResult(
+            lifecycle = SessionLifecycle.ACTIVE,
+            requestId = "req-1",
+            packageName = "com.example.app",
+            expiresAtMs = 1500_500L,
+            reason = null,
+        )
+        val obj = json(result)
+        assertEquals(1500L, obj.getLong("expires_at"))
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/session/SessionTestHelpers.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/session/SessionTestHelpers.kt
@@ -1,0 +1,7 @@
+package com.iblu01.portallauncher.session
+
+class TestTimeSource(private var time: Long = 0L) : SessionTimeSource {
+    override fun now(): Long = time
+    fun advance(ms: Long) { time += ms }
+    fun set(timeMs: Long) { time = timeMs }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/ui/screens/SettingsSessionVisibilityTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/screens/SettingsSessionVisibilityTest.kt
@@ -1,0 +1,16 @@
+package com.iblu01.portallauncher.ui.screens
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SettingsSessionVisibilityTest {
+    @Test fun `sessions are hidden without a configured broker`() {
+        assertFalse(shouldShowAppSessions(""))
+        assertFalse(shouldShowAppSessions("   "))
+    }
+
+    @Test fun `sessions are visible with a configured broker`() {
+        assertTrue(shouldShowAppSessions("homeassistant.local"))
+    }
+}

--- a/docs/session-protocol.md
+++ b/docs/session-protocol.md
@@ -142,6 +142,8 @@ Only one session may be active at a time. A second `start` while a session is ac
 2. A duplicate command (same `request_id` and every field identical: `action`, `package`,
    `duration_s`, `expires_at`, `reason`) replays the recorded result **without side effects** and
    **before** the rate-limit check.
+   Optional temporal fields are compared exactly as requested. A clock-derived expiry for an omitted
+   `expires_at` is deliberately excluded, so delayed QoS 1 redelivery remains idempotent.
 3. A conflicting duplicate (same `request_id` but different command fields) is rejected with
    `request_id_conflict`.
 4. Lifecycle updates (`launching` → `active`, `ending` → `completed`, `expired`) update the replay
@@ -173,8 +175,9 @@ Only one session may be active at a time. A second `start` while a session is ac
 ## Allowlist
 
 - The allowlist defaults to empty and is stored only in Portal's local preferences.
-- The on-device Application settings page can add installed apps, cycle each app's classification,
-  clear the list, and arm/disarm the feature.
+- When an MQTT broker is configured, the on-device Application settings page can add installed apps,
+  choose a classification from a dialog that shows its default/maximum duration, clear the list,
+  and arm/disarm the feature. The section is hidden when MQTT is not configured.
 - Each entry is `package + classification`; malformed stored entries are ignored and storage is
   capped at 32 entries.
 - Each classification (`HOME`, `MEDIA`, `UTILITY`, `COMMUNICATION`) defines a default duration and a
@@ -189,7 +192,9 @@ Only one session may be active at a time. A second `start` while a session is ac
 - One coordinator is built per service process and preserved across ordinary MQTT reconnects. A local
   allowlist change ends any active session and atomically replaces the coordinator.
 - `DeviceStateHub.foregroundPackage` drives `launching → active`; a broker-independent one-second tick
-  checks expiry so a network outage cannot extend a session. No new Usage Access or location
+  checks expiry only while a session is active, so a network outage cannot extend a session without
+  waking the main loop when idle. Activity launch/return runs directly from the service command
+  executor and never blocks waiting for the main looper. No new Usage Access or location
   permission is requested.
 - The bridge republishes current session state every five seconds. Home Assistant discovery uses
   `expire_after: 15`, so the diagnostic becomes unavailable after broker/device loss instead of

--- a/docs/session-protocol.md
+++ b/docs/session-protocol.md
@@ -1,9 +1,7 @@
 # Bounded App-Session Protocol
 
-This document defines the pure protocol, state machine, and MQTT contract for the Portal
-bounded external-app session feature. It covers only the parser, state machine, and serializer;
-runtime integration (MQTT bridge, Android launcher, settings UI) is intentionally out of scope
-for Phase A.
+This document defines the protocol, state machine, MQTT contract, Android runtime adapter, and
+local settings behavior for Portal's bounded external-app sessions.
 
 ## Design goals
 
@@ -25,10 +23,9 @@ All topics are under the device-specific prefix `portal/<deviceId>/session`.
 | Topic | Direction | QoS | Retained | Purpose |
 |-------|-----------|-----|----------|---------|
 | `portal/<deviceId>/session/command` | Incoming | 1 | No (clear-message retained) | Request to start/end/cancel a session. |
-| `portal/<deviceId>/session/event` | Outgoing | 1 | No | Transient lifecycle events (accepted, launching, active, ending, completed, expired, rejected). |
+| `portal/<deviceId>/session/event` | Outgoing | 1 | No | Transient lifecycle events (accepted, launching, active, ending, completed, expired, failed, rejected). |
 | `portal/<deviceId>/session/state` | Outgoing | 1 | Yes | Last-known lifecycle state for Home Assistant. |
-| `portal/<deviceId>/session/kill_switch/set` | Incoming | 1 | No | Toggle the local kill switch (`ON` / `OFF`). |
-| `portal/<deviceId>/session/kill_switch/state` | Outgoing | 1 | Yes | Current kill-switch state (`ON` / `OFF`). |
+| `portal/<deviceId>/session/enabled` | Outgoing | 1 | Yes | Read-only local enabled state (`ON` / `OFF`). There is no matching command topic. |
 
 The bridge publishes a zero-byte retained message to `.../command` on connect so that a stale
 retained command from a previous broker session cannot be replayed after reconnect.
@@ -136,6 +133,8 @@ Only one session may be active at a time. A second `start` while a session is ac
 | `package_mismatch` | `end`/`cancel` package does not match the active session. |
 | `session_already_ending` | `end`/`cancel` arrived while the session is already ending. |
 | `request_id_conflict` | Duplicate `request_id` with different command fields. |
+| `launch_failed` | Android could not resolve or launch the locally allowed package. |
+| `return_to_launcher_failed` | Android could not return to Portal after an ending or expiry transition. |
 
 ## Idempotency and replay rules
 
@@ -167,15 +166,40 @@ Only one session may be active at a time. A second `start` while a session is ac
 - Toggling the switch to `OFF` while a session is active immediately transitions it to `ending` and
   requests a return to the launcher.
 - There is no remote command that can force sessions to be enabled; the switch must be set on the
-  device or through the local settings surface.
+  device through the local settings surface.
+- Home Assistant discovery exposes enabled state as a read-only diagnostic binary sensor and does
+  not include a `command_topic`.
 
 ## Allowlist
 
-- Allowed packages and their classifications are supplied by the local configuration.
-- `SessionAllowlist.DEFAULT` is an optional seed for convenience, not the only source.
+- The allowlist defaults to empty and is stored only in Portal's local preferences.
+- The on-device Application settings page can add installed apps, cycle each app's classification,
+  clear the list, and arm/disarm the feature.
+- Each entry is `package + classification`; malformed stored entries are ignored and storage is
+  capped at 32 entries.
 - Each classification (`HOME`, `MEDIA`, `UTILITY`, `COMMUNICATION`) defines a default duration and a
   hard maximum duration; the parser enforces both.
+- Runtime launch uses only Android's package-manager launch intent for the exact allowed package.
+  Commands cannot supply a component, URI, deep link, extras, or arbitrary intent.
 - Unknown packages are rejected before any side effect.
+
+## Runtime behavior
+
+- The bridge clears the retained command topic before subscribing. Empty clear payloads are ignored.
+- One coordinator is built per service process and preserved across ordinary MQTT reconnects. A local
+  allowlist change ends any active session and atomically replaces the coordinator.
+- `DeviceStateHub.foregroundPackage` drives `launching → active`; a broker-independent one-second tick
+  checks expiry so a network outage cannot extend a session. No new Usage Access or location
+  permission is requested.
+- The bridge republishes current session state every five seconds. Home Assistant discovery uses
+  `expire_after: 15`, so the diagnostic becomes unavailable after broker/device loss instead of
+  displaying stale `active` state indefinitely.
+- A successful explicit return to Portal completes an `ending` session immediately; foreground
+  observation is a second idempotent confirmation path. Once return begins, expiry cannot overwrite
+  `ending` with `expired`.
+- Portal's existing `DeviceStateHub` continues to cancel/apply `SleepScheduler` around external-app
+  transitions; sessions do not add a second screen-sleep scheduler.
+- Launch/return failures publish bounded `failed` event/state payloads without exception text.
 
 ## Example flow
 

--- a/docs/session-protocol.md
+++ b/docs/session-protocol.md
@@ -1,0 +1,189 @@
+# Bounded App-Session Protocol
+
+This document defines the pure protocol, state machine, and MQTT contract for the Portal
+bounded external-app session feature. It covers only the parser, state machine, and serializer;
+runtime integration (MQTT bridge, Android launcher, settings UI) is intentionally out of scope
+for Phase A.
+
+## Design goals
+
+- **Fail-closed**: unknown packages, malformed commands, disabled kill switch, or expired requests are
+  rejected before any side effect.
+- **Bounded inputs**: payload size, field lengths, durations, and expiry are capped.
+- **Machine-readable errors**: operational reasons are never returned as free-form strings; a fixed
+  enumeration of rejection codes is emitted instead.
+- **Idempotent commands**: a repeated `request_id` replays the recorded result without side effects.
+- **Local-only kill switch**: the feature defaults to disabled and is controlled by a local device flag;
+  there is no remote override.
+- **Restart-safe but not resuming**: a fresh process starts from an idle `completed` state and never
+  resumes a session from the previous process.
+
+## MQTT topics
+
+All topics are under the device-specific prefix `portal/<deviceId>/session`.
+
+| Topic | Direction | QoS | Retained | Purpose |
+|-------|-----------|-----|----------|---------|
+| `portal/<deviceId>/session/command` | Incoming | 1 | No (clear-message retained) | Request to start/end/cancel a session. |
+| `portal/<deviceId>/session/event` | Outgoing | 1 | No | Transient lifecycle events (accepted, launching, active, ending, completed, expired, rejected). |
+| `portal/<deviceId>/session/state` | Outgoing | 1 | Yes | Last-known lifecycle state for Home Assistant. |
+| `portal/<deviceId>/session/kill_switch/set` | Incoming | 1 | No | Toggle the local kill switch (`ON` / `OFF`). |
+| `portal/<deviceId>/session/kill_switch/state` | Outgoing | 1 | Yes | Current kill-switch state (`ON` / `OFF`). |
+
+The bridge publishes a zero-byte retained message to `.../command` on connect so that a stale
+retained command from a previous broker session cannot be replayed after reconnect.
+
+## Command schema
+
+Only the fields listed below are accepted. Extra fields, missing required fields, or type mismatches
+are rejected.
+
+```json
+{
+  "schema_version": 1,
+  "request_id": "req-001",
+  "action": "start",
+  "package": "com.example.app",
+  "duration_s": 60,
+  "expires_at": 1234567890,
+  "reason": "Homework break"
+}
+```
+
+### Field table
+
+| Field | Required | Type | Bounds |
+|-------|----------|------|--------|
+| `schema_version` | Yes | Integer | Must be exactly `1`. Strings/floats rejected. |
+| `request_id` | Yes | String | 1–64 chars, `[A-Za-z0-9_-]`. No spaces or control chars. |
+| `action` | Yes | String | `start`, `end`, or `cancel`. |
+| `package` | Yes | String | 1–128 chars, starts with a letter, only `[A-Za-z0-9._-]`. Must be in the local allowlist. |
+| `duration_s` | No | Integer | Positive. `start` only. Capped at the classification maximum. Defaults to the classification default. |
+| `expires_at` | No | Integer | Unix epoch seconds, in the future, not beyond `now + classification.max`. `start` only. |
+| `reason` | No | String | 0–120 chars after trim; control chars (`< 0x20`) removed except tab. |
+
+`duration_s` and `expires_at` are **not** allowed on `end`/`cancel` commands.
+
+Integer fields are accepted only as JSON integers; strings and floats are rejected (no coercion).
+
+## State/event schema
+
+```json
+{
+  "schema_version": 1,
+  "lifecycle": "active",
+  "request_id": "req-001",
+  "package": "com.example.app",
+  "expires_at": 1234567890,
+  "reason": "Homework break",
+  "code": null
+}
+```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `schema_version` | Integer | Always `1`. |
+| `lifecycle` | String | `accepted`, `launching`, `active`, `ending`, `completed`, `expired`, or `rejected`. |
+| `request_id` | String or `null` | Command request id; `null` for idle state. |
+| `package` | String or `null` | Target package; `null` when not applicable. |
+| `expires_at` | Integer or `null` | Epoch seconds when the active session expires; `null` when inactive. |
+| `reason` | String or `null` | Sanitized user-provided reason from the command. Never an operational error string. |
+| `code` | String or `null` | Machine-readable rejection code; present only when `lifecycle == "rejected"`. |
+
+`null` is emitted for absent values so consumers see a stable schema.
+
+## Transition table
+
+| From event | Current state | Next state | Side effects | Notes |
+|------------|---------------|------------|--------------|-------|
+| `start` command | Idle, kill switch on | `accepted` → `launching` | `LaunchApp` | Recorded for replay. |
+| Foreground = target package | `launching` | `active` | None | Update replay record. |
+| `end`/`cancel` command | `active` | `ending` | `ReturnToLauncher` | Update replay record. |
+| Foreground = launcher / none | `ending` | `completed` | None | Update replay record; session removed. |
+| `onReturnToLauncher()` | `ending` | `completed` | None | Mirrors the above without a foreground report. |
+| `now >= expires_at` | `launching` or `active` | `expired` | `ReturnToLauncher` | Exactly one side effect. |
+| `now >= expires_at` | `ending` | `expired` | None | Terminal. |
+| Kill switch `OFF` | Any active | `ending` | `ReturnToLauncher` | Update replay record. |
+| Restart | — | `completed` (idle) | None | Fresh manager only; no resume. |
+| Duplicate `request_id` | Any | Replay recorded result | None | No side effects. |
+
+Only one session may be active at a time. A second `start` while a session is active is rejected.
+
+## Rejection codes
+
+| Code | Meaning |
+|------|---------|
+| `payload_too_large` | Command payload exceeds 2048 bytes. |
+| `invalid_json` | Payload is not valid JSON. |
+| `unknown_schema_version` | `schema_version` missing, wrong, or non-integer. |
+| `unknown_fields` | Command contains a field not in the schema. |
+| `malformed_request_id` | `request_id` missing, wrong type, or does not match grammar. |
+| `unknown_action` | `action` missing or not `start`/`end`/`cancel`. |
+| `malformed_package` | `package` missing, wrong type, or does not match grammar. |
+| `unknown_package` | `package` is not in the local allowlist. |
+| `malformed_reason` | `reason` is present but not a string. |
+| `duration_out_of_range` | `duration_s` is missing, zero, negative, or non-integer. |
+| `duration_exceeds_max` | `duration_s` exceeds the classification maximum. |
+| `expires_at_invalid` | `expires_at` is present but non-integer. |
+| `expires_at_in_the_past` | `expires_at` is not in the future. |
+| `expires_at_exceeds_max` | `expires_at` is beyond `now + classification.max`. |
+| `end_command_with_temporal_fields` | `end`/`cancel` included `duration_s` or `expires_at`. |
+| `rate_limited` | Commands arrived faster than the configured interval. |
+| `kill_switch_disabled` | The local kill switch is off. |
+| `session_already_active` | A session is already active; only one allowed. |
+| `expired_before_launch` | `start` command was already expired on arrival. |
+| `no_active_session` | `end`/`cancel` arrived with no active session. |
+| `package_mismatch` | `end`/`cancel` package does not match the active session. |
+| `session_already_ending` | `end`/`cancel` arrived while the session is already ending. |
+| `request_id_conflict` | Duplicate `request_id` with different command fields. |
+
+## Idempotency and replay rules
+
+1. The manager records the latest result for every processed `request_id`.
+2. A duplicate command (same `request_id` and every field identical: `action`, `package`,
+   `duration_s`, `expires_at`, `reason`) replays the recorded result **without side effects** and
+   **before** the rate-limit check.
+3. A conflicting duplicate (same `request_id` but different command fields) is rejected with
+   `request_id_conflict`.
+4. Lifecycle updates (`launching` → `active`, `ending` → `completed`, `expired`) update the replay
+   record so that a later duplicate returns the latest state, never a stale `launching` result.
+5. Rejected commands are also recorded, so duplicates replay the same rejection.
+6. Rate-limited commands are recorded, so a duplicate of a previously rate-limited command replays
+   the rate-limited result even after the rate-limit window has passed.
+7. Records expire after a bounded TTL and count cap to prevent unbounded memory growth.
+
+## Restart rules
+
+- The manager is instantiated once per process.
+- A fresh manager has no `activeSession` and an implicit `completed` idle state.
+- The serializer provides `idleState()` to publish the initial retained state after a restart.
+- Any incomplete session from a previous process is intentionally dropped; the new process never
+  resumes or re-activates it.
+
+## Kill switch rules
+
+- The kill switch is a **local-only** device setting; it defaults to `OFF` (fail-closed).
+- When the switch is `OFF`, all `start` commands are rejected with `kill_switch_disabled`.
+- Toggling the switch to `OFF` while a session is active immediately transitions it to `ending` and
+  requests a return to the launcher.
+- There is no remote command that can force sessions to be enabled; the switch must be set on the
+  device or through the local settings surface.
+
+## Allowlist
+
+- Allowed packages and their classifications are supplied by the local configuration.
+- `SessionAllowlist.DEFAULT` is an optional seed for convenience, not the only source.
+- Each classification (`HOME`, `MEDIA`, `UTILITY`, `COMMUNICATION`) defines a default duration and a
+  hard maximum duration; the parser enforces both.
+- Unknown packages are rejected before any side effect.
+
+## Example flow
+
+1. Broker publishes `start` command on `portal/<deviceId>/session/command`.
+2. Bridge parses and forwards to the manager.
+3. Manager emits `accepted` then `launching` events on `.../session/event` and publishes `launching`
+   as retained state on `.../session/state`.
+4. Runtime launches the app; when the app reaches the foreground, manager emits `active`.
+5. When the session expires or an `end` command arrives, manager emits `ending` with a
+   `ReturnToLauncher` side effect, then `completed` once the launcher is in the foreground.
+6. On reconnect, the bridge clears the command topic and publishes the retained `completed` state.


### PR DESCRIPTION
## Summary

- add a strict, versioned bounded external-app session protocol over MQTT
- implement fail-closed parsing, classifications, duration caps, idempotency, rate limits, and lifecycle state
- integrate safe Android launch/return behavior with retained state and non-retained lifecycle events
- add local-only enable and classified package allowlist settings, disabled and empty by default
- expose read-only Home Assistant diagnostics with no remote kill-switch or allowlist mutation path

## Safety model

- only exact locally allowlisted package names can launch
- launch uses `PackageManager.getLaunchIntentForPackage`; commands cannot provide URIs, components, extras, or deep links
- retained command topics are cleared before subscription; empty clear payloads are ignored
- launch and return failures emit bounded machine codes without exception text
- expiry enforcement continues while MQTT is disconnected
- ordinary broker reconnects preserve in-process session state without relaunching
- process restart begins idle and never resumes a previous external session
- successful return completes deterministically; foreground observation remains an idempotent confirmation path

## Home Assistant / MQTT

- command: `portal/<deviceId>/session/command` — QoS 1, non-retained commands
- event: `portal/<deviceId>/session/event` — QoS 1, non-retained
- state: `portal/<deviceId>/session/state` — QoS 1, retained, five-second heartbeat
- enabled: `portal/<deviceId>/session/enabled` — retained, read-only diagnostic
- session diagnostic uses `expire_after: 15` to avoid stale active state after disconnect

## Verification

- `test`: 284 tests, 0 failures/errors/skips
- `assembleDebug`: passed
- `git diff --check`: passed
- debug APK SHA-256: `dfd3b86f1446a8c1185192939af19a0efb9061a42fc7da57de815c61c87a470f`
- independent read-only review: no blockers; actionable lifecycle/concurrency/offline-state findings addressed before final gate

Closes #2
