### PR TITLE
feat(ui): redesign panels with responsive shared controls

### DIFF
--- a/.planning/todos/pending/2026-08-07-support-extensible-home-assistant-entity-icons.md
+++ b/.planning/todos/pending/2026-08-07-support-extensible-home-assistant-entity-icons.md
@@ -1,0 +1,37 @@
+---
+created: 2026-08-07T15:16:43.492Z
+title: Support extensible Home Assistant entity icons
+area: ui
+files:
+  - app/src/main/java/com/iblu01/portallauncher/HaStateRepository.kt:151
+  - app/src/main/java/com/iblu01/portallauncher/ui/components/LauncherIcons.kt:36
+  - app/src/main/java/com/iblu01/portallauncher/ui/components/MediaDevicesPanel.kt:48
+---
+
+## Problem
+
+Portal currently ignores entity icons returned by Home Assistant and maps every item through a
+small built-in Compose icon table. This loses user customizations such as `mdi:sonos` on media
+players. The repository already downloads the Home Assistant entity registry, but only retains
+area and device relationships. A fixed bundled icon list would still prevent users and third-party
+integrations from introducing new icon families without an application release.
+
+## Solution
+
+Add an extensible entity-icon pipeline with this resolution order:
+
+1. User-defined entity-registry `icon` (or compact display-registry `ic`).
+2. State attribute `icon` supplied by the integration.
+3. Authenticated `entity_picture` when an actual image is appropriate.
+4. Portal's domain/device-class fallback.
+
+Persist the resolved icon reference alongside entity metadata rather than mutating the HA state
+attributes. Introduce an icon-provider interface capable of resolving namespaced references such
+as `mdi:sonos`. Ship an MDI provider by default, cache rendered/vector assets locally, and allow
+additional third-party icon repositories or packs to be registered through a manifest containing
+namespace, version, license, checksum, icon index, and asset base URL. Providers must support
+offline fallback, bounded cache storage, safe SVG/vector parsing, repository allowlisting or
+explicit user approval, update/version invalidation, and graceful fallback for missing icons.
+
+Use the same resolver for home pills, media-player rows, panel headers, accessory lists, and future
+components so a Home Assistant customization is visually consistent everywhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.0.5-beta
+
+### Added
+
+- **Entity contracts**: `ClimateEntityContract` and `FanEntityContract` — UI-neutral adapters that extract capabilities from Home Assistant entities. Climate handles all thermostat modes (heat, cool, auto, heat_cool, dry, fan_only) with target temp ranges. Fan maps to one of three control modes: on/off, percentage slider, or preset selector.
+- **`PortalThreeWayControl`**: reusable three-action capsule control (previous / center / next) shared between media player and covers, with compact and regular densities.
+- **`PortalVacuum`**: dedicated vacuum controls — large play/pause disk button, status chip, action chips (stop/dock/locate), room selection chips with toggles.
+- **`HorizontalSegmentedSelector`**: Apple Home-style horizontal picker with drag gesture, haptics, and animated floating capsule highlight.
+- **Alarm alert handling**: `PanelSource.ALERT` with highest priority — alarm chips surface immediately, `SleepScheduler.alarmHold` keeps screen on until disarmed, dismiss/rearm logic with per-alarm key.
+- **Battery display**: vacuum entities show battery percentage in `SidePanel` header and quick tiles, with color-coded indicators (red ≤10%, orange ≤20%).
+- **Domain-specific accent colors**: lock turquoise, fan blue, thermostat orange/blue.
+- **Playground screen**: interactive panel lab with 14 fake entities for testing all panel layouts.
+- **WallpaperPage** activated (was `.disabled`) with native Android wallpaper picker integration.
+- **System wallpaper mode**: new `"system"` background mode uses native `WallpaperService` with scroll offset protocol for live wallpaper parallax.
+- **Tests**: `PanelStateTest` (28+ reducer scenarios), `ClimateEntityContractTest`, `FanEntityContractTest`.
+
+### Changed
+
+- **All panel controls are now responsive**: sliders, switches, selectors, keypad use proportional scaling (`RoundedCornerShape(percent = 30)`, 96:240 viewport ratio, `contentScale`) instead of fixed dp values. Controls adapt to any screen size (wall tablet, phone).
+- **`PanelHeader`**: unified header component used by all panels — frosted navigation circle, optional icon + title, configurable accent, battery indicator.
+- **Light panel**: single `AdaptiveLightDetail` layout replaces separate portrait/landscape layouts. Smoother color presets (sunset, candle, soft pink, forest, lagoon, dusk, lavender, evening).
+- **Thermostat panel**: Canvas‑drawn arc replaced by `ClimateEntityContract` + `PortalThermostat`. Mode selection via `WheelPicker`. Optimistic UI with 5s timeout. Support for `heat_cool` range mode with dual handles.
+- **Cover panel**: three separate `GlassButton` replaced by single `PortalThreeWayControl` with labels. Slider viewport responsive.
+- **Vacuum panel**: `PanelModeButton` rows replaced by `VacuumRunButton` + `VacuumStatusChip` + `VacuumActionChips`. Speed selector via `WheelPicker`.
+- **Fan/Switch controls**: `BigCircleButton` replaced by responsive `VerticalSwitch` with optimistic UI. Fan uses `FanEntityContract` for mode‑appropriate controls (on/off switch, percentage slider, or preset selector).
+- **Alarm panel**: `AccessoryGrid` replaced by responsive `VerticalSegmentedSelector`. Added `DISABLED` arm state. Optimistic arming with 5s timeout. Keypad pulse animation during code verification.
+- **Lock panel**: accent changed to turquoise. Responsive viewport.
+- **Media player**: transport controls replaced by `PortalThreeWayControl`. Header uses `PanelHeader` with source title.
+- **WallpaperPage**: activated from `.disabled`; new "Choose Android wallpaper" picker integration.
+- **SettingsScreen**: new `WALLPAPER` page and navigation tile.
+- **styles.xml**: window background transparent with `windowShowWallpaper=true` for native wallpaper support.
+- **PRODUCT.md**: enriched with 7 design principles, Apple Home interaction reference, wall-panel usage personas.
+
+### Performance
+
+- `PortalWheelPicker`: only emits `onSelect` when scrolling stops (not on every item), reducing HA service calls.
+- Keypad: input disabled during loading state to prevent double-taps.
+
 ## 0.0.4-beta
 
 ### Added

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,28 +6,33 @@ product
 
 ## Users
 
-People configuring an Android phone, tablet, or wall-mounted smart display for shared household use. During onboarding they are close to the device, focused on setup, and may use a small touch screen or a short landscape window.
+Household members using an Android device as a shared wall-mounted smart-home panel, often from several feet away and in low light. They need to understand important home state at a glance and reach a focused control with one tap, without learning a dense dashboard. During onboarding they are close to the device, focused on setup, and may use a small touch screen or a short landscape window.
 
 ## Product Purpose
 
-Portal Launcher turns an Android device into a calm, appliance-like home launcher with optional Home Assistant and MQTT integration. Onboarding should make the device usable quickly, explain optional capabilities honestly, and let users complete setup without technical expertise.
+Portal Launcher turns an Android device into a calm, appliance-like home launcher with optional Home Assistant and MQTT integration. Success means the resting screen stays calm and legible, urgent states surface themselves, and each panel lets anyone complete one device-specific task quickly. Onboarding should make the device usable quickly, explain optional capabilities honestly, and let users complete setup without technical expertise.
 
 ## Brand Personality
 
-Calm, direct, trustworthy. The interface should feel deliberate and appliance-like, with familiar controls and no decorative complexity.
+Calm, simple, quiet, and precise. The interaction reference is Apple Home: familiar controls, restrained motion, and direct manipulation whose form reflects the device being controlled.
 
 ## Anti-references
 
-Dense Home Assistant dashboards, phone settings pages presented as one long form, miniature desktop or tablet layouts squeezed onto small screens, and onboarding that hides optionality or blocks progress on nonessential permissions.
+Dense Home Assistant dashboards, scrolling grids of dozens of tiles, decorative motion, loud gradients, phone settings pages presented as one long form, miniature desktop or tablet layouts squeezed onto small screens, and onboarding that hides optionality or blocks progress on nonessential permissions.
 
 ## Design Principles
 
+- Keep one primary task per screen or panel.
+- Make important state readable at a glance and from a distance.
 - One meaningful decision per screen, especially on compact displays.
 - Adapt the information architecture to the available space instead of shrinking a large-screen composition.
+- Reuse a small, consistent control vocabulary across device domains.
+- Let each control visually reflect the thing or state it manipulates.
 - Keep the primary action predictable and easy to reach while content remains independently scrollable.
+- Keep the idle experience dark, still, and unobtrusive.
 - Explain why a permission or integration matters before asking for it.
 - Preserve user control: optional capabilities stay optional and setup can always progress.
 
 ## Accessibility & Inclusion
 
-Prioritize close-range readability during setup, clear hierarchy, 48 dp touch targets, logical keyboard and D-pad navigation, sufficient contrast, reduced-motion support, and layouts that remain usable with larger text. Everyday glance-distance requirements apply to the launcher itself, not to onboarding.
+Prioritize large touch targets, strong dark-theme contrast, clear icon-and-label pairings, and state cues that do not rely on color alone. Keep motion restrained and preserve a usable reduced-motion path. Support logical keyboard and D-pad navigation, sufficient contrast, and layouts that remain usable with larger text. Controls must remain readable across supported wall-panel, phone, and tablet sizes.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.iblu01.portallauncher"
         minSdk = 28
         targetSdk = 28
-        versionCode = 4
-        versionName = "0.0.4-beta"
+        versionCode = 5
+        versionName = "0.0.5-beta"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
@@ -7,6 +7,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.appwidget.AppWidgetManager
+import android.app.WallpaperManager
 import android.os.Environment
 import android.provider.Settings
 import android.view.MotionEvent
@@ -48,6 +49,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -121,6 +123,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import androidx.compose.runtime.snapshotFlow
 
 @AndroidEntryPoint
 class LauncherActivity : ComponentActivity() {
@@ -345,6 +350,10 @@ class LauncherActivity : ComponentActivity() {
     }
 
     private fun setWallpaper() {
+        // The Android picker changes the system wallpaper, so switch Portal to the matching source
+        // before leaving. This also makes live wallpapers visible as soon as their preview applies.
+        prefs.backgroundMode = "system"
+        SettingsChangeBus.get().emit("backgroundMode")
         openFromLauncher(
             Intent.createChooser(Intent(Intent.ACTION_SET_WALLPAPER), getString(R.string.toast_choose_wallpaper))
         )
@@ -488,6 +497,29 @@ private fun PortalLauncherApp(
         derivedStateOf { appPageCount(placedItems.value, spare = gridDrag.isDragging) }
     }
     val pagerState = rememberLauncherPagerState { appPages.value }
+
+    // Match Launcher3's wallpaper protocol: advertise the horizontal page step and continuously
+    // report the pager position. WallpaperService handles static and live wallpaper movement;
+    // failures are intentionally ignored because some fixed-wallpaper OEM implementations reject
+    // offsets even though displaying the wallpaper still works.
+    val hostView = LocalView.current
+    LaunchedEffect(hostView, pagerState, appPages.value, backgroundMode) {
+        if (backgroundMode != "system") return@LaunchedEffect
+        val manager = WallpaperManager.getInstance(hostView.context)
+        val pageCount = (PAGE_FIRST_APP + appPages.value).coerceAtLeast(1)
+        val xStep = if (pageCount > 1) 1f / (pageCount - 1) else 0f
+        runCatching { manager.setWallpaperOffsetSteps(xStep, 0f) }
+        snapshotFlow { pagerState.currentPage + pagerState.currentPageOffsetFraction }
+            .map { page ->
+                if (pageCount > 1) (page / (pageCount - 1)).coerceIn(0f, 1f) else 0.5f
+            }
+            .distinctUntilChanged()
+            .collect { x ->
+                hostView.windowToken?.let { token ->
+                    runCatching { manager.setWallpaperOffsets(token, x, 0.5f) }
+                }
+            }
+    }
 
     LaunchedEffect(Unit) {
         SettingsChangeBus.get().changes.collect { key ->
@@ -720,9 +752,14 @@ private fun PortalLauncherApp(
 
     // Only the media chip hides when its panel is open — other chips stay visible.
     val mediaChipId = if (panelContent is PanelContent.Media) "media_group" else null
-    // Placement (design §7) decides tray vs floating; the media chip hides while its panel is open.
+    // Presence only renders through the top-left ambient indicator. Energy stays available to the
+    // data layer but has no launcher pill; the media chip hides while its panel is open.
     val presenceChip = chips.firstOrNull { it.chipPlacement() == ChipPlacement.FLOATING }
-    val visibleChips = chips.filterNot { it.id == mediaChipId || it.chipPlacement() == ChipPlacement.FLOATING }
+    val visibleChips = chips.filterNot {
+        it.id == mediaChipId ||
+            it.chipPlacement() == ChipPlacement.FLOATING ||
+            it.kind == PillKind.ENERGY
+    }
     // The selected chip (its panel is open) gets a highlighted style in the tray.
     val selectedChipKey = (panel.request as? PanelRequest.Chip)?.key
 

--- a/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
@@ -147,6 +147,8 @@ class LauncherActivity : ComponentActivity() {
      * appears and coming back lands on the clock instead of where the icon was.
      */
     private var openingFromLauncher = false
+    /** True while an alarm is counting down / triggered: the screen must not lock under the keypad. */
+    private var alarmHold = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -186,6 +188,7 @@ class LauncherActivity : ComponentActivity() {
                     onAddWidget = ::addWidget,
                     onRemoveWidget = { widgets.release(it) },
                     keepPageAcrossPause = ::keepPageAcrossPause,
+                    onAlarmAlerting = ::onAlarmAlerting,
                 )
             }
         }
@@ -263,6 +266,9 @@ class LauncherActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        // The hold lives in a process-wide object: leaving it set would keep the idle timeout off
+        // for good if the alarm is still alerting when the launcher goes away.
+        onAlarmAlerting(false)
         appList.stop()
         super.onDestroy()
     }
@@ -280,8 +286,19 @@ class LauncherActivity : ComponentActivity() {
         return super.dispatchTouchEvent(ev)
     }
 
+    /**
+     * Alarm entry delay / triggered: hold the screen awake and suspend the idle timeout, so the
+     * disarm keypad the UI just forced open cannot be locked away before the code is typed.
+     */
+    private fun onAlarmAlerting(active: Boolean) {
+        if (alarmHold == active) return
+        alarmHold = active
+        SleepScheduler.setAlarmHold(this, active)
+        applyPowerPolicy()
+    }
+
     private fun applyPowerPolicy() {
-        if (prefs.powerMode == PowerMode.ALWAYS_ON || prefs.devKeepScreenOn) {
+        if (alarmHold || prefs.powerMode == PowerMode.ALWAYS_ON || prefs.devKeepScreenOn) {
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         } else {
             window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -437,6 +454,7 @@ private fun PortalLauncherApp(
     onAddWidget: (WidgetOffer) -> Unit,
     onRemoveWidget: (Int) -> Unit,
     keepPageAcrossPause: () -> Boolean,
+    onAlarmAlerting: (Boolean) -> Unit,
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     var backgroundMode by remember { mutableStateOf(prefs.backgroundMode) }
@@ -585,15 +603,23 @@ private fun PortalLauncherApp(
     val panelChip by vm.panelChip.collectAsStateWithLifecycle()
     val autoReturnState by autoReturnTimer.state.collectAsStateWithLifecycle()
 
+    // Alarm entry delay / triggered: the VM forces the keypad panel up (PanelSource.ALERT); the
+    // Activity mirrors the flag onto the screen policy so nothing locks it away mid-countdown.
+    val alarmAlerting by vm.alarmAlerting.collectAsStateWithLifecycle()
+    LaunchedEffect(alarmAlerting) { onAlarmAlerting(alarmAlerting) }
+
     // Auto-return is for *user* state only: a USER panel, the expanded tray, the app overlay. An
     // AUTO (media) panel is the resting state while something plays, so it must not arm the timer.
     // Sitting on the apps page is user state too, exactly like the expanded tray: the wall panel
     // must fall back to the clock on its own.
     val onAppsPage = pagerState.currentPage != PAGE_CLOCK
     val userState = pillsExpanded || overlayVisible || onAppsPage || menuTarget != null || showHidden
-    LaunchedEffect(panel.request, panel.source, userState, resumed) {
+    // While an alarm is alerting the countdown is suspended outright: returning to the clock would
+    // take the disarm keypad off screen exactly when it is needed.
+    LaunchedEffect(panel.request, panel.source, userState, resumed, alarmAlerting) {
         val userPanelOpen = panel.request != null && panel.source == PanelSource.USER
-        if (resumed && (userPanelOpen || userState)) autoReturnTimer.start() else autoReturnTimer.stop()
+        if (resumed && !alarmAlerting && (userPanelOpen || userState)) autoReturnTimer.start()
+        else autoReturnTimer.stop()
     }
 
     LaunchedEffect(autoReturnState.shouldReturn) {

--- a/app/src/main/java/com/iblu01/portallauncher/LauncherChip.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/LauncherChip.kt
@@ -22,4 +22,6 @@ data class LauncherChip(
     val details: List<PillDetail> = emptyList(),
     /** Accessory kind, drives per-accessory tap behaviour and which control panel opens. */
     val kind: PillKind = PillKind.GENERIC,
+    /** Battery percentage resolved from the entity itself or one of its related HA sensors. */
+    val batteryPercent: Int? = null,
 )

--- a/app/src/main/java/com/iblu01/portallauncher/PillPriorityEngine.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/PillPriorityEngine.kt
@@ -344,6 +344,13 @@ class PillPriorityEngine(private val context: Context) {
         val unit = e.attributes.optString("unit_of_measurement")
         val phase = related.firstOrNull { it.entityId.contains("cycle") || it.entityId.contains("task_state") || it.entityId.contains("etat_du_cycle") }?.state
         val battery = related.firstOrNull { it.deviceClass == "battery" && it.state.toFloatOrNull() != null }?.state
+        val batteryPercent = listOf("battery_level", "battery", "battery_percentage")
+            .firstNotNullOfOrNull { key ->
+                if (e.attributes.has(key)) e.attributes.optDouble(key).takeIf { !it.isNaN() } else null
+            }
+            ?.roundToInt()
+            ?.takeIf { it in 0..100 }
+            ?: battery?.toFloatOrNull()?.roundToInt()?.takeIf { it in 0..100 }
         val completionTimeStr = completionEntity?.state
         
         val formattedCompletion = runCatching {
@@ -460,6 +467,7 @@ class PillPriorityEngine(private val context: Context) {
         }
         val details = if (rule.kind == PillKind.AIR) listOf(PillDetail(e.name, e.state + e.attributes.optString("unit_of_measurement"))) else emptyList()
         return LauncherChip(rule.entityId, rule.kind.icon, finalLabel, qualitativeAir, visual,
-            ((progressValue ?: 0.0) / 100.0).toFloat().coerceIn(0f, 1f), e.entityId, score, false, details, kind = rule.kind)
+            ((progressValue ?: 0.0) / 100.0).toFloat().coerceIn(0f, 1f), e.entityId, score, false, details,
+            kind = rule.kind, batteryPercent = batteryPercent)
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/SettingsActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/SettingsActivity.kt
@@ -154,6 +154,20 @@ class SettingsActivity : ComponentActivity() {
 
         override fun onSetBackgroundMode(mode: String) {
             prefs.backgroundMode = mode
+            SettingsChangeBus.get().emit("backgroundMode")
+        }
+
+        override fun onOpenSystemWallpaperPicker() {
+            prefs.backgroundMode = "system"
+            SettingsChangeBus.get().emit("backgroundMode")
+            runCatching {
+                startActivity(Intent.createChooser(
+                    Intent(Intent.ACTION_SET_WALLPAPER),
+                    getString(R.string.toast_choose_wallpaper),
+                ))
+            }.onFailure {
+                Toast.makeText(this@SettingsActivity, R.string.toast_cannot_open_wallpaper_picker, Toast.LENGTH_SHORT).show()
+            }
         }
 
         override fun onOpenOpacityPreview() {

--- a/app/src/main/java/com/iblu01/portallauncher/SleepScheduler.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/SleepScheduler.kt
@@ -20,7 +20,22 @@ object SleepScheduler {
     private const val ARM_THROTTLE_MS = 5_000L
     @Volatile private var lastArmAtMs = 0L
 
+    /**
+     * Set while an alarm is in its entry delay or triggered: the screen must stay up so the disarm
+     * keypad is reachable, so every path here becomes a no-op and any pending idle alarm is dropped.
+     */
+    @Volatile private var alarmHold = false
+
+    /** Called by the UI when the alarm enters/leaves an alerting state. */
+    fun setAlarmHold(context: Context, hold: Boolean) {
+        if (alarmHold == hold) return
+        alarmHold = hold
+        Log.i(TAG, "alarm hold=$hold")
+        if (hold) cancel(context) else apply(context)
+    }
+
     fun apply(context: Context) {
+        if (alarmHold) { cancel(context); return }
         val prefs = Prefs(context)
         if (prefs.devKeepScreenOn || !prefs.screenTimeoutEnabled || prefs.powerMode == PowerMode.ALWAYS_ON) {
             cancel(context)
@@ -36,12 +51,14 @@ object SleepScheduler {
     }
 
     fun onInteraction(context: Context) {
+        if (alarmHold) return
         val prefs = Prefs(context)
         if (prefs.devKeepScreenOn || !prefs.screenTimeoutEnabled || prefs.powerMode == PowerMode.ALWAYS_ON) return
         if (DeviceStateHub.current.display == DisplayMode.SCREENSAVER) arm(context)
     }
 
     fun onIdleElapsed(context: Context) {
+        if (alarmHold) return
         val prefs = Prefs(context)
         if (prefs.devKeepScreenOn || !prefs.screenTimeoutEnabled || prefs.powerMode == PowerMode.ALWAYS_ON) return
         if (!isInteractive(context)) return
@@ -52,6 +69,7 @@ object SleepScheduler {
     }
 
     fun arm(context: Context) {
+        if (alarmHold) { cancel(context); return }
         val prefs = Prefs(context)
         if (prefs.devKeepScreenOn || !prefs.screenTimeoutEnabled || prefs.powerMode == PowerMode.ALWAYS_ON) {
             cancel(context)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/LauncherViewModel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/LauncherViewModel.kt
@@ -8,6 +8,8 @@ import com.iblu01.portallauncher.domain.model.PillSnapshot
 import com.iblu01.portallauncher.domain.model.PlayingMedia
 import com.iblu01.portallauncher.domain.model.TemperatureSummary
 import kotlinx.coroutines.flow.Flow
+import com.iblu01.portallauncher.ui.mapper.toPanelKind
+import com.iblu01.portallauncher.ui.model.PanelKind
 import com.iblu01.portallauncher.ui.panel.PanelEvent
 import com.iblu01.portallauncher.ui.panel.PanelRequest
 import com.iblu01.portallauncher.ui.panel.PanelState
@@ -41,6 +43,23 @@ data class LauncherUiState(
 )
 
 /**
+ * Alarm states that must put the disarm keypad on screen by themselves: `pending` is the entry
+ * delay (the siren is about to fire) and `triggered` is the siren itself. `arming` (exit delay) is
+ * deliberately excluded — the user just armed and is walking out, forcing a keypad there would be
+ * in the way.
+ */
+private val ALERTING_ALARM_STATES = setOf("pending", "triggered")
+
+/** The alarm chip that is currently alerting, as a panel request — null when none is. */
+private fun LauncherUiState.alarmAlert(): PanelRequest.Chip? {
+    val chip = chips.firstOrNull {
+        it.toPanelKind() == PanelKind.ALARM &&
+            latestStates[it.entityId]?.state?.lowercase() in ALERTING_ALARM_STATES
+    } ?: return null
+    return PanelRequest.Chip(chip.id, PanelKind.ALARM)
+}
+
+/**
  * Owns the screen state (MAD/UDF). Collects the injected snapshot `Flow` (transforms already run on
  * `Dispatchers.Default`) into a conflated `StateFlow`. Also drives the panel state machine
  * ([reduce]) via [onEvent] and resolves the panel chip last-known-good.
@@ -67,6 +86,15 @@ class LauncherViewModel(
             )
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LauncherUiState())
+
+    /**
+     * True while an alarm is in its entry delay or already triggered. The Activity mirrors this
+     * onto the screen policy so the idle timeout cannot lock the panel away mid-countdown.
+     */
+    val alarmAlerting: StateFlow<Boolean> = uiState
+        .map { it.alarmAlert() != null }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     private val _panel = MutableStateFlow(PanelState())
     val panel: StateFlow<PanelState> = _panel.asStateFlow()
@@ -105,6 +133,21 @@ class LauncherViewModel(
             ) { primaryId, _ -> primaryId }
                 .collect { id ->
                     if (id != null) onEvent(PanelEvent.MediaAutoOpen(id)) else onEvent(PanelEvent.MediaStopped)
+                }
+        }
+
+        // Alarm entry delay / triggered: the keypad panel is forced open, over whatever is showing.
+        // Keyed on "is the panel closed" for the same reason as media above — if the user navigates
+        // elsewhere and comes back to the resting state while the alarm is still counting down, the
+        // keypad must come back too. `dismissedAlertKey` in the reducer is what makes an explicit
+        // dismissal stick.
+        viewModelScope.launch {
+            combine(
+                uiState.map { it.alarmAlert() }.distinctUntilChanged(),
+                _panel.map { it.request == null }.distinctUntilChanged(),
+            ) { alert, _ -> alert }
+                .collect { alert ->
+                    if (alert != null) onEvent(PanelEvent.AlarmAlert(alert)) else onEvent(PanelEvent.AlarmCleared)
                 }
         }
     }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/AccessoryToggles.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/AccessoryToggles.kt
@@ -1,10 +1,7 @@
 package com.iblu01.portallauncher.ui.components
 
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,77 +9,74 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Air
-import androidx.compose.material.icons.outlined.PowerSettingsNew
 import androidx.compose.material.icons.outlined.Sync
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.LauncherChip
 import com.iblu01.portallauncher.ui.LocalCallService
 import com.iblu01.portallauncher.ui.theme.AppleColors
-import com.iblu01.portallauncher.ui.theme.AppleMotion
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 import com.iblu01.portallauncher.R
 import androidx.compose.ui.res.stringResource
+import com.iblu01.portallauncher.ui.components.controls.VerticalSwitch
+import com.iblu01.portallauncher.ui.components.controls.VerticalFillSlider
+import com.iblu01.portallauncher.ui.components.controls.VerticalSegmentedSelector
+import com.iblu01.portallauncher.ui.components.controls.ControlContentLayout
 
-/**
- * The big round HomeKit-style accessory button used by simple on/off accessories
- * (lock, switch, fan). Tap toggles; colour and glyph reflect the live state.
- */
-@Composable
-fun BigCircleButton(
-    active: Boolean,
-    color: Color,
-    icon: ImageVector,
-    caption: String,
-    onClick: () -> Unit,
-) {
-    val bg by animateColorAsState(color.copy(alpha = if (active) 0.22f else 0.08f), AppleMotion.spring(), label = "bigBtnBg")
-    val tint by animateColorAsState(if (active) color else AppleColors.secondary, AppleMotion.spring(), label = "bigBtnTint")
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(
-            modifier = Modifier
-                .size(156.dp)
-                .clip(CircleShape)
-                .background(bg, CircleShape)
-                .border(0.5.dp, AppleColors.frostedBorder, CircleShape)
-                .appleClickable(onClick),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(icon, null, tint = tint, modifier = Modifier.size(66.dp))
-        }
-        Spacer(Modifier.height(14.dp))
-        Text(caption, style = AppleTypography.titleMedium.copy(fontSize = 17.sp), color = AppleColors.primary)
-    }
+private sealed interface FanModeOption {
+    data object Off : FanModeOption
+    data class Preset(val value: String) : FanModeOption
 }
 
 @Composable
-fun SwitchControl(chip: LauncherChip) {
+fun SwitchControl(chip: LauncherChip, modifier: Modifier = Modifier) {
     val callService = LocalCallService.current
     val entity = rememberEntity(chip.entityId)
     if (entity == null || entity.isUnavailable()) { PanelUnavailable(); return }
     val on = entity.state.equals("on", true)
-    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-        Spacer(Modifier.height(6.dp))
-        BigCircleButton(on, AppleColors.active, Icons.Outlined.PowerSettingsNew, if (on) stringResource(R.string.switch_state_on) else stringResource(R.string.switch_state_off)) {
-            callService("switch", "toggle", chip.entityId)
+    var pending by remember(chip.entityId) { mutableStateOf<Boolean?>(null) }
+    LaunchedEffect(on, pending) {
+        val expected = pending ?: return@LaunchedEffect
+        if (on == expected) pending = null else {
+            kotlinx.coroutines.delay(5_000)
+            if (pending == expected && on != expected) pending = null
+        }
+    }
+    val displayedOn = pending ?: on
+    val onLabel = stringResource(R.string.switch_state_on)
+    val offLabel = stringResource(R.string.switch_state_off)
+    Column(modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxWidth(0.54f).weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            val ratio = 96f / 240f
+            val controlHeight = minOf(maxHeight, maxWidth / ratio)
+            val controlWidth = controlHeight * ratio
+            VerticalSwitch(
+                checked = displayedOn,
+                onCheckedChange = { wanted ->
+                    if (wanted != displayedOn) {
+                        pending = wanted
+                        callService("switch", if (wanted) "turn_on" else "turn_off", chip.entityId)
+                    }
+                },
+                accent = AppleColors.active,
+                label = { enabled -> if (enabled) onLabel else offLabel },
+                modifier = Modifier.size(controlWidth, controlHeight),
+            )
         }
         Spacer(Modifier.height(20.dp))
         chip.details.forEach { PanelDetailRow(it) }
@@ -90,40 +84,88 @@ fun SwitchControl(chip: LauncherChip) {
 }
 
 @Composable
-fun FanControl(chip: LauncherChip) {
+fun FanControl(chip: LauncherChip, modifier: Modifier = Modifier) {
     val callService = LocalCallService.current
     val entity = rememberEntity(chip.entityId)
     if (entity == null || entity.isUnavailable()) { PanelUnavailable(); return }
-    val on = entity.state.equals("on", true)
-    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+    val fan = entity.toFanContract()
+    val onLabel = stringResource(R.string.fan_state_on)
+    val offLabel = stringResource(R.string.fan_state_off)
+    val speedLabel = stringResource(R.string.fan_speed_label)
+    Column(modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(Modifier.height(6.dp))
-        BigCircleButton(on, AppleColors.accent, Icons.Outlined.Air, if (on) stringResource(R.string.fan_state_on) else stringResource(R.string.fan_state_off)) {
-            callService("fan", "toggle", chip.entityId)
+        Text(
+            if (fan.primaryControl is FanPrimaryControl.OnOff) if (fan.isOn) onLabel else offLabel else speedLabel,
+            style = AppleTypography.titleMedium.copy(fontSize = 17.sp),
+            color = AppleColors.primary,
+        )
+        Spacer(Modifier.height(12.dp))
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxWidth(0.54f).weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            val ratio = 96f / 240f
+            val controlHeight = minOf(maxHeight, maxWidth / ratio)
+            val controlWidth = controlHeight * ratio
+        when (val control = fan.primaryControl) {
+            FanPrimaryControl.OnOff -> {
+                VerticalSwitch(
+                    checked = fan.isOn,
+                    onCheckedChange = { wanted -> callService("fan", if (wanted) "turn_on" else "turn_off", chip.entityId) },
+                    accent = AppleColors.fanAccent,
+                    icon = { Icons.Outlined.Air },
+                    label = { if (it) onLabel else offLabel },
+                    modifier = Modifier.size(controlWidth, controlHeight),
+                )
+            }
+            is FanPrimaryControl.Percentage -> {
+                VerticalFillSlider(
+                    value = control.value.toFloat(),
+                    onValueChange = {},
+                    valueRange = 0f..100f,
+                    accent = AppleColors.fanAccent,
+                    hapticSteps = (100 / control.step).coerceAtLeast(1),
+                    icon = Icons.Outlined.Air,
+                    label = { "${it.toInt()} %" },
+                    onValueChangeFinished = { value ->
+                        callService("fan", "set_percentage", chip.entityId, mapOf("percentage" to value.toInt()))
+                    },
+                    modifier = Modifier.size(controlWidth, controlHeight),
+                )
+            }
+            is FanPrimaryControl.Presets -> {
+                val options = listOf(FanModeOption.Off) + control.values.map(FanModeOption::Preset)
+                val selected = if (!fan.isOn) FanModeOption.Off else {
+                    FanModeOption.Preset(control.selected ?: control.values.first())
+                }
+                VerticalSegmentedSelector(
+                    options = options,
+                    selected = selected,
+                    onSelect = { option -> when (option) {
+                        FanModeOption.Off -> callService("fan", "turn_off", chip.entityId)
+                        is FanModeOption.Preset -> callService("fan", "set_preset_mode", chip.entityId, mapOf("preset_mode" to option.value))
+                    } },
+                    label = { option -> when (option) {
+                        FanModeOption.Off -> offLabel
+                        is FanModeOption.Preset -> option.value.replace('_', ' ').replaceFirstChar { it.uppercase() }
+                    } },
+                    icon = { option -> if (option == FanModeOption.Off) null else Icons.Outlined.Air },
+                    accent = AppleColors.fanAccent,
+                    isNeutral = { it == FanModeOption.Off },
+                    contentLayout = ControlContentLayout.Horizontal,
+                    segmentHeight = controlHeight / options.size,
+                    modifier = Modifier.width(controlWidth),
+                )
+            }
+        }
         }
         Spacer(Modifier.height(20.dp))
 
-        if (entity.supports(FanFeature.SET_SPEED)) {
-            val committed = entity.attributes.optInt("percentage", 0)
-            var slider by remember(committed) { mutableFloatStateOf(committed.toFloat()) }
-            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                Text(stringResource(R.string.fan_speed_label), style = AppleTypography.bodyLarge, color = AppleColors.secondary, modifier = Modifier.weight(1f))
-                Text("${slider.toInt()}%", style = AppleTypography.bodyLarge, color = AppleColors.primary)
-            }
-            Slider(
-                value = slider,
-                onValueChange = { slider = it },
-                onValueChangeFinished = { callService("fan", "set_percentage", chip.entityId, mapOf("percentage" to slider.toInt())) },
-                valueRange = 0f..100f,
-                colors = SliderDefaults.colors(thumbColor = AppleColors.accent, activeTrackColor = AppleColors.accent),
-            )
-        }
-
-        if (entity.supports(FanFeature.OSCILLATE)) {
-            val oscillating = entity.attributes.optBoolean("oscillating", false)
+        if (fan.supportsOscillation) {
             Spacer(Modifier.height(4.dp))
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-                PanelModeButton(stringResource(R.string.fan_oscillation_label), Icons.Outlined.Sync, oscillating) {
-                    callService("fan", "oscillate", chip.entityId, mapOf("oscillating" to !oscillating))
+                PanelModeButton(stringResource(R.string.fan_oscillation_label), Icons.Outlined.Sync, fan.isOscillating) {
+                    callService("fan", "oscillate", chip.entityId, mapOf("oscillating" to !fan.isOscillating))
                 }
             }
         }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/AirQualityPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/AirQualityPanel.kt
@@ -73,31 +73,12 @@ private fun statusColor(value: String): Color = when {
 
 @Composable
 private fun AirQualityHeader(onBack: () -> Unit) {
-    Box(Modifier.fillMaxWidth().height(36.dp)) {
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .size(36.dp)
-                .clip(CircleShape)
-                .background(AppleColors.frostedFill)
-                .border(0.5.dp, AppleColors.frostedBorder, CircleShape)
-                .clickable { onBack() },
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                Icons.Filled.ArrowBack,
-                contentDescription = stringResource(R.string.air_quality_back_desc),
-                tint = AppleColors.secondary,
-                modifier = Modifier.size(18.dp),
-            )
-        }
-        Text(
-            stringResource(R.string.air_quality_panel_title),
-            style = AppleTypography.labelSmall.copy(fontSize = 12.sp, letterSpacing = 1.sp),
-            color = AppleColors.tertiary,
-            modifier = Modifier.align(Alignment.Center),
-        )
-    }
+    PanelHeader(
+        title = stringResource(R.string.air_quality_panel_title),
+        onNavigation = onBack,
+        navigationIcon = Icons.Filled.ArrowBack,
+        navigationContentDescription = stringResource(R.string.air_quality_back_desc),
+    )
 }
 
 /** Centered status word with a soft colored glow — the emotional anchor of the panel. */

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/AlarmPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/AlarmPanel.kt
@@ -2,18 +2,20 @@ package com.iblu01.portallauncher.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Bedtime
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Luggage
 import androidx.compose.material.icons.outlined.NightShelter
+import androidx.compose.material.icons.outlined.PowerSettingsNew
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -26,14 +28,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.LauncherChip
 import com.iblu01.portallauncher.ui.LocalCallService
-import com.iblu01.portallauncher.ui.components.controls.AccessoryGrid
-import com.iblu01.portallauncher.ui.components.controls.AccessoryItem
 import com.iblu01.portallauncher.ui.components.controls.PinKeypad
+import com.iblu01.portallauncher.ui.components.controls.VerticalSegmentedSelector
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
@@ -55,50 +57,89 @@ fun AlarmControl(chip: LauncherChip) {
     val entity = rememberEntity(chip.entityId)
     if (entity == null || entity.isUnavailable()) { PanelUnavailable(); return }
     val state = entity.state.lowercase()
-    val armed = state != "disarmed"
     val alerting = state == "triggered" || state == "pending"
+    val confirmedMode = ArmOption.entries.firstOrNull { it.armedState == state } ?: ArmOption.DISABLED
 
-    var pendingArm by remember(chip.entityId) { mutableStateOf<String?>(null) }
+    var pendingService by remember(chip.entityId) { mutableStateOf<String?>(null) }
+    var optimisticMode by remember(chip.entityId) { mutableStateOf<ArmOption?>(null) }
+
+    LaunchedEffect(confirmedMode, optimisticMode) {
+        val pending = optimisticMode ?: return@LaunchedEffect
+        if (confirmedMode == pending) optimisticMode = null
+        else {
+            kotlinx.coroutines.delay(5000)
+            optimisticMode = null
+        }
+    }
+
+    LaunchedEffect(state, pendingService) {
+        val target = ArmOption.entries.firstOrNull { it.service == pendingService } ?: return@LaunchedEffect
+        if (state == target.armedState) pendingService = null
+    }
 
     // The armed/mode label is already shown in the panel header (chip.value), so it isn't
     // repeated here — this composable renders only the keypad / arm actions.
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         when {
-            // Armed + code required, or an arm action is awaiting its code → keypad.
-            (armed && entity.alarmCodeRequired(arming = false)) || pendingArm != null -> {
-                val service = pendingArm ?: "alarm_disarm"
+            // Triggered alarms keep disarming prominent. Other protected actions open the keypad
+            // only after the user selects their target mode.
+            (alerting && entity.alarmCodeRequired(arming = false)) || pendingService != null -> {
+                val service = pendingService ?: ArmOption.DISABLED.service
                 AlarmKeypad(
                     entityId = chip.entityId,
                     service = service,
                     currentState = state,
                     prompt = if (service == "alarm_disarm") stringResource(R.string.alarm_disarm_prompt) else stringResource(R.string.alarm_arm_prompt),
-                    onCancel = if (pendingArm != null) ({ pendingArm = null }) else null,
+                    onCancel = if (pendingService != null) ({ pendingService = null }) else null,
                 )
             }
-            // Armed, no code needed → single disarm button.
-            armed -> {
-                DisarmButton(highlight = alerting) { callService(ALARM_DOMAIN, "alarm_disarm", chip.entityId) }
-            }
-            // Disarmed → arm options.
+            // Complete mode selector, including the neutral disabled state.
             else -> {
-                val arm: (String) -> Unit = { svc ->
-                    if (entity.alarmCodeRequired(arming = true)) pendingArm = svc
-                    else callService(ALARM_DOMAIN, svc, chip.entityId)
+                val options = ArmOption.entries.filter { it.feature == null || entity.supports(it.feature) }
+                if (options.isNotEmpty()) {
+                    val labels = options.associateWith { stringResource(it.labelRes) }
+                    BoxWithConstraints(
+                        // Use the same responsive viewport and 96:240 aspect ratio as the cover
+                        // control instead of pinning the selector to hard-coded dp dimensions.
+                        modifier = Modifier.fillMaxWidth(0.54f),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        val widthToHeightRatio = 96f / 240f
+                        val selectorWidth = maxWidth
+                        val selectorHeight = selectorWidth / widthToHeightRatio
+                        // The cover slider rounds by 30% of its width. Derive both selector
+                        // radii from that same live width and keep the inset highlight concentric.
+                        val outerRadius = selectorWidth * 0.30f
+                        val highlightInset = 5.dp
+                        VerticalSegmentedSelector(
+                            options = options,
+                            selected = optimisticMode ?: confirmedMode,
+                            onSelect = { option ->
+                                if (option != confirmedMode) {
+                                    val needsCode = entity.alarmCodeRequired(
+                                        arming = option != ArmOption.DISABLED,
+                                    )
+                                    if (needsCode) pendingService = option.service
+                                    else {
+                                        optimisticMode = option
+                                        callService(ALARM_DOMAIN, option.service, chip.entityId)
+                                    }
+                                }
+                            },
+                            label = { labels[it]!! },
+                            icon = { it.icon },
+                            accent = AppleColors.active,
+                            isNeutral = { it == ArmOption.DISABLED },
+                            shape = RoundedCornerShape(outerRadius),
+                            highlightShape = RoundedCornerShape(
+                                (outerRadius - highlightInset).coerceAtLeast(0.dp),
+                            ),
+                            segmentHeight = selectorHeight / options.size,
+                            segmentPadding = 4.dp,
+                            modifier = Modifier.size(selectorWidth, selectorHeight),
+                        )
+                    }
                 }
-                AccessoryGrid(
-                    items = ArmOption.entries
-                        .filter { entity.supports(it.feature) }
-                        .map { option ->
-                            AccessoryItem(
-                                id = option.service,
-                                title = stringResource(option.labelRes),
-                                icon = option.icon,
-                                // Disarmed here, so no option is live — the tiles read as actions.
-                                on = state == option.armedState,
-                                onToggle = { arm(option.service) },
-                            )
-                        },
-                )
             }
         }
     }
@@ -106,7 +147,7 @@ fun AlarmControl(chip: LauncherChip) {
 
 /** The arm actions an entity can expose, in the order they're offered. */
 private enum class ArmOption(
-    val feature: Int,
+    val feature: Int?,
     val service: String,
     val armedState: String,
     val labelRes: Int,
@@ -116,23 +157,7 @@ private enum class ArmOption(
     HOME(AlarmFeature.ARM_HOME, "alarm_arm_home", "armed_home", R.string.alarm_mode_home, Icons.Outlined.Home),
     NIGHT(AlarmFeature.ARM_NIGHT, "alarm_arm_night", "armed_night", R.string.alarm_mode_night, Icons.Outlined.Bedtime),
     VACATION(AlarmFeature.ARM_VACATION, "alarm_arm_vacation", "armed_vacation", R.string.alarm_mode_vacation, Icons.Outlined.NightShelter),
-}
-
-@Composable
-private fun DisarmButton(highlight: Boolean, onClick: () -> Unit) {
-    val color = if (highlight) AppleColors.error else AppleColors.accent
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(AppleShapes.pill)
-            .background(color.copy(alpha = 0.16f), AppleShapes.pill)
-            .border(0.5.dp, color.copy(alpha = 0.4f), AppleShapes.pill)
-            .appleClickable(onClick)
-            .padding(vertical = 16.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(stringResource(R.string.alarm_disarm_button), style = AppleTypography.titleMedium.copy(fontSize = 17.sp), color = color)
-    }
+    DISABLED(null, "alarm_disarm", "disarmed", R.string.alarm_mode_off, Icons.Outlined.PowerSettingsNew),
 }
 
 /**
@@ -154,6 +179,7 @@ private fun AlarmKeypad(
     val callService = LocalCallService.current
     var submitCount by remember(service) { mutableIntStateOf(0) }
     var wrongCode by remember(service) { mutableStateOf(false) }
+    var waitingForHa by remember(service) { mutableStateOf(false) }
     val stateAtSubmit = remember { mutableStateOf("") }
     val liveState by rememberUpdatedState(currentState)
 
@@ -161,18 +187,25 @@ private fun AlarmKeypad(
         if (submitCount > 0) {
             kotlinx.coroutines.delay(2600)
             if (liveState == stateAtSubmit.value) wrongCode = true
+            waitingForHa = false
         }
+    }
+
+    LaunchedEffect(currentState, submitCount) {
+        if (submitCount > 0 && currentState != stateAtSubmit.value) waitingForHa = false
     }
 
     PinKeypad(
         onSubmit = { code ->
             stateAtSubmit.value = liveState
+            waitingForHa = true
             callService(ALARM_DOMAIN, service, entityId, mapOf("code" to code))
             submitCount++
         },
         codeLength = 0,
         subtitle = prompt,
         error = wrongCode,
+        loading = waitingForHa,
         onErrorConsumed = { wrongCode = false },
         onCancel = onCancel,
     )

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/AlarmPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/AlarmPanel.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -107,10 +106,6 @@ fun AlarmControl(chip: LauncherChip) {
                         val widthToHeightRatio = 96f / 240f
                         val selectorWidth = maxWidth
                         val selectorHeight = selectorWidth / widthToHeightRatio
-                        // The cover slider rounds by 30% of its width. Derive both selector
-                        // radii from that same live width and keep the inset highlight concentric.
-                        val outerRadius = selectorWidth * 0.30f
-                        val highlightInset = 5.dp
                         VerticalSegmentedSelector(
                             options = options,
                             selected = optimisticMode ?: confirmedMode,
@@ -130,10 +125,6 @@ fun AlarmControl(chip: LauncherChip) {
                             icon = { it.icon },
                             accent = AppleColors.active,
                             isNeutral = { it == ArmOption.DISABLED },
-                            shape = RoundedCornerShape(outerRadius),
-                            highlightShape = RoundedCornerShape(
-                                (outerRadius - highlightInset).coerceAtLeast(0.dp),
-                            ),
                             segmentHeight = selectorHeight / options.size,
                             segmentPadding = 4.dp,
                             modifier = Modifier.size(selectorWidth, selectorHeight),

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/ClimateEntityContract.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/ClimateEntityContract.kt
@@ -1,0 +1,69 @@
+package com.iblu01.portallauncher.ui.components
+
+import com.iblu01.portallauncher.HaEntity
+
+/** Home Assistant `ClimateEntityFeature` flags used by the thermostat adapter. */
+object ClimateFeature {
+    const val TARGET_TEMPERATURE = 1
+    const val TARGET_TEMPERATURE_RANGE = 2
+}
+
+/**
+ * UI-neutral view of Home Assistant's climate contract. The panel consumes this model instead of
+ * knowing which optional attributes a particular thermostat integration happens to expose.
+ */
+data class ClimateEntityContract(
+    val hvacMode: String,
+    val hvacAction: String?,
+    val availableModes: List<String>,
+    val currentTemperature: Float?,
+    val targetTemperature: Float?,
+    val targetLow: Float?,
+    val targetHigh: Float?,
+    val minimumTemperature: Float,
+    val maximumTemperature: Float,
+    val temperatureStep: Float,
+    val temperatureUnit: String,
+    val supportsSingleTarget: Boolean,
+    val supportsTargetRange: Boolean,
+) {
+    val hasTemperatureControl: Boolean get() = supportsSingleTarget || supportsTargetRange
+}
+
+fun HaEntity.toClimateContract(): ClimateEntityContract {
+    fun number(name: String): Float? = attributes.optDouble(name, Double.NaN)
+        .takeUnless(Double::isNaN)
+        ?.toFloat()
+
+    val featureMask = attributes.optInt("supported_features", 0)
+    val target = number("temperature")
+    val low = number("target_temp_low")
+    val high = number("target_temp_high")
+    val modesArray = attributes.optJSONArray("hvac_modes")
+    val modes = if (modesArray == null) emptyList() else buildList {
+        for (index in 0 until modesArray.length()) {
+            modesArray.optString(index).trim().lowercase().takeIf(String::isNotBlank)?.let(::add)
+        }
+    }.distinct()
+
+    val min = number("min_temp") ?: 7f
+    val max = (number("max_temp") ?: 35f).coerceAtLeast(min + 1f)
+    return ClimateEntityContract(
+        hvacMode = state.trim().lowercase(),
+        hvacAction = attributes.optString("hvac_action").trim().lowercase().takeIf(String::isNotBlank),
+        availableModes = modes,
+        currentTemperature = number("current_temperature"),
+        targetTemperature = target,
+        targetLow = low,
+        targetHigh = high,
+        minimumTemperature = min,
+        maximumTemperature = max,
+        temperatureStep = (number("target_temp_step") ?: 0.5f).coerceAtLeast(0.1f),
+        temperatureUnit = attributes.optString("temperature_unit")
+            .ifBlank { attributes.optString("unit_of_measurement") }
+            .ifBlank { "°" },
+        // Some integrations omit the feature mask but expose the corresponding attributes.
+        supportsSingleTarget = featureMask and ClimateFeature.TARGET_TEMPERATURE != 0 || target != null,
+        supportsTargetRange = featureMask and ClimateFeature.TARGET_TEMPERATURE_RANGE != 0 || (low != null && high != null),
+    )
+}

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/CoverPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/CoverPanel.kt
@@ -1,14 +1,13 @@
 package com.iblu01.portallauncher.ui.components
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.KeyboardArrowUp
 import androidx.compose.material3.Text
@@ -23,6 +22,8 @@ import androidx.compose.ui.unit.dp
 import com.iblu01.portallauncher.LauncherChip
 import com.iblu01.portallauncher.ui.LocalCallService
 import com.iblu01.portallauncher.ui.components.controls.VerticalFillSlider
+import com.iblu01.portallauncher.ui.components.controls.PortalThreeWayControl
+import com.iblu01.portallauncher.ui.components.controls.FillOrigin
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 import com.iblu01.portallauncher.R
@@ -30,7 +31,7 @@ import androidx.compose.ui.res.stringResource
 import kotlin.math.roundToInt
 
 @Composable
-fun CoverControl(chip: LauncherChip) {
+fun CoverControl(chip: LauncherChip, modifier: Modifier = Modifier) {
     val callService = LocalCallService.current
     val entity = rememberEntity(chip.entityId)
     if (entity == null || entity.isUnavailable()) { PanelUnavailable(); return }
@@ -41,61 +42,62 @@ fun CoverControl(chip: LauncherChip) {
     // While dragging, the finger owns the readout; otherwise it follows the entity.
     var sliderPos by remember(position) { mutableFloatStateOf(position.toFloat()) }
 
-    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-        Spacer(Modifier.height(4.dp))
-        Text(
-            when {
-                canSetPosition -> "${sliderPos.roundToInt()} %"
-                position in 0..100 -> "$position %"
-                state == "open" -> stringResource(R.string.cover_state_open)
-                state == "closed" -> stringResource(R.string.cover_state_closed)
-                state == "opening" -> stringResource(R.string.cover_state_opening)
-                state == "closing" -> stringResource(R.string.cover_state_closing)
-                else -> chip.value
-            },
-            style = AppleTypography.headlineLarge,
-            color = AppleColors.primary,
-        )
-        Spacer(Modifier.height(16.dp))
-
+    Column(modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         if (canSetPosition) {
-            VerticalFillSlider(
-                value = sliderPos,
-                onValueChange = { sliderPos = it },
-                onValueChangeFinished = {
-                    callService("cover", "set_cover_position", chip.entityId, mapOf("position" to sliderPos.roundToInt()))
-                },
-                valueRange = 0f..100f,
-                accent = AppleColors.active,
-                hapticSteps = 20,
-                modifier = Modifier.height(240.dp).width(96.dp),
-            )
+            BoxWithConstraints(
+                // The slider lives in a centred viewport rather than consuming the whole panel.
+                // 54% matches the visual footprint of the gallery control while still scaling
+                // fluidly with the panel on different wall-tablet sizes.
+                modifier = Modifier.fillMaxWidth(0.54f).weight(1f),
+                contentAlignment = Alignment.Center,
+            ) {
+                val widthToHeightRatio = 96f / 240f
+                val sliderHeight = minOf(maxHeight, maxWidth / widthToHeightRatio)
+                val sliderWidth = sliderHeight * widthToHeightRatio
+                VerticalFillSlider(
+                    value = sliderPos,
+                    onValueChange = { sliderPos = it },
+                    onValueChangeFinished = {
+                        callService("cover", "set_cover_position", chip.entityId, mapOf("position" to sliderPos.roundToInt()))
+                    },
+                    valueRange = 0f..100f,
+                    origin = FillOrigin.TOP,
+                    accent = AppleColors.active,
+                    hapticSteps = 20,
+                    modifier = Modifier.size(sliderWidth, sliderHeight),
+                )
+            }
             Spacer(Modifier.height(20.dp))
+        } else {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                when {
+                    position in 0..100 -> "$position %"
+                    state == "open" -> stringResource(R.string.cover_state_open)
+                    state == "closed" -> stringResource(R.string.cover_state_closed)
+                    state == "opening" -> stringResource(R.string.cover_state_opening)
+                    state == "closing" -> stringResource(R.string.cover_state_closing)
+                    else -> chip.value
+                },
+                style = AppleTypography.headlineLarge,
+                color = AppleColors.primary,
+            )
+            Spacer(Modifier.height(16.dp))
         }
 
-        Row(
-            Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly,
-        ) {
-            GlassButton(
-                label = stringResource(R.string.cover_button_open),
-                icon = Icons.Outlined.KeyboardArrowUp,
-                active = state == "opening",
-                onClick = { callService("cover", "open_cover", chip.entityId) },
-            )
-            GlassButton(
-                label = stringResource(R.string.cover_button_stop),
-                icon = Icons.Filled.Stop,
-                active = false,
-                onClick = { callService("cover", "stop_cover", chip.entityId) },
-            )
-            GlassButton(
-                label = stringResource(R.string.cover_button_close),
-                icon = Icons.Outlined.KeyboardArrowDown,
-                active = state == "closing",
-                onClick = { callService("cover", "close_cover", chip.entityId) },
-            )
-        }
+        PortalThreeWayControl(
+            leadingIcon = Icons.Outlined.KeyboardArrowDown,
+            leadingContentDescription = stringResource(R.string.cover_button_close),
+            leadingLabel = stringResource(R.string.cover_button_close),
+            onLeadingClick = { callService("cover", "close_cover", chip.entityId) },
+            centerIcon = Icons.Filled.Pause,
+            centerContentDescription = stringResource(R.string.cover_button_stop),
+            onCenterClick = { callService("cover", "stop_cover", chip.entityId) },
+            trailingIcon = Icons.Outlined.KeyboardArrowUp,
+            trailingContentDescription = stringResource(R.string.cover_button_open),
+            trailingLabel = stringResource(R.string.cover_button_open),
+            onTrailingClick = { callService("cover", "open_cover", chip.entityId) },
+        )
 
         Spacer(Modifier.height(12.dp))
         chip.details.forEach { PanelDetailRow(it) }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/DynamicBackground.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/DynamicBackground.kt
@@ -42,6 +42,7 @@ internal val unsplashUrls = listOf(
 )
 
 val backgroundModes = listOf(
+    "system" to R.string.bg_mode_system,
     "neutral" to R.string.bg_mode_neutral,
     "nature" to R.string.bg_mode_nature,
     "custom" to R.string.bg_mode_custom,
@@ -51,6 +52,9 @@ val backgroundModes = listOf(
 @Composable
 fun AmbientBackground(mode: String, wallpaperVersion: Int = 0, modifier: Modifier = Modifier) {
     when (mode) {
+        // Android draws its wallpaper (including live wallpapers) in the layer exposed by the
+        // activity's windowShowWallpaper flag. Drawing nothing here is the native launcher path.
+        "system" -> Box(modifier)
         "nature" -> UnsplashCycling(modifier)
         "custom" -> CustomWallpaper(modifier, wallpaperVersion)
         "immich" -> ImmichBackground(modifier)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/FanEntityContract.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/FanEntityContract.kt
@@ -1,0 +1,44 @@
+package com.iblu01.portallauncher.ui.components
+
+import com.iblu01.portallauncher.HaEntity
+
+sealed interface FanPrimaryControl {
+    data object OnOff : FanPrimaryControl
+    data class Percentage(val value: Int, val step: Int) : FanPrimaryControl
+    data class Presets(val values: List<String>, val selected: String?) : FanPrimaryControl
+}
+
+data class FanEntityContract(
+    val isOn: Boolean,
+    val primaryControl: FanPrimaryControl,
+    val supportsOscillation: Boolean,
+    val isOscillating: Boolean,
+)
+
+/** Maps only capabilities and attributes defined by Home Assistant's fan entity contract. */
+fun HaEntity.toFanContract(): FanEntityContract {
+    val presetArray = attributes.optJSONArray("preset_modes")
+    val presets = if (presetArray == null) emptyList() else buildList {
+        for (index in 0 until presetArray.length()) {
+            presetArray.optString(index).trim().takeIf(String::isNotBlank)?.let(::add)
+        }
+    }.distinct()
+    val hasPercentage = supports(FanFeature.SET_SPEED) || attributes.has("percentage")
+    val primary = when {
+        presets.isNotEmpty() -> FanPrimaryControl.Presets(
+            values = presets,
+            selected = attributes.optString("preset_mode").takeIf { it.isNotBlank() },
+        )
+        hasPercentage -> FanPrimaryControl.Percentage(
+            value = attributes.optInt("percentage", 0).coerceIn(0, 100),
+            step = attributes.optDouble("percentage_step", 1.0).toInt().coerceIn(1, 100),
+        )
+        else -> FanPrimaryControl.OnOff
+    }
+    return FanEntityContract(
+        isOn = state.equals("on", true),
+        primaryControl = primary,
+        supportsOscillation = supports(FanFeature.OSCILLATE) || attributes.has("oscillating"),
+        isOscillating = attributes.optBoolean("oscillating", false),
+    )
+}

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/LightDetailPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/LightDetailPanel.kt
@@ -101,8 +101,14 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 private val colorPresets = listOf(
-    Triple(255, 59, 48), Triple(255, 149, 0), Triple(255, 204, 0), Triple(52, 199, 89),
-    Triple(0, 199, 190), Triple(0, 122, 255), Triple(175, 82, 222), Triple(255, 45, 85),
+    Triple(255, 120, 72),  // coucher de soleil
+    Triple(255, 178, 102), // bougie
+    Triple(255, 105, 135), // rose feutré
+    Triple(125, 210, 160), // forêt douce
+    Triple(72, 190, 205),  // lagon
+    Triple(80, 130, 255),  // crépuscule
+    Triple(155, 110, 230), // lavande
+    Triple(220, 85, 155),  // soirée
 )
 
 private val whitePresets = listOf(
@@ -112,7 +118,7 @@ private val whitePresets = listOf(
 
 private val colorModes = setOf("hs", "rgb", "xy", "rgbw", "rgbww")
 
-private enum class LightSliderMode { BRIGHTNESS, COLOR_TEMPERATURE }
+private enum class LightSliderMode { COLOR, COLOR_TEMPERATURE }
 
 @Composable
 fun LightDetailContent(detail: PillDetail, onBack: () -> Unit) {
@@ -126,7 +132,6 @@ fun LightDetailContent(detail: PillDetail, onBack: () -> Unit) {
     val supportsColor = modes.any { it in colorModes }
     val supportsWhite = "color_temp" in modes
     val supportsBrightness = modes.isEmpty() || modes.any { it != "onoff" }
-    val isWhiteChannelLight = modes.any { it == "rgbw" || it == "rgbww" }
     val onOffOnly = modes.isNotEmpty() && modes.all { it == "onoff" }
     val minKelvin = attrs?.optInt("min_color_temp_kelvin", 2000)?.coerceAtLeast(1000) ?: 2000
     val maxKelvin = max(minKelvin + 1, attrs?.optInt("max_color_temp_kelvin", 6500) ?: 6500)
@@ -150,7 +155,7 @@ fun LightDetailContent(detail: PillDetail, onBack: () -> Unit) {
     }
     var lightOn by remember(detail.entityId) { mutableStateOf(isOn) }
     var sliderMode by remember(detail.entityId) {
-        mutableStateOf(if (supportsBrightness) LightSliderMode.BRIGHTNESS else LightSliderMode.COLOR_TEMPERATURE)
+        mutableStateOf(if (supportsColor) LightSliderMode.COLOR else LightSliderMode.COLOR_TEMPERATURE)
     }
     var wheelVisible by remember { mutableStateOf(false) }
     var entered by remember { mutableStateOf(false) }
@@ -193,37 +198,18 @@ fun LightDetailContent(detail: PillDetail, onBack: () -> Unit) {
                     lightOn = true; brightness = max(brightness, 0.5f); selectedColor = color; selectedHsv = colorToHsv(color); action()
                 }
                 val onOpenWheel: (Color?) -> Unit = { preset -> preset?.let { selectedHsv = colorToHsv(it) }; wheelVisible = true }
-                val onPowerToggle: (Boolean) -> Unit = { on -> lightOn = on; callService("light", if (on) "turn_on" else "turn_off", detail.entityId) }
-
-                if (deviceLandscape) {
-                    LandscapeLightDetail(
-                        brightness, onBrightnessLive, onBrightnessFinal,
-                        selectedColor, lightOn, sliderMode, { sliderMode = it },
-                        supportsBrightness, supportsColor, supportsWhite, isWhiteChannelLight,
-                        kelvin, minKelvin, maxKelvin,
-                        onKelvinChange = onKelvinLive,
-                        onKelvinCommit = onKelvinFinal,
-                        currentColor = selectedColor,
-                        onPreset = onPreset,
-                        onOpenWheel = onOpenWheel,
-                        onPowerToggle = onPowerToggle,
-                        entityId = detail.entityId,
-                    )
-                } else {
-                    PortraitLightDetail(
-                        brightness, onBrightnessLive, onBrightnessFinal,
-                        selectedColor, lightOn, sliderMode, { sliderMode = it },
-                        supportsBrightness, supportsColor, supportsWhite, isWhiteChannelLight,
-                        kelvin, minKelvin, maxKelvin,
-                        onKelvinChange = onKelvinLive,
-                        onKelvinCommit = onKelvinFinal,
-                        currentColor = selectedColor,
-                        onPreset = onPreset,
-                        onOpenWheel = onOpenWheel,
-                        onPowerToggle = onPowerToggle,
-                        entityId = detail.entityId,
-                    )
-                }
+                AdaptiveLightDetail(
+                    brightness, onBrightnessLive, onBrightnessFinal,
+                    selectedColor, lightOn, sliderMode, { sliderMode = it },
+                    supportsBrightness, supportsColor, supportsWhite,
+                    kelvin, minKelvin, maxKelvin,
+                    onKelvinChange = onKelvinLive,
+                    onKelvinCommit = onKelvinFinal,
+                    currentColor = selectedColor,
+                    onPreset = onPreset,
+                    onOpenWheel = onOpenWheel,
+                    entityId = detail.entityId,
+                )
             }
         }
     }
@@ -269,23 +255,32 @@ private fun DetailHeader(label: String, onBack: () -> Unit) {
 }
 
 @Composable
-private fun ColumnScope.LandscapeLightDetail(
+private fun ColumnScope.AdaptiveLightDetail(
     brightness: Float, onBrightnessChange: (Float) -> Unit, onBrightnessCommit: (Float) -> Unit,
     trackColor: Color, isOn: Boolean, sliderMode: LightSliderMode, onSliderModeChange: (LightSliderMode) -> Unit,
     supportsBrightness: Boolean, supportsColor: Boolean, supportsWhite: Boolean,
-    whiteChannel: Boolean, kelvin: Int, minKelvin: Int, maxKelvin: Int,
+    kelvin: Int, minKelvin: Int, maxKelvin: Int,
     onKelvinChange: (Int) -> Unit, onKelvinCommit: (Int) -> Unit,
     currentColor: Color, onPreset: (Color, () -> Unit) -> Unit, onOpenWheel: (Color?) -> Unit,
-    onPowerToggle: (Boolean) -> Unit, entityId: String,
+    entityId: String,
 ) {
     BoxWithConstraints(Modifier.fillMaxWidth().weight(1f), contentAlignment = Alignment.Center) {
-        val sliderHeight = minOf(maxHeight * if (supportsWhite && supportsBrightness) 0.78f else 0.82f, 320.dp)
-        Column(
-            Modifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
+        val showTemperature = sliderMode == LightSliderMode.COLOR_TEMPERATURE && supportsWhite
+        val sliderCount = (if (supportsBrightness) 1 else 0) + (if (showTemperature) 1 else 0)
+        val gap = 18.dp
+        val widthFraction = if (sliderCount > 1) 0.78f else 0.54f
+        val availableWidth = maxWidth * widthFraction - gap * (sliderCount - 1).coerceAtLeast(0)
+        val sliderWidthFromSpace = if (sliderCount > 0) availableWidth / sliderCount else 0.dp
+        val ratio = 96f / 240f
+        val sliderHeight = minOf(maxHeight, sliderWidthFromSpace / ratio)
+        val sliderWidth = sliderHeight * ratio
+
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.spacedBy(gap, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (sliderMode == LightSliderMode.BRIGHTNESS && supportsBrightness) {
+            if (supportsBrightness) {
                 VerticalFillSlider(
                     value = if (isOn) brightness else 0f,
                     onValueChange = onBrightnessChange,
@@ -293,172 +288,69 @@ private fun ColumnScope.LandscapeLightDetail(
                     accent = trackColor,
                     icon = Icons.Filled.WbSunny,
                     hapticSteps = 10,
-                    modifier = Modifier.height(sliderHeight).width(88.dp),
+                    modifier = Modifier.size(sliderWidth, sliderHeight),
                 )
-            } else if (supportsWhite) {
+            }
+            if (showTemperature) {
                 VerticalColorTempSlider(
                     kelvin = kelvin,
                     onKelvinChange = onKelvinChange,
                     onKelvinChangeFinished = onKelvinCommit,
                     minKelvin = minKelvin,
                     maxKelvin = maxKelvin,
-                    modifier = Modifier.height(sliderHeight).width(88.dp),
+                    modifier = Modifier.size(sliderWidth, sliderHeight),
                 )
             }
-            if (supportsWhite && supportsBrightness) {
-                Spacer(Modifier.height(14.dp))
-                SliderModeSwitch(sliderMode, onSliderModeChange)
-            } else if (whiteChannel) {
-                Spacer(Modifier.height(14.dp))
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(7.dp)) {
-                    Icon(Icons.Filled.WbSunny, null, tint = AppleColors.secondary, modifier = Modifier.size(18.dp))
-                    Text(stringResource(R.string.light_white_channel_label), style = AppleTypography.bodySmall, color = AppleColors.secondary)
-                }
-            }
         }
     }
-    Spacer(Modifier.height(16.dp))
-    ColorPresetsBar(false, supportsColor, supportsWhite, whiteChannel, currentColor, minKelvin, maxKelvin, entityId, isOn, onPreset, onOpenWheel, onPowerToggle)
-}
-
-@Composable
-private fun ColumnScope.PortraitLightDetail(
-    brightness: Float, onBrightnessChange: (Float) -> Unit, onBrightnessCommit: (Float) -> Unit,
-    trackColor: Color, isOn: Boolean, sliderMode: LightSliderMode, onSliderModeChange: (LightSliderMode) -> Unit,
-    supportsBrightness: Boolean, supportsColor: Boolean, supportsWhite: Boolean,
-    whiteChannel: Boolean, kelvin: Int, minKelvin: Int, maxKelvin: Int,
-    onKelvinChange: (Int) -> Unit, onKelvinCommit: (Int) -> Unit,
-    currentColor: Color, onPreset: (Color, () -> Unit) -> Unit, onOpenWheel: (Color?) -> Unit,
-    onPowerToggle: (Boolean) -> Unit, entityId: String,
-) {
-    BoxWithConstraints(Modifier.fillMaxWidth().weight(1f), contentAlignment = Alignment.Center) {
-        val controlHeight = minOf(maxHeight, 440.dp)
-        Row(Modifier.fillMaxWidth().height(controlHeight), horizontalArrangement = Arrangement.spacedBy(22.dp)) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                if (sliderMode == LightSliderMode.BRIGHTNESS && supportsBrightness) {
-                    VerticalFillSlider(
-                        value = if (isOn) brightness else 0f,
-                        onValueChange = onBrightnessChange,
-                        onValueChangeFinished = onBrightnessCommit,
-                        accent = trackColor,
-                        icon = Icons.Filled.WbSunny,
-                        hapticSteps = 10,
-                        modifier = Modifier.weight(1f).width(92.dp),
-                    )
-                } else if (supportsWhite) {
-                    VerticalColorTempSlider(
-                        kelvin = kelvin,
-                        onKelvinChange = onKelvinChange,
-                        onKelvinChangeFinished = onKelvinCommit,
-                        minKelvin = minKelvin,
-                        maxKelvin = maxKelvin,
-                        modifier = Modifier.weight(1f).width(92.dp),
-                    )
-                }
-                if (supportsWhite && supportsBrightness) {
-                    Spacer(Modifier.height(12.dp))
-                    SliderModeSwitch(sliderMode, onSliderModeChange, compact = true)
-                }
-            }
-            Column(
-                Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(14.dp),
-            ) {
-                ColorPresetsBar(true, supportsColor, supportsWhite, whiteChannel, currentColor, minKelvin, maxKelvin, entityId, isOn, onPreset, onOpenWheel, onPowerToggle)
-            }
-        }
+    Spacer(Modifier.height(14.dp))
+    LightPresetsBar(
+        mode = sliderMode,
+        supportsColor = supportsColor,
+        supportsWhite = supportsWhite,
+        currentColor = currentColor,
+        minKelvin = minKelvin,
+        maxKelvin = maxKelvin,
+        entityId = entityId,
+        onPreset = onPreset,
+        onOpenWheel = onOpenWheel,
+    )
+    if (supportsColor && supportsWhite) {
+        Spacer(Modifier.height(10.dp))
+        SliderModeSwitch(sliderMode, onSliderModeChange)
     }
 }
 
 @Composable
-private fun ColorPresetsBar(
-    portrait: Boolean, supportsColor: Boolean, supportsWhite: Boolean, whiteChannel: Boolean,
+private fun LightPresetsBar(
+    mode: LightSliderMode, supportsColor: Boolean, supportsWhite: Boolean,
     currentColor: Color, minKelvin: Int, maxKelvin: Int, entityId: String,
-    isOn: Boolean, onPreset: (Color, () -> Unit) -> Unit, onOpenWheel: (Color?) -> Unit,
-    onPowerToggle: (Boolean) -> Unit,
+    onPreset: (Color, () -> Unit) -> Unit, onOpenWheel: (Color?) -> Unit,
 ) {
     val callService = LocalCallService.current
-    val presetDots = @Composable {
-        if (supportsColor) {
+    Row(Modifier.fillMaxWidth().padding(horizontal = 4.dp), verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            Modifier.weight(1f).horizontalScroll(rememberScrollState()).padding(horizontal = 3.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+        if (mode == LightSliderMode.COLOR && supportsColor) {
             colorPresets.forEach { (r, g, b) ->
                 val color = Color(r, g, b)
                 ColorDot(color, colorsNear(color, currentColor), { onPreset(color) { callService("light", "turn_on", entityId, mapOf("rgb_color" to listOf(r, g, b))) } }, { onOpenWheel(color) })
             }
         }
-        if (supportsWhite) {
+        if (mode == LightSliderMode.COLOR_TEMPERATURE && supportsWhite) {
             whitePresets.forEach { (rawKelvin, swatch) ->
                 val value = rawKelvin.coerceIn(minKelvin, maxKelvin)
                 ColorDot(swatch, colorsNear(swatch, currentColor), { onPreset(swatch) { callService("light", "turn_on", entityId, mapOf("color_temp_kelvin" to value)) } }, null)
             }
         }
-    }
-    if (!portrait) {
-        Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-            Row(Modifier.fillMaxWidth().padding(horizontal = 4.dp), verticalAlignment = Alignment.CenterVertically) {
-                Row(
-                    Modifier.weight(1f).horizontalScroll(rememberScrollState()).padding(horizontal = 3.dp, vertical = 8.dp),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) { presetDots() }
-                if (supportsColor) {
-                    Spacer(Modifier.width(12.dp))
-                    PaletteButton { onOpenWheel(null) }
-                }
-            }
-            Spacer(Modifier.height(10.dp))
-            PowerButton(isOn, onPowerToggle)
         }
-    } else {
-        if (supportsColor) Text(stringResource(R.string.light_colors_section), style = AppleTypography.bodySmall, color = AppleColors.secondary)
-        val colorRows = colorPresets.takeIf { supportsColor }?.chunked(3).orEmpty()
-        colorRows.forEachIndexed { index, row ->
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                row.forEach { rgb ->
-                    val color = Color(rgb.first, rgb.second, rgb.third)
-                    ColorDot(color, colorsNear(color, currentColor), { onPreset(color) { callService("light", "turn_on", entityId, mapOf("rgb_color" to listOf(rgb.first, rgb.second, rgb.third))) } }, { onOpenWheel(color) })
-                }
-                if (index == colorRows.lastIndex && row.size < 3) PaletteButton { onOpenWheel(null) }
-            }
+        if (mode == LightSliderMode.COLOR && supportsColor) {
+            Spacer(Modifier.width(12.dp))
+            PaletteButton { onOpenWheel(null) }
         }
-        if (supportsColor && colorPresets.size % 3 == 0) PaletteButton { onOpenWheel(null) }
-        if (supportsWhite) {
-            Text(if (whiteChannel) stringResource(R.string.light_whites_w_channel_label) else stringResource(R.string.light_whites_label), style = AppleTypography.bodySmall, color = AppleColors.secondary)
-            whitePresets.chunked(3).forEach { row ->
-                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    row.forEach { (rawKelvin, swatch) ->
-                        val value = rawKelvin.coerceIn(minKelvin, maxKelvin)
-                        ColorDot(swatch, colorsNear(swatch, currentColor), { onPreset(swatch) { callService("light", "turn_on", entityId, mapOf("color_temp_kelvin" to value)) } }, null)
-                    }
-                }
-            }
-        }
-        Spacer(Modifier.height(4.dp))
-        PowerButton(isOn, onPowerToggle)
-    }
-}
-
-@Composable
-private fun PowerButton(isOn: Boolean, onToggle: (Boolean) -> Unit) {
-    var pressed by remember { mutableStateOf(false) }
-    val scale by animateFloatAsState(if (pressed) AppleMotion.PRESS_SCALE else 1f, AppleMotion.spring(), label = "powerScale")
-    val background by animateColorAsState(
-        if (isOn) AppleColors.accent.copy(alpha = 0.22f) else AppleColors.frostedFill,
-        tween(200), label = "powerBackground",
-    )
-    Row(
-        Modifier.scale(scale).height(40.dp).clip(AppleShapes.pill).background(background)
-            .border(0.5.dp, if (isOn) AppleColors.accent.copy(alpha = 0.45f) else AppleColors.frostedBorder, AppleShapes.pill)
-            .pointerInput(isOn) {
-                detectTapGestures(
-                    onPress = { pressed = true; tryAwaitRelease(); pressed = false },
-                    onTap = { onToggle(!isOn) },
-                )
-            }.padding(horizontal = 18.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Icon(Icons.Filled.PowerSettingsNew, null, tint = if (isOn) AppleColors.accent else AppleColors.secondary, modifier = Modifier.size(17.dp))
-        Text(if (isOn) stringResource(R.string.light_power_off) else stringResource(R.string.light_power_on), style = AppleTypography.bodySmall, color = AppleColors.primary)
     }
 }
 
@@ -511,10 +403,10 @@ private fun SliderModeSwitch(
         horizontalArrangement = Arrangement.spacedBy(3.dp),
     ) {
         SliderModeButton(
-            icon = Icons.Filled.WbSunny,
+            icon = Icons.Filled.Palette,
             label = if (compact) null else stringResource(R.string.light_mode_brightness),
-            selected = mode == LightSliderMode.BRIGHTNESS,
-            onClick = { onModeChange(LightSliderMode.BRIGHTNESS) },
+            selected = mode == LightSliderMode.COLOR,
+            onClick = { onModeChange(LightSliderMode.COLOR) },
         )
         SliderModeButton(
             icon = Icons.Filled.NightsStay,

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/LightDetailPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/LightDetailPanel.kt
@@ -232,26 +232,12 @@ fun LightDetailContent(detail: PillDetail, onBack: () -> Unit) {
 
 @Composable
 private fun DetailHeader(label: String, onBack: () -> Unit) {
-    var pressed by remember { mutableStateOf(false) }
-    val scale by animateFloatAsState(if (pressed) AppleMotion.PRESS_SCALE else 1f, AppleMotion.spring(), label = "backScale")
-    Box(Modifier.fillMaxWidth().height(40.dp)) {
-        Box(
-            Modifier.align(Alignment.CenterStart).scale(scale).size(40.dp).clip(CircleShape)
-                .background(AppleColors.frostedFill).border(0.5.dp, AppleColors.frostedBorder, CircleShape)
-                .pointerInput(onBack) {
-                    detectTapGestures(onPress = { pressed = true; tryAwaitRelease(); pressed = false }, onTap = { onBack() })
-                },
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Retour aux lumières", tint = AppleColors.primary, modifier = Modifier.size(19.dp))
-        }
-        Text(
-            label, style = AppleTypography.bodySmall.copy(fontSize = 13.sp), color = AppleColors.secondary,
-            maxLines = 1, overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.align(Alignment.Center).clip(AppleShapes.pill).background(AppleColors.frostedFill)
-                .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.pill).padding(horizontal = 14.dp, vertical = 7.dp),
-        )
-    }
+    PanelHeader(
+        title = label,
+        onNavigation = onBack,
+        navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
+        navigationContentDescription = "Retour aux lumières",
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/LockPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/LockPanel.kt
@@ -1,10 +1,11 @@
 package com.iblu01.portallauncher.ui.components
 
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.ErrorOutline
@@ -23,11 +24,11 @@ import com.iblu01.portallauncher.R
 import androidx.compose.ui.res.stringResource
 
 /**
- * HomeKit-style lock as a 2-position toggle: up/green is locked, down/amber is unlocked.
+ * HomeKit-style lock as a 2-position toggle using the lock's dedicated turquoise accent.
  * Tap or drag flips it; a jammed lock goes red and retries a lock on the next flip.
  */
 @Composable
-fun LockControl(chip: LauncherChip) {
+fun LockControl(chip: LauncherChip, modifier: Modifier = Modifier) {
     val callService = LocalCallService.current
     val entity = rememberEntity(chip.entityId)
     if (entity == null || entity.isUnavailable()) { PanelUnavailable(); return }
@@ -35,22 +36,30 @@ fun LockControl(chip: LauncherChip) {
     val locked = state == "locked"
     val jammed = state == "jammed"
 
-    val accent = if (jammed) AppleColors.error else AppleColors.active
+    val accent = if (jammed) AppleColors.error else AppleColors.lockAccent
     val caption = when { jammed -> stringResource(R.string.lock_state_jammed); locked -> stringResource(R.string.lock_state_locked); else -> stringResource(R.string.lock_state_unlocked) }
 
-    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(Modifier.height(6.dp))
         Text(caption, style = AppleTypography.headlineLarge, color = AppleColors.primary)
         Spacer(Modifier.height(16.dp))
-        VerticalSwitch(
-            checked = locked,
-            onCheckedChange = { wantLocked ->
-                callService("lock", if (wantLocked) "lock" else "unlock", chip.entityId)
-            },
-            accent = accent,
-            icon = { on -> if (jammed) Icons.Outlined.ErrorOutline else if (on) Icons.Outlined.Lock else Icons.Outlined.LockOpen },
-            modifier = Modifier.height(220.dp).width(96.dp),
-        )
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxWidth(0.54f).weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            val ratio = 96f / 240f
+            val controlHeight = minOf(maxHeight, maxWidth / ratio)
+            val controlWidth = controlHeight * ratio
+            VerticalSwitch(
+                checked = locked,
+                onCheckedChange = { wantLocked ->
+                    callService("lock", if (wantLocked) "lock" else "unlock", chip.entityId)
+                },
+                accent = accent,
+                icon = { on -> if (jammed) Icons.Outlined.ErrorOutline else if (on) Icons.Outlined.Lock else Icons.Outlined.LockOpen },
+                modifier = Modifier.size(controlWidth, controlHeight),
+            )
+        }
         Spacer(Modifier.height(20.dp))
         chip.details.forEach { PanelDetailRow(it) }
     }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/MediaPlayerView.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/MediaPlayerView.kt
@@ -71,6 +71,8 @@ import coil.request.ImageRequest
 import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.domain.model.MediaPlayerVolume
 import com.iblu01.portallauncher.domain.model.PlayingMedia
+import com.iblu01.portallauncher.ui.components.controls.PortalThreeWayControl
+import com.iblu01.portallauncher.ui.components.controls.ThreeWayControlSize
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
@@ -305,25 +307,18 @@ fun MediaPlayerView(
                             }
                         }
 
-                        Row(
-                            modifier = Modifier
-                                .clip(AppleShapes.pill)
-                                .background(AppleColors.frostedFill, AppleShapes.pill)
-                                .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.pill)
-                                .padding(horizontal = 10.dp, vertical = 6.dp),
-                            horizontalArrangement = Arrangement.spacedBy(14.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            IconButton(onClick = onPrevious, modifier = Modifier.size(40.dp)) {
-                                Icon(Icons.Filled.SkipPrevious, stringResource(R.string.media_previous_track_desc), tint = AppleColors.primary, modifier = Modifier.size(22.dp))
-                            }
-                            IconButton(onClick = onPlayPause, modifier = Modifier.size(50.dp).background(Color.White, CircleShape)) {
-                                Icon(if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow, if (isPlaying) stringResource(R.string.media_pause_desc) else stringResource(R.string.media_play_desc), tint = Color.Black, modifier = Modifier.size(28.dp))
-                            }
-                            IconButton(onClick = onNext, modifier = Modifier.size(40.dp)) {
-                                Icon(Icons.Filled.SkipNext, stringResource(R.string.media_next_track_desc), tint = AppleColors.primary, modifier = Modifier.size(22.dp))
-                            }
-                        }
+                        PortalThreeWayControl(
+                            leadingIcon = Icons.Filled.SkipPrevious,
+                            leadingContentDescription = stringResource(R.string.media_previous_track_desc),
+                            onLeadingClick = onPrevious,
+                            centerIcon = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                            centerContentDescription = if (isPlaying) stringResource(R.string.media_pause_desc) else stringResource(R.string.media_play_desc),
+                            onCenterClick = onPlayPause,
+                            trailingIcon = Icons.Filled.SkipNext,
+                            trailingContentDescription = stringResource(R.string.media_next_track_desc),
+                            onTrailingClick = onNext,
+                            size = ThreeWayControlSize.Compact,
+                        )
 
                         Row(
                             modifier = Modifier
@@ -426,25 +421,17 @@ fun MediaPlayerView(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                Row(
-                    modifier = Modifier
-                        .clip(AppleShapes.pill)
-                        .background(AppleColors.frostedFill, AppleShapes.pill)
-                        .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.pill)
-                        .padding(horizontal = 14.dp, vertical = 8.dp),
-                    horizontalArrangement = Arrangement.spacedBy(18.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onPrevious, modifier = Modifier.size(46.dp)) {
-                        Icon(Icons.Filled.SkipPrevious, stringResource(R.string.media_previous_track_desc), tint = AppleColors.primary, modifier = Modifier.size(26.dp))
-                    }
-                    IconButton(onClick = onPlayPause, modifier = Modifier.size(58.dp).background(Color.White, CircleShape)) {
-                        Icon(if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow, if (isPlaying) stringResource(R.string.media_pause_desc) else stringResource(R.string.media_play_desc), tint = Color.Black, modifier = Modifier.size(32.dp))
-                    }
-                    IconButton(onClick = onNext, modifier = Modifier.size(46.dp)) {
-                        Icon(Icons.Filled.SkipNext, stringResource(R.string.media_next_track_desc), tint = AppleColors.primary, modifier = Modifier.size(26.dp))
-                    }
-                }
+                PortalThreeWayControl(
+                    leadingIcon = Icons.Filled.SkipPrevious,
+                    leadingContentDescription = stringResource(R.string.media_previous_track_desc),
+                    onLeadingClick = onPrevious,
+                    centerIcon = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                    centerContentDescription = if (isPlaying) stringResource(R.string.media_pause_desc) else stringResource(R.string.media_play_desc),
+                    onCenterClick = onPlayPause,
+                    trailingIcon = Icons.Filled.SkipNext,
+                    trailingContentDescription = stringResource(R.string.media_next_track_desc),
+                    onTrailingClick = onNext,
+                )
 
                 Row(
                     modifier = Modifier

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/MediaPlayerView.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/MediaPlayerView.kt
@@ -284,16 +284,17 @@ fun MediaPlayerView(
                     ) {
                         Row(
                             modifier = Modifier
-                                .clip(AppleShapes.pill)
-                                .background(AppleColors.frostedFill, AppleShapes.pill)
-                                .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.pill)
                                 .then(if (media.groupablePlayers.size > 1) Modifier.clickable { groupDialogVisible = true } else Modifier)
-                                .padding(horizontal = 14.dp, vertical = 7.dp),
+                                .padding(horizontal = 8.dp, vertical = 7.dp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(7.dp),
                         ) {
                             Box(Modifier.size(7.dp).background(if (isPlaying) AppleColors.active else AppleColors.warning, CircleShape))
-                            Text(sourceName, style = AppleTypography.bodySmall.copy(fontSize = 13.sp), color = AppleColors.secondary)
+                            Text(
+                                sourceName,
+                                style = AppleTypography.titleLarge.copy(fontSize = 20.sp, fontWeight = FontWeight.SemiBold),
+                                color = AppleColors.primary,
+                            )
                         }
                         Column(
                             horizontalAlignment = Alignment.CenterHorizontally,
@@ -340,14 +341,14 @@ fun MediaPlayerView(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
                             .padding(10.dp)
-                            .size(32.dp)
+                            .size(48.dp)
                             .clip(CircleShape)
                             .background(AppleColors.frostedFill)
                             .border(0.5.dp, AppleColors.frostedBorder, CircleShape)
                             .clickable { onDismiss() },
                         contentAlignment = Alignment.Center,
                     ) {
-                        Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.media_close_player_desc), tint = AppleColors.secondary, modifier = Modifier.size(16.dp))
+                        Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.media_close_player_desc), tint = AppleColors.primary, modifier = Modifier.size(24.dp))
                     }
                 }
             }
@@ -359,37 +360,21 @@ fun MediaPlayerView(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(14.dp)
             ) {
-                Box(
-                    modifier = Modifier.fillMaxWidth().height(36.dp),
-                ) {
-                    if (onDismiss != null) {
-                        Box(
-                            modifier = Modifier
-                                .align(Alignment.CenterStart)
-                                .size(36.dp)
-                                .clip(CircleShape)
-                                .background(AppleColors.frostedFill)
-                                .border(0.5.dp, AppleColors.frostedBorder, CircleShape)
-                                .clickable { onDismiss() },
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.media_close_player_desc), tint = AppleColors.secondary, modifier = Modifier.size(18.dp))
-                        }
-                    }
-                    Row(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .clip(AppleShapes.pill)
-                            .background(AppleColors.frostedFill, AppleShapes.pill)
-                            .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.pill)
-                            .then(if (media.groupablePlayers.size > 1) Modifier.clickable { groupDialogVisible = true } else Modifier)
-                            .padding(horizontal = 14.dp, vertical = 7.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(7.dp),
-                    ) {
-                        Box(Modifier.size(7.dp).background(if (isPlaying) AppleColors.active else AppleColors.warning, CircleShape))
-                        Text(sourceName, style = AppleTypography.bodySmall.copy(fontSize = 13.sp), color = AppleColors.secondary)
-                    }
+                if (onDismiss != null) {
+                    PanelHeader(
+                        title = sourceName,
+                        onNavigation = onDismiss,
+                        navigationIcon = Icons.Filled.Close,
+                        navigationContentDescription = stringResource(R.string.media_close_player_desc),
+                        accent = if (isPlaying) AppleColors.active else AppleColors.warning,
+                        onTitleClick = if (media.groupablePlayers.size > 1) ({ groupDialogVisible = true }) else null,
+                    )
+                } else {
+                    Text(
+                        sourceName,
+                        style = AppleTypography.titleLarge.copy(fontSize = 22.sp, fontWeight = FontWeight.SemiBold),
+                        color = AppleColors.primary,
+                    )
                 }
 
                 Box(

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/PurifierPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/PurifierPanel.kt
@@ -1,11 +1,12 @@
 package com.iblu01.portallauncher.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AutoMode
 import androidx.compose.material.icons.outlined.Bedtime
@@ -38,7 +39,7 @@ private enum class PurifierMode(val preset: String?, val labelRes: Int, val icon
 }
 
 @Composable
-fun PurifierActions(chip: LauncherChip) {
+fun PurifierActions(chip: LauncherChip, modifier: Modifier = Modifier) {
     val callService = LocalCallService.current
     val entity = rememberEntity(chip.entityId)
     val running = entity?.state?.equals("on", true) == true
@@ -69,29 +70,39 @@ fun PurifierActions(chip: LauncherChip) {
         PurifierMode.OFF to stringResource(R.string.purifier_mode_off),
     )
 
-    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-        VerticalSegmentedSelector(
-            options = PurifierMode.entries.toList(),
-            selected = optimisticMode ?: currentMode,
-            onSelect = { mode ->
-                if (mode != currentMode) {
-                    optimisticMode = mode
-                    if (mode == PurifierMode.OFF) {
-                        callService("fan", "turn_off", chip.entityId)
-                    } else {
-                        callService("fan", "set_preset_mode", chip.entityId, mapOf("preset_mode" to mode.preset!!))
+    Column(modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        val options = PurifierMode.entries.toList()
+        BoxWithConstraints(
+            // Match the alarm selector's responsive 96:240 viewport.
+            modifier = Modifier.fillMaxWidth(0.54f).weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            val widthToHeightRatio = 96f / 240f
+            val selectorHeight = minOf(maxHeight, maxWidth / widthToHeightRatio)
+            val selectorWidth = selectorHeight * widthToHeightRatio
+            VerticalSegmentedSelector(
+                options = options,
+                selected = optimisticMode ?: currentMode,
+                onSelect = { mode ->
+                    if (mode != currentMode) {
+                        optimisticMode = mode
+                        if (mode == PurifierMode.OFF) {
+                            callService("fan", "turn_off", chip.entityId)
+                        } else {
+                            callService("fan", "set_preset_mode", chip.entityId, mapOf("preset_mode" to mode.preset!!))
+                        }
                     }
-                }
-            },
-            label = { purifierLabels[it]!! },
-            icon = { it.icon },
-            accent = AppleColors.active,
-            isNeutral = { it == PurifierMode.OFF },
-            enabled = entity != null,
-            segmentHeight = 66.dp,
-            segmentPadding = 4.dp,
-            modifier = Modifier.width(88.dp),
-        )
+                },
+                label = { purifierLabels[it]!! },
+                icon = { it.icon },
+                accent = AppleColors.active,
+                isNeutral = { it == PurifierMode.OFF },
+                enabled = entity != null,
+                segmentHeight = selectorHeight / options.size,
+                segmentPadding = 4.dp,
+                modifier = Modifier.size(selectorWidth, selectorHeight),
+            )
+        }
         if (chip.details.isNotEmpty()) {
             Spacer(Modifier.height(12.dp))
             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/PurifierPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/PurifierPanel.kt
@@ -13,6 +13,11 @@ import androidx.compose.material.icons.outlined.Pets
 import androidx.compose.material.icons.outlined.PowerSettingsNew
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -45,6 +50,16 @@ fun PurifierActions(chip: LauncherChip) {
             ?: PurifierMode.MANUAL
         else -> PurifierMode.MANUAL
     }
+    var optimisticMode by remember(chip.entityId) { mutableStateOf<PurifierMode?>(null) }
+
+    LaunchedEffect(currentMode, optimisticMode) {
+        val pending = optimisticMode ?: return@LaunchedEffect
+        if (currentMode == pending) optimisticMode = null
+        else {
+            kotlinx.coroutines.delay(5000)
+            optimisticMode = null
+        }
+    }
 
     val purifierLabels = mapOf(
         PurifierMode.AUTO to stringResource(R.string.purifier_mode_auto),
@@ -57,12 +72,15 @@ fun PurifierActions(chip: LauncherChip) {
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         VerticalSegmentedSelector(
             options = PurifierMode.entries.toList(),
-            selected = currentMode,
+            selected = optimisticMode ?: currentMode,
             onSelect = { mode ->
-                if (mode == PurifierMode.OFF) {
-                    callService("fan", "turn_off", chip.entityId)
-                } else {
-                    callService("fan", "set_preset_mode", chip.entityId, mapOf("preset_mode" to mode.preset!!))
+                if (mode != currentMode) {
+                    optimisticMode = mode
+                    if (mode == PurifierMode.OFF) {
+                        callService("fan", "turn_off", chip.entityId)
+                    } else {
+                        callService("fan", "set_preset_mode", chip.entityId, mapOf("preset_mode" to mode.preset!!))
+                    }
                 }
             },
             label = { purifierLabels[it]!! },

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/QuickTiles.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/QuickTiles.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.LauncherChip
+import com.iblu01.portallauncher.PillKind
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleMotion
 import com.iblu01.portallauncher.ui.theme.AppleShapes
@@ -71,7 +72,18 @@ import com.iblu01.portallauncher.ui.theme.stateColor
 
 @Composable
 fun StatusChip(chip: LauncherChip, modifier: Modifier = Modifier, selected: Boolean = false, onClick: (() -> Unit)? = null, onLongPress: (() -> Unit)? = null) {
-    val target = stateColor(chip.state)
+    val entity = rememberEntity(chip.entityId)
+    val target = when (chip.kind) {
+        PillKind.LOCK -> if (chip.state.lowercase() in setOf("critical", "error")) AppleColors.error else AppleColors.lockAccent
+        PillKind.FAN -> AppleColors.fanAccent
+        PillKind.THERMOSTAT -> when (entity?.state?.lowercase()) {
+            "heat" -> AppleColors.thermostatHeat
+            "cool" -> AppleColors.thermostatCool
+            "off" -> AppleColors.inactive
+            else -> stateColor(chip.state)
+        }
+        else -> stateColor(chip.state)
+    }
     val accent by animateColorAsState(target, AppleMotion.spring(), label = "chipAccent")
     val animatedProgress by animateFloatAsState(chip.progress, AppleMotion.spring(), label = "chipProgress")
     // Selected chip: iOS-style — white fill, dark text, matching border.

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/SidePanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/SidePanel.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -117,70 +118,32 @@ private fun ChipActionsContent(
 ) {
     val entity = rememberEntity(chip.entityId)
     val batteryPercent = chip.batteryPercent ?: entity?.headerBatteryPercent()
-    val showHeadlineValue = chip.toPanelKind() != PanelKind.COVER ||
-        entity?.let { !it.supports(CoverFeature.SET_POSITION) || it.attributes.optInt("current_position", -1) !in 0..100 } != false
+    val showHeadlineValue = when (chip.toPanelKind()) {
+        PanelKind.THERMOSTAT -> false // The dial owns the target and room temperatures.
+        PanelKind.SWITCH -> false // The switch thumb already carries the on/off state.
+        PanelKind.LOCK -> false // The lock control owns the translated state; avoid raw "locked".
+        PanelKind.PURIFIER -> false // The mode selector already displays the active state.
+        PanelKind.VACUUM -> false // The reusable vacuum status chip owns the active state.
+        PanelKind.COVER -> entity?.let {
+            !it.supports(CoverFeature.SET_POSITION) || it.attributes.optInt("current_position", -1) !in 0..100
+        } != false
+        else -> true
+    }
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(horizontal = 24.dp.scaled(), vertical = 20.dp.scaled()),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Box(Modifier.fillMaxWidth().height(36.dp.scaled())) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.CenterStart)
-                    .size(36.dp.scaled())
-                    .clip(CircleShape)
-                    .background(AppleColors.frostedFill)
-                    .border(0.5.dp, AppleColors.frostedBorder, CircleShape)
-                    .clickable { onDismiss() },
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    Icons.Filled.Close,
-                    contentDescription = stringResource(R.string.side_panel_close_desc),
-                    tint = AppleColors.secondary,
-                    modifier = Modifier.size(18.dp.scaled()),
-                )
-            }
-            Row(
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .clip(AppleShapes.pill)
-                    .background(AppleColors.frostedFill, AppleShapes.pill)
-                    .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.pill)
-                    .padding(horizontal = 14.dp.scaled(), vertical = 7.dp.scaled()),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(7.dp.scaled()),
-            ) {
-                Icon(launcherIcon(chip.icon), null, tint = accent, modifier = Modifier.size(16.dp.scaled()))
-                Text(
-                    chip.label,
-                    style = AppleTypography.bodySmall.copy(fontSize = 13.sp.scaled()),
-                    color = AppleColors.secondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                if (batteryPercent != null) {
-                    val batteryColor = when {
-                        batteryPercent <= 10 -> AppleColors.error
-                        batteryPercent <= 20 -> AppleColors.warning
-                        else -> AppleColors.secondary
-                    }
-                    Icon(
-                        Icons.Filled.BatteryFull,
-                        contentDescription = stringResource(R.string.side_panel_battery_desc, batteryPercent),
-                        tint = batteryColor,
-                        modifier = Modifier.size(14.dp.scaled()),
-                    )
-                    Text(
-                        stringResource(R.string.side_panel_battery_value, batteryPercent),
-                        style = AppleTypography.bodySmall.copy(fontSize = 12.sp.scaled()),
-                        color = batteryColor,
-                    )
-                }
-            }
-        }
+        PanelHeader(
+            title = chip.label,
+            onNavigation = onDismiss,
+            navigationIcon = Icons.Filled.Close,
+            navigationContentDescription = stringResource(R.string.side_panel_close_desc),
+            titleIcon = launcherIcon(chip.icon),
+            accent = accent,
+            batteryPercent = batteryPercent,
+        )
 
         Spacer(Modifier.height(if (showHeadlineValue) 14.dp.scaled() else 8.dp.scaled()))
         if (showHeadlineValue) {
@@ -197,10 +160,18 @@ private fun ChipActionsContent(
         // Center the control block vertically in the remaining space; it still scrolls if a
         // panel's content is taller than the panel (keypads, long detail lists).
         Box(Modifier.fillMaxWidth().weight(1f)) {
-            if (chip.toPanelKind() == PanelKind.COVER) {
-                // Covers need finite width and height constraints so their slider can choose the
-                // largest size that fits while preserving its aspect ratio.
-                CoverControl(chip, Modifier.fillMaxSize())
+            if (chip.toPanelKind() in setOf(PanelKind.COVER, PanelKind.FAN, PanelKind.SWITCH, PanelKind.LOCK, PanelKind.PURIFIER, PanelKind.VACUUM)) {
+                // Vertical controls need finite panel constraints so they can fill the available
+                // height while preserving the same proportions as lights and covers.
+                when (chip.toPanelKind()) {
+                    PanelKind.COVER -> CoverControl(chip, Modifier.fillMaxSize())
+                    PanelKind.FAN -> FanControl(chip, Modifier.fillMaxSize())
+                    PanelKind.SWITCH -> SwitchControl(chip, Modifier.fillMaxSize())
+                    PanelKind.LOCK -> LockControl(chip, Modifier.fillMaxSize())
+                    PanelKind.PURIFIER -> PurifierActions(chip, Modifier.fillMaxSize())
+                    PanelKind.VACUUM -> VacuumControl(chip, Modifier.fillMaxSize())
+                    else -> Unit
+                }
             } else {
                 Column(
                     modifier = Modifier
@@ -214,16 +185,14 @@ private fun ChipActionsContent(
                     // catch-all `else` — every PanelKind is handled explicitly.
                     when (chip.toPanelKind()) {
                 PanelKind.LIGHTS -> LightsActions(chip, onOpenLight)
-                PanelKind.PURIFIER -> PurifierActions(chip)
+                PanelKind.PURIFIER -> Unit // Bounded branch above.
                 PanelKind.SCENES -> ScenesActions(chip)
                 PanelKind.PRESENCE -> PresenceActions(chip)
                 PanelKind.ENERGY -> EnergyActions(chip)
-                PanelKind.LOCK -> LockControl(chip)
-                PanelKind.COVER -> Unit // Rendered in the bounded branch above.
+                PanelKind.LOCK -> Unit // Bounded branch above.
+                PanelKind.COVER, PanelKind.FAN, PanelKind.SWITCH -> Unit // Bounded branch above.
                 PanelKind.THERMOSTAT -> ThermostatControl(chip)
-                PanelKind.VACUUM -> VacuumControl(chip)
-                PanelKind.FAN -> FanControl(chip)
-                PanelKind.SWITCH -> SwitchControl(chip)
+                PanelKind.VACUUM -> Unit // Bounded branch above.
                 PanelKind.ALARM -> AlarmControl(chip)
                 // AIR_QUALITY is rendered full-screen upstream in ChipActionsPanel; MEDIA/WEATHER
                 // are separate PanelContent types and never reach the chip-actions router.
@@ -232,6 +201,88 @@ private fun ChipActionsContent(
                     }
                 }
             }
+        }
+    }
+}
+
+/** Large, background-free header shared by full panels and nested panel pages. */
+@Composable
+internal fun PanelHeader(
+    title: String,
+    onNavigation: () -> Unit,
+    navigationIcon: ImageVector,
+    navigationContentDescription: String,
+    modifier: Modifier = Modifier,
+    titleIcon: ImageVector? = null,
+    accent: Color = AppleColors.primary,
+    batteryPercent: Int? = null,
+    onTitleClick: (() -> Unit)? = null,
+) {
+    val batteryColor = when {
+        batteryPercent == null -> AppleColors.secondary
+        batteryPercent <= 10 -> AppleColors.error
+        batteryPercent <= 20 -> AppleColors.warning
+        else -> AppleColors.secondary
+    }
+    Row(
+        modifier = modifier.fillMaxWidth().height(52.dp.scaled()),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp.scaled())
+                .clip(CircleShape)
+                .background(AppleColors.frostedFill)
+                .border(0.5.dp, AppleColors.frostedBorder, CircleShape)
+                .clickable(onClick = onNavigation),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                navigationIcon,
+                contentDescription = navigationContentDescription,
+                tint = AppleColors.primary,
+                modifier = Modifier.size(24.dp.scaled()),
+            )
+        }
+        Spacer(Modifier.size(14.dp.scaled()))
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .then(if (onTitleClick != null) Modifier.clickable(onClick = onTitleClick) else Modifier),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (titleIcon != null) {
+                Icon(titleIcon, null, tint = accent, modifier = Modifier.size(23.dp.scaled()))
+                Spacer(Modifier.size(9.dp.scaled()))
+            }
+            Text(
+                title,
+                style = AppleTypography.titleLarge.copy(
+                    fontSize = 22.sp.scaled(),
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                color = AppleColors.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (batteryPercent != null) {
+            Spacer(Modifier.size(10.dp.scaled()))
+            Icon(
+                Icons.Filled.BatteryFull,
+                contentDescription = stringResource(R.string.side_panel_battery_desc, batteryPercent),
+                tint = batteryColor,
+                modifier = Modifier.size(17.dp.scaled()),
+            )
+            Spacer(Modifier.size(4.dp.scaled()))
+            Text(
+                stringResource(R.string.side_panel_battery_value, batteryPercent),
+                style = AppleTypography.bodySmall.copy(
+                    fontSize = 13.sp.scaled(),
+                    fontWeight = FontWeight.Medium,
+                ),
+                color = batteryColor,
+            )
         }
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/SidePanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/SidePanel.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BatteryFull
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -35,6 +36,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.LauncherChip
+import com.iblu01.portallauncher.HaEntity
 import com.iblu01.portallauncher.domain.model.PillDetail
 import com.iblu01.portallauncher.PillKind
 import com.iblu01.portallauncher.domain.model.PlayingMedia
@@ -47,6 +49,7 @@ import com.iblu01.portallauncher.ui.theme.scaled
 import com.iblu01.portallauncher.ui.theme.stateColor
 import com.iblu01.portallauncher.R
 import androidx.compose.ui.res.stringResource
+import kotlin.math.roundToInt
 
 /**
  * What the side panel is currently showing. Media auto-opens when playback starts
@@ -112,6 +115,10 @@ private fun ChipActionsContent(
     onDismiss: () -> Unit,
     onOpenLight: (PillDetail) -> Unit,
 ) {
+    val entity = rememberEntity(chip.entityId)
+    val batteryPercent = chip.batteryPercent ?: entity?.headerBatteryPercent()
+    val showHeadlineValue = chip.toPanelKind() != PanelKind.COVER ||
+        entity?.let { !it.supports(CoverFeature.SET_POSITION) || it.attributes.optInt("current_position", -1) !in 0..100 } != false
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -147,41 +154,72 @@ private fun ChipActionsContent(
                 horizontalArrangement = Arrangement.spacedBy(7.dp.scaled()),
             ) {
                 Icon(launcherIcon(chip.icon), null, tint = accent, modifier = Modifier.size(16.dp.scaled()))
-                Text(chip.label, style = AppleTypography.bodySmall.copy(fontSize = 13.sp.scaled()), color = AppleColors.secondary)
+                Text(
+                    chip.label,
+                    style = AppleTypography.bodySmall.copy(fontSize = 13.sp.scaled()),
+                    color = AppleColors.secondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (batteryPercent != null) {
+                    val batteryColor = when {
+                        batteryPercent <= 10 -> AppleColors.error
+                        batteryPercent <= 20 -> AppleColors.warning
+                        else -> AppleColors.secondary
+                    }
+                    Icon(
+                        Icons.Filled.BatteryFull,
+                        contentDescription = stringResource(R.string.side_panel_battery_desc, batteryPercent),
+                        tint = batteryColor,
+                        modifier = Modifier.size(14.dp.scaled()),
+                    )
+                    Text(
+                        stringResource(R.string.side_panel_battery_value, batteryPercent),
+                        style = AppleTypography.bodySmall.copy(fontSize = 12.sp.scaled()),
+                        color = batteryColor,
+                    )
+                }
             }
         }
 
-        Spacer(Modifier.height(14.dp.scaled()))
-        Text(
-            chip.value,
-            style = AppleTypography.titleLarge.copy(fontSize = AppleTypography.titleLarge.fontSize.scaled()),
-            color = AppleColors.primary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Spacer(Modifier.height(16.dp.scaled()))
+        Spacer(Modifier.height(if (showHeadlineValue) 14.dp.scaled() else 8.dp.scaled()))
+        if (showHeadlineValue) {
+            Text(
+                chip.value,
+                style = AppleTypography.titleLarge.copy(fontSize = AppleTypography.titleLarge.fontSize.scaled()),
+                color = AppleColors.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.height(16.dp.scaled()))
+        }
 
         // Center the control block vertically in the remaining space; it still scrolls if a
         // panel's content is taller than the panel (keypads, long detail lists).
         Box(Modifier.fillMaxWidth().weight(1f)) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.Center)
-                    .verticalScroll(rememberScrollState()),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-            // Exhaustive typed router (design §4/Finding 8): no string-id branching, no catch-all
-            // `else` — every PanelKind is handled, GENERIC_DETAILS is the explicit detail-rows case.
-            when (chip.toPanelKind()) {
+            if (chip.toPanelKind() == PanelKind.COVER) {
+                // Covers need finite width and height constraints so their slider can choose the
+                // largest size that fits while preserving its aspect ratio.
+                CoverControl(chip, Modifier.fillMaxSize())
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.Center)
+                        .verticalScroll(rememberScrollState()),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    // Exhaustive typed router (design §4/Finding 8): no string-id branching, no
+                    // catch-all `else` — every PanelKind is handled explicitly.
+                    when (chip.toPanelKind()) {
                 PanelKind.LIGHTS -> LightsActions(chip, onOpenLight)
                 PanelKind.PURIFIER -> PurifierActions(chip)
                 PanelKind.SCENES -> ScenesActions(chip)
                 PanelKind.PRESENCE -> PresenceActions(chip)
                 PanelKind.ENERGY -> EnergyActions(chip)
                 PanelKind.LOCK -> LockControl(chip)
-                PanelKind.COVER -> CoverControl(chip)
+                PanelKind.COVER -> Unit // Rendered in the bounded branch above.
                 PanelKind.THERMOSTAT -> ThermostatControl(chip)
                 PanelKind.VACUUM -> VacuumControl(chip)
                 PanelKind.FAN -> FanControl(chip)
@@ -191,9 +229,22 @@ private fun ChipActionsContent(
                 // are separate PanelContent types and never reach the chip-actions router.
                 PanelKind.AIR_QUALITY, PanelKind.MEDIA, PanelKind.WEATHER,
                 PanelKind.GENERIC_DETAILS -> chip.details.forEach { PanelDetailRow(it) }
-            }
+                    }
+                }
             }
         }
+    }
+}
+
+/** Battery attributes exposed directly by HA integrations for battery-powered devices. */
+private fun HaEntity.headerBatteryPercent(): Int? {
+    val keys = listOf("battery_level", "battery", "battery_percentage")
+    return keys.firstNotNullOfOrNull { key ->
+        if (!attributes.has(key)) return@firstNotNullOfOrNull null
+        attributes.optDouble(key, Double.NaN)
+            .takeUnless(Double::isNaN)
+            ?.roundToInt()
+            ?.takeIf { it in 0..100 }
     }
 }
 
@@ -236,4 +287,3 @@ fun PanelDetailRow(detail: PillDetail) {
         Text(detail.value, style = rowStyle, color = AppleColors.primary, maxLines = 1)
     }
 }
-

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/ThermostatPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/ThermostatPanel.kt
@@ -1,15 +1,9 @@
 package com.iblu01.portallauncher.ui.components
 
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AcUnit
 import androidx.compose.material.icons.outlined.Air
@@ -17,141 +11,148 @@ import androidx.compose.material.icons.outlined.AutoMode
 import androidx.compose.material.icons.outlined.LocalFireDepartment
 import androidx.compose.material.icons.outlined.PowerSettingsNew
 import androidx.compose.material.icons.outlined.WaterDrop
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.iblu01.portallauncher.LauncherChip
-import com.iblu01.portallauncher.ui.LocalCallService
-import com.iblu01.portallauncher.ui.theme.AppleColors
-import com.iblu01.portallauncher.ui.theme.AppleTypography
-import com.iblu01.portallauncher.R
 import androidx.compose.ui.res.stringResource
-import kotlin.math.atan2
-import kotlin.math.cos
+import androidx.compose.ui.unit.dp
+import com.iblu01.portallauncher.LauncherChip
+import com.iblu01.portallauncher.R
+import com.iblu01.portallauncher.domain.model.PillDetail
+import com.iblu01.portallauncher.ui.LocalCallService
+import com.iblu01.portallauncher.ui.components.controls.ControlNeutral
+import com.iblu01.portallauncher.ui.components.controls.ThermostatArc
+import com.iblu01.portallauncher.ui.components.controls.ThermostatActivity
+import com.iblu01.portallauncher.ui.components.controls.ThermostatMode
+import com.iblu01.portallauncher.ui.components.controls.WheelPicker
+import com.iblu01.portallauncher.ui.theme.AppleColors
 import kotlin.math.roundToInt
-import kotlin.math.sin
 
-private const val START_ANGLE = 135f   // bottom-left
-private const val SWEEP = 270f          // 90° gap at the bottom
-
-/**
- * HomeKit-style thermostat: a circular ring the user drags to set the target temperature,
- * current temperature in the centre, and an HVAC-mode row built from the entity's `hvac_modes`.
- */
+/** Home Assistant adapter around the reusable, backend-agnostic thermostat controls. */
 @Composable
 fun ThermostatControl(chip: LauncherChip) {
     val callService = LocalCallService.current
     val entity = rememberEntity(chip.entityId)
     if (entity == null || entity.isUnavailable()) { PanelUnavailable(); return }
-    val minTemp = entity.attributes.optDouble("min_temp", 7.0).toFloat()
-    val maxTemp = entity.attributes.optDouble("max_temp", 35.0).toFloat()
-    val step = entity.attributes.optDouble("target_temp_step", 0.5).toFloat().coerceAtLeast(0.1f)
-    val current = entity.attributes.optDouble("current_temperature").let { if (it.isNaN()) null else it.toFloat() }
-    val committed = entity.attributes.optDouble("temperature").let { if (it.isNaN()) (current ?: minTemp) else it.toFloat() }
-    val mode = entity.state.lowercase()
-    val action = entity.attributes.optString("hvac_action").lowercase()
+    val climate = entity.toClimateContract()
 
-    var target by remember(committed) { mutableFloatStateOf(committed) }
+    val initialTarget = climate.targetTemperature ?: climate.currentTemperature ?: climate.minimumTemperature
+    val initialLow = climate.targetLow ?: initialTarget
+    val initialHigh = climate.targetHigh ?: initialTarget
+    var target by remember(chip.entityId, climate.targetTemperature) { mutableFloatStateOf(initialTarget) }
+    var low by remember(chip.entityId, climate.targetLow) { mutableFloatStateOf(initialLow) }
+    var high by remember(chip.entityId, climate.targetHigh) { mutableFloatStateOf(initialHigh) }
+    var pendingMode by remember(chip.entityId) { mutableStateOf<String?>(null) }
 
-    val ringColor = when {
-        action == "heating" || mode == "heat" -> Color(0xFFFF9F0A)
-        action == "cooling" || mode == "cool" -> AppleColors.accent
-        mode == "off" -> AppleColors.inactive
-        else -> AppleColors.active
+    // Move immediately under the finger, then let HA confirm the choice. If the integration never
+    // acknowledges it, fall back to the last real snapshot instead of leaving a false UI state.
+    LaunchedEffect(climate.hvacMode, pendingMode) {
+        val pending = pendingMode ?: return@LaunchedEffect
+        if (climate.hvacMode == pending) {
+            pendingMode = null
+        } else {
+            kotlinx.coroutines.delay(5_000)
+            if (pendingMode == pending && climate.hvacMode != pending) pendingMode = null
+        }
     }
+    val displayedMode = pendingMode ?: climate.hvacMode
 
-    fun fmt(t: Float) = if (t % 1f == 0f) "${t.toInt()}°" else "%.1f°".format(t)
-    fun commit() = callService("climate", "set_temperature", chip.entityId, mapOf("temperature" to target))
-    fun snap(fraction: Float): Float {
-        val raw = minTemp + fraction.coerceIn(0f, 1f) * (maxTemp - minTemp)
-        return (((raw / step).roundToInt()) * step).coerceIn(minTemp, maxTemp)
+    val usesRange = climate.supportsTargetRange &&
+        displayedMode in setOf("heat_cool", "auto") &&
+        climate.targetLow != null && climate.targetHigh != null
+    val dialMode = when {
+        displayedMode == "off" -> ThermostatMode.OFF
+        usesRange -> ThermostatMode.HEAT_COOL
+        displayedMode == "heat" -> ThermostatMode.HEAT
+        displayedMode == "cool" -> ThermostatMode.COOL
+        else -> ThermostatMode.AUTO
+    }
+    val activity = when (climate.hvacAction) {
+        "heating", "preheating" -> ThermostatActivity.HEATING
+        "cooling" -> ThermostatActivity.COOLING
+        "idle" -> ThermostatActivity.IDLE
+        "off" -> ThermostatActivity.OFF
+        else -> null
     }
 
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(
-            modifier = Modifier
-                .size(240.dp)
-                .pointerInput(minTemp, maxTemp, step) {
-                    detectDragGestures(onDragEnd = { commit() }) { change, _ ->
-                        change.consume()
-                        val cx = size.width / 2f
-                        val cy = size.height / 2f
-                        var deg = Math.toDegrees(atan2((change.position.y - cy).toDouble(), (change.position.x - cx).toDouble())).toFloat()
-                        if (deg < 0) deg += 360f
-                        val delta = (deg - START_ANGLE + 360f) % 360f
-                        val fraction = when {
-                            delta <= SWEEP -> delta / SWEEP
-                            delta < (SWEEP + (360f - SWEEP) / 2f) -> 1f   // past open end → snap max
-                            else -> 0f                                    // in bottom gap toward closed end → min
-                        }
-                        target = snap(fraction)
+        if (climate.hasTemperatureControl && displayedMode !in setOf("dry", "fan_only")) {
+            ThermostatArc(
+                mode = dialMode,
+                activity = activity,
+                target = target,
+                onTargetChange = { target = it },
+                lowTarget = low,
+                highTarget = high,
+                onRangeChange = { nextLow, nextHigh -> low = nextLow; high = nextHigh },
+                valueRange = climate.minimumTemperature..climate.maximumTemperature,
+                step = climate.temperatureStep,
+                current = climate.currentTemperature,
+                unit = climate.temperatureUnit,
+                modifier = Modifier.fillMaxWidth().height(240.dp),
+                onCommit = {
+                    val data = if (usesRange) {
+                        mapOf("target_temp_low" to low, "target_temp_high" to high)
+                    } else {
+                        mapOf("temperature" to target)
+                    }
+                    callService("climate", "set_temperature", chip.entityId, data)
+                },
+            )
+            Spacer(Modifier.height(12.dp))
+        } else if (climate.currentTemperature != null) {
+            PanelDetailRow(PillDetail(stringResource(R.string.thermostat_room_temperature), formatTemperature(climate.currentTemperature, climate.temperatureStep, climate.temperatureUnit)))
+            Spacer(Modifier.height(12.dp))
+        }
+
+        if (climate.availableModes.isNotEmpty()) {
+            val labels = climate.availableModes.associateWith { mode ->
+                hvacModePresentation(mode).label?.let { stringResource(it) }
+                    ?: mode.replace('_', ' ').replaceFirstChar { it.uppercase() }
+            }
+            val modeAccent = when (displayedMode) {
+                "heat" -> AppleColors.thermostatHeat
+                "cool" -> AppleColors.thermostatCool
+                "off" -> ControlNeutral
+                else -> AppleColors.active
+            }
+            WheelPicker(
+                options = climate.availableModes,
+                selected = displayedMode,
+                onSelect = { mode ->
+                    if (mode != displayedMode) {
+                        pendingMode = mode
+                        callService("climate", "set_hvac_mode", chip.entityId, mapOf("hvac_mode" to mode))
                     }
                 },
-            contentAlignment = Alignment.Center,
-        ) {
-            Canvas(Modifier.size(240.dp)) {
-                val stroke = 18.dp.toPx()
-                val diameter = size.minDimension - stroke
-                val topLeft = Offset((size.width - diameter) / 2f, (size.height - diameter) / 2f)
-                val arcSize = Size(diameter, diameter)
-                drawArc(AppleColors.frostedFill, START_ANGLE, SWEEP, false, topLeft, arcSize, style = Stroke(stroke, cap = StrokeCap.Round))
-                val fraction = ((target - minTemp) / (maxTemp - minTemp)).coerceIn(0f, 1f)
-                drawArc(ringColor, START_ANGLE, SWEEP * fraction, false, topLeft, arcSize, style = Stroke(stroke, cap = StrokeCap.Round))
-                // Knob
-                val knobAngle = Math.toRadians((START_ANGLE + SWEEP * fraction).toDouble())
-                val radius = diameter / 2f
-                val knob = Offset(center.x + (radius * cos(knobAngle)).toFloat(), center.y + (radius * sin(knobAngle)).toFloat())
-                drawCircle(Color.White, stroke / 2f - 2.dp.toPx(), knob)
-            }
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(fmt(target), style = AppleTypography.displayLarge.copy(fontSize = 64.sp), color = AppleColors.primary)
-                if (current != null) Text(stringResource(R.string.thermostat_current_temp_format, fmt(current)), style = AppleTypography.bodyLarge, color = AppleColors.secondary)
-            }
-        }
-        Spacer(Modifier.height(20.dp))
-
-        val modes = entity.attributes.optJSONArray("hvac_modes")
-        if (modes != null && modes.length() > 0) {
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
-                for (i in 0 until modes.length()) {
-                    val m = modes.optString(i).lowercase()
-                    val label = when (m) {
-                        "off" -> stringResource(R.string.hvac_mode_off)
-                        "heat" -> stringResource(R.string.hvac_mode_heat)
-                        "cool" -> stringResource(R.string.hvac_mode_cool)
-                        "heat_cool", "auto" -> stringResource(R.string.hvac_mode_auto)
-                        "dry" -> stringResource(R.string.hvac_mode_dry)
-                        "fan_only" -> stringResource(R.string.hvac_mode_fan_only)
-                        else -> m.replaceFirstChar { it.uppercase() }
-                    }
-                    val icon = when (m) {
-                        "off" -> Icons.Outlined.PowerSettingsNew
-                        "heat" -> Icons.Outlined.LocalFireDepartment
-                        "cool" -> Icons.Outlined.AcUnit
-                        "heat_cool", "auto" -> Icons.Outlined.AutoMode
-                        "dry" -> Icons.Outlined.WaterDrop
-                        "fan_only" -> Icons.Outlined.Air
-                        else -> Icons.Outlined.AutoMode
-                    }
-                    PanelModeButton(label, icon, active = m == mode) {
-                        callService("climate", "set_hvac_mode", chip.entityId, mapOf("hvac_mode" to m))
-                    }
-                }
-            }
+                label = { labels.getValue(it) },
+                accent = modeAccent,
+                modifier = Modifier.fillMaxWidth(0.72f),
+            )
         }
     }
+}
+
+private data class HvacModePresentation(val label: Int?, val icon: ImageVector)
+
+private fun hvacModePresentation(mode: String): HvacModePresentation = when (mode) {
+    "off" -> HvacModePresentation(R.string.hvac_mode_off, Icons.Outlined.PowerSettingsNew)
+    "heat" -> HvacModePresentation(R.string.hvac_mode_heat, Icons.Outlined.LocalFireDepartment)
+    "cool" -> HvacModePresentation(R.string.hvac_mode_cool, Icons.Outlined.AcUnit)
+    "heat_cool", "auto" -> HvacModePresentation(R.string.hvac_mode_auto, Icons.Outlined.AutoMode)
+    "dry" -> HvacModePresentation(R.string.hvac_mode_dry, Icons.Outlined.WaterDrop)
+    "fan_only" -> HvacModePresentation(R.string.hvac_mode_fan_only, Icons.Outlined.Air)
+    else -> HvacModePresentation(null, Icons.Outlined.AutoMode)
+}
+
+private fun formatTemperature(value: Float, step: Float, unit: String): String {
+    val number = if (step < 1f) String.format("%.1f", value) else value.roundToInt().toString()
+    return "$number $unit"
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/VacuumPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/VacuumPanel.kt
@@ -1,75 +1,115 @@
 package com.iblu01.portallauncher.ui.components
 
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.MyLocation
-import androidx.compose.material.icons.outlined.Pause
-import androidx.compose.material.icons.outlined.PlayArrow
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.iblu01.portallauncher.LauncherChip
-import com.iblu01.portallauncher.domain.model.PillDetail
-import com.iblu01.portallauncher.ui.LocalCallService
-import com.iblu01.portallauncher.ui.theme.AppleColors
-import com.iblu01.portallauncher.ui.theme.AppleTypography
 import com.iblu01.portallauncher.R
-import androidx.compose.ui.res.stringResource
+import com.iblu01.portallauncher.ui.LocalCallService
+import com.iblu01.portallauncher.ui.components.controls.VacuumAction
+import com.iblu01.portallauncher.ui.components.controls.VacuumActionChips
+import com.iblu01.portallauncher.ui.components.controls.VacuumRunButton
+import com.iblu01.portallauncher.ui.components.controls.VacuumStatusChip
+import com.iblu01.portallauncher.ui.components.controls.WheelPicker
+import com.iblu01.portallauncher.ui.theme.AppleColors
 
-/**
- * Vacuum control: start / pause / stop / dock / locate, gated by the entity's
- * `supported_features`. Status is shown as a read-only row; battery lives in the shared header.
- */
+/** Home Assistant adapter for the reusable vacuum controls. */
 @Composable
-fun VacuumControl(chip: LauncherChip) {
+fun VacuumControl(chip: LauncherChip, modifier: Modifier = Modifier) {
     val callService = LocalCallService.current
     val entity = rememberEntity(chip.entityId)
     if (entity == null || entity.isUnavailable()) { PanelUnavailable(); return }
-    val cleaning = entity.state.lowercase() in setOf("cleaning", "returning")
 
-    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-        Spacer(Modifier.height(2.dp))
-        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
-            PanelModeButton(stringResource(R.string.vacuum_button_start), Icons.Outlined.PlayArrow, cleaning) {
-                callService("vacuum", "start", chip.entityId)
-            }
-            if (entity.supports(VacuumFeature.PAUSE)) {
-                PanelModeButton(stringResource(R.string.vacuum_button_pause), Icons.Outlined.Pause, entity.state.equals("paused", true)) {
-                    callService("vacuum", "pause", chip.entityId)
-                }
-            }
-            if (entity.supports(VacuumFeature.STOP)) {
-                PanelModeButton(stringResource(R.string.vacuum_button_stop), Icons.Filled.Stop, false) {
-                    callService("vacuum", "stop", chip.entityId)
-                }
-            }
-            if (entity.supports(VacuumFeature.RETURN_HOME)) {
-                PanelModeButton(stringResource(R.string.vacuum_button_dock), Icons.Outlined.Home, entity.state.equals("returning", true)) {
-                    callService("vacuum", "return_to_base", chip.entityId)
-                }
-            }
-            if (entity.supports(VacuumFeature.LOCATE)) {
-                PanelModeButton(stringResource(R.string.vacuum_button_locate), Icons.Outlined.MyLocation, false) {
-                    callService("vacuum", "locate", chip.entityId)
-                }
-            }
+    val state = entity.state.lowercase()
+    val running = state in setOf("cleaning", "returning")
+    val status = entity.attributes.optString("status").ifBlank { chip.value }
+    val speedOptions = entity.attributes.optJSONArray("fan_speed_list")?.let { values ->
+        List(values.length()) { values.optString(it) }.filter(String::isNotBlank)
+    }.orEmpty()
+    val selectedSpeed = entity.attributes.optString("fan_speed").takeIf { it in speedOptions }
+    val stopLabel = stringResource(R.string.vacuum_button_stop)
+    val dockLabel = stringResource(R.string.vacuum_button_dock)
+    val locateLabel = stringResource(R.string.vacuum_button_locate)
+
+    val actions = buildList {
+        if (running && entity.supports(VacuumFeature.STOP)) {
+            add(VacuumAction("stop", stopLabel, Icons.Filled.Stop) {
+                callService("vacuum", "stop", chip.entityId)
+            })
         }
-        Spacer(Modifier.height(18.dp))
+        if (entity.supports(VacuumFeature.RETURN_HOME)) {
+            add(VacuumAction(
+                "dock",
+                dockLabel,
+                Icons.Outlined.Home,
+                active = state == "returning",
+            ) { callService("vacuum", "return_to_base", chip.entityId) })
+        }
+        if (entity.supports(VacuumFeature.LOCATE)) {
+            add(VacuumAction("locate", locateLabel, Icons.Outlined.MyLocation) {
+                callService("vacuum", "locate", chip.entityId)
+            })
+        }
+    }
 
-        val status = entity.attributes.optString("status").ifBlank { chip.value }
-        if (status.isNotBlank()) PanelDetailRow(PillDetail(stringResource(R.string.vacuum_detail_status), status))
-        chip.details.forEach {
-            Spacer(Modifier.height(8.dp))
-            PanelDetailRow(it)
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        if (status.isNotBlank()) VacuumStatusChip(status, prominent = true)
+        Spacer(Modifier.height(20.dp))
+
+        BoxWithConstraints(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            val buttonSize = (maxWidth * 0.38f).coerceIn(104.dp, 148.dp)
+            VacuumRunButton(
+                running = running,
+                onToggle = { wasRunning ->
+                    when {
+                        wasRunning && entity.supports(VacuumFeature.PAUSE) ->
+                            callService("vacuum", "pause", chip.entityId)
+                        wasRunning && entity.supports(VacuumFeature.STOP) ->
+                            callService("vacuum", "stop", chip.entityId)
+                        !wasRunning -> callService("vacuum", "start", chip.entityId)
+                    }
+                },
+                size = buttonSize,
+            )
+        }
+
+        if (speedOptions.isNotEmpty() && selectedSpeed != null) {
+            Spacer(Modifier.height(12.dp))
+            WheelPicker(
+                options = speedOptions,
+                selected = selectedSpeed,
+                onSelect = { speed ->
+                    if (speed != selectedSpeed) {
+                        callService("vacuum", "set_fan_speed", chip.entityId, mapOf("fan_speed" to speed))
+                    }
+                },
+                label = { value -> value.replace('_', ' ').replaceFirstChar { it.uppercase() } },
+                accent = AppleColors.primary,
+                visibleCount = 3,
+                modifier = Modifier.fillMaxWidth(0.72f),
+            )
+        }
+
+        if (actions.isNotEmpty()) {
+            Spacer(Modifier.height(16.dp))
+            VacuumActionChips(actions, modifier = Modifier.fillMaxWidth(), accent = AppleColors.active)
         }
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/VacuumPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/VacuumPanel.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.res.stringResource
 
 /**
  * Vacuum control: start / pause / stop / dock / locate, gated by the entity's
- * `supported_features`. Battery and status shown as read-only rows.
+ * `supported_features`. Status is shown as a read-only row; battery lives in the shared header.
  */
 @Composable
 fun VacuumControl(chip: LauncherChip) {
@@ -65,13 +65,8 @@ fun VacuumControl(chip: LauncherChip) {
         }
         Spacer(Modifier.height(18.dp))
 
-        val battery = entity.attributes.optInt("battery_level", -1)
         val status = entity.attributes.optString("status").ifBlank { chip.value }
         if (status.isNotBlank()) PanelDetailRow(PillDetail(stringResource(R.string.vacuum_detail_status), status))
-        if (battery in 0..100) {
-            Spacer(Modifier.height(8.dp))
-            PanelDetailRow(PillDetail(stringResource(R.string.vacuum_detail_battery), "$battery %"))
-        }
         chip.details.forEach {
             Spacer(Modifier.height(8.dp))
             PanelDetailRow(it)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherPanel.kt
@@ -58,15 +58,12 @@ fun WeatherPanel(weather: WeatherUi, onDismiss: () -> Unit, modifier: Modifier =
             Column(
                 Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp).verticalScroll(rememberScrollState()),
             ) {
-                Box(Modifier.fillMaxWidth().height(36.dp)) {
-                    Box(
-                        Modifier.align(Alignment.CenterStart).size(36.dp).clip(CircleShape)
-                            .background(AppleColors.frostedFill).border(0.5.dp, AppleColors.frostedBorder, CircleShape)
-                            .appleClickable(onDismiss),
-                        contentAlignment = Alignment.Center,
-                    ) { Icon(Icons.Filled.Close, stringResource(R.string.weather_close_desc), tint = AppleColors.secondary, modifier = Modifier.size(18.dp)) }
-                    Text(stringResource(R.string.weather_panel_title), style = AppleTypography.titleMedium.copy(fontSize = 15.sp), color = AppleColors.secondary, modifier = Modifier.align(Alignment.Center))
-                }
+                PanelHeader(
+                    title = stringResource(R.string.weather_panel_title),
+                    onNavigation = onDismiss,
+                    navigationIcon = Icons.Filled.Close,
+                    navigationContentDescription = stringResource(R.string.weather_close_desc),
+                )
 
                 Spacer(Modifier.height(18.dp))
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalAccessory.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalAccessory.kt
@@ -40,12 +40,8 @@ import com.iblu01.portallauncher.ui.theme.AppleTypography
 import com.iblu01.portallauncher.R
 import androidx.compose.ui.res.stringResource
 
-/**
- * HomeKit accessory-tile radius. Tuned to Apple's Home app: a rounded rectangle that is neither
- * pill nor square. Keep it here so every tile (and the grid) shares the exact same curvature.
- */
-private val AccessoryCorner: Dp = 19.dp
-private val AccessoryShape: Shape = RoundedCornerShape(AccessoryCorner)
+/** HomeKit tile corners scale with the tile's shortest axis. */
+private val AccessoryShape: Shape = RoundedCornerShape(percent = 30)
 
 /**
  * A single HomeKit-style accessory tile: an icon on the left, name and an optional status line.
@@ -70,6 +66,7 @@ fun AccessoryTile(
     height: Dp = 66.dp,
     onLongPress: (() -> Unit)? = null,
 ) {
+    val contentScale = (height / 66.dp).coerceIn(0.7f, 1.5f)
     val background by animateColorAsState(
         when {
             !enabled -> AppleColors.frostedFill
@@ -106,15 +103,15 @@ fun AccessoryTile(
                 if (enabled) Modifier.appleClickable({ onToggle(!on) }, onLongPress)
                 else Modifier,
             )
-            .padding(horizontal = 12.dp),
+            .padding(horizontal = 12.dp * contentScale),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(Modifier.size(38.dp)) {
+        Box(Modifier.size(38.dp * contentScale)) {
             Box(
                 Modifier.matchParentSize().clip(CircleShape).background(iconCircle, CircleShape),
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(icon, null, tint = iconTint, modifier = Modifier.size(21.dp))
+                Icon(icon, null, tint = iconTint, modifier = Modifier.size(21.dp * contentScale))
             }
             // Alert badge rides above the circle's top-right, protruding onto the tile.
             if (warning) {
@@ -124,16 +121,18 @@ fun AccessoryTile(
                     tint = onContent,
                     modifier = Modifier
                         .align(Alignment.TopEnd)
-                        .offset(x = 5.dp, y = (-5).dp)
-                        .size(16.dp),
+                        .offset(x = 5.dp * contentScale, y = (-5).dp * contentScale)
+                        .size(16.dp * contentScale),
                 )
             }
         }
-        Spacer(Modifier.width(11.dp))
+        Spacer(Modifier.width(11.dp * contentScale))
         Column {
             Text(
                 title,
-                style = AppleTypography.titleMedium.copy(fontSize = 18.sp),
+                style = AppleTypography.titleMedium.copy(
+                    fontSize = 18.sp * contentScale,
+                ),
                 fontWeight = if (on && enabled) FontWeight.Bold else FontWeight.Normal,
                 color = titleColor,
                 maxLines = 1,
@@ -142,7 +141,9 @@ fun AccessoryTile(
             if (subtitle != null) {
                 Text(
                     subtitle,
-                    style = AppleTypography.bodySmall,
+                    style = AppleTypography.bodySmall.copy(
+                        fontSize = AppleTypography.bodySmall.fontSize * contentScale,
+                    ),
                     fontWeight = FontWeight.Normal,
                     color = subtitleColor,
                     maxLines = 1,

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -59,6 +60,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleMotion
 import com.iblu01.portallauncher.ui.theme.AppleTypography
@@ -94,21 +96,8 @@ private fun valueOf(fraction: Float, range: ClosedFloatingPointRange<Float>): Fl
 fun percentLabel(value: Float, range: ClosedFloatingPointRange<Float> = 0f..1f): String =
     "${(fractionOf(value, range) * 100).roundToInt()} %"
 
-/** Outer corner radius of every pill-shaped control. */
-private val ControlCornerRadius: Dp = 26.dp
-
-/** Continuous-corner squircle used by the pill-shaped controls. */
-private val ControlSquircle: Shape = RoundedCornerShape(ControlCornerRadius)
-
-/** Slider-only corners scale with the control width instead of staying frozen at 26 dp. */
+/** Control corners scale with the shortest axis instead of relying on a frozen dp radius. */
 private val VerticalSliderSquircle: Shape = RoundedCornerShape(percent = 30)
-
-/**
- * Concentric-corner rule (Apple HIG): a shape nested inside another, [inset] away from its
- * edge, must round by `outer − inset` so the curves stay parallel. Never reuse the outer radius.
- */
-private fun innerCorner(inset: Dp): Shape =
-    RoundedCornerShape((ControlCornerRadius - inset).coerceAtLeast(0.dp))
 
 /** Neutral tint for an "off"/disabled selection — used in place of the accent (iOS systemGray4). */
 val ControlNeutral: Color = Color(0xFFC7C7CC)
@@ -167,7 +156,7 @@ const val ControlAspectRatio: Float = 88f / 220f
 fun Modifier.controlSize(width: Dp = 88.dp): Modifier = this.width(width).aspectRatio(ControlAspectRatio)
 
 /** Most options a [VerticalSegmentedSelector] holds before it would grow uncomfortably tall. */
-const val MaxSegments: Int = 6
+const val MaxSegments: Int = 8
 
 /**
  * Height of one selector segment. Chosen so a 4-option selector matches the canonical control
@@ -484,7 +473,17 @@ fun VerticalGradientSlider(
         val inset = maxWidth * (6f / 88f)
         val thumbHeight = (maxWidth * (57f / 88f)).coerceAtMost((maxHeight - inset * 2).coerceAtLeast(0.dp))
         val travel = (maxHeight - thumbHeight - inset * 2).coerceAtLeast(0.dp)
-        val thumbShape = RoundedCornerShape(percent = 30)
+        val outerRadius = maxWidth * 0.30f
+        val thumbRadius = minOf(
+            (outerRadius - inset).coerceAtLeast(0.dp),
+            (maxWidth - inset * 2) / 2,
+            thumbHeight / 2,
+        )
+        val thumbShape = RoundedCornerShape(thumbRadius)
+        val contentScale = minOf(
+            maxWidth / 88.dp,
+            thumbHeight / 57.dp,
+        ).coerceIn(0.65f, 1.5f)
         val contentColor = contentColorOn(markerColor)
         Box(
             Modifier
@@ -501,10 +500,13 @@ fun VerticalGradientSlider(
                 icon = icon?.invoke(currentValue),
                 text = label?.invoke(currentValue),
                 color = contentColor,
-                textStyle = AppleTypography.bodySmall,
+                textStyle = AppleTypography.bodySmall.copy(
+                    fontSize = AppleTypography.bodySmall.fontSize * contentScale,
+                ),
                 layout = contentLayout,
-                iconSize = 17.dp,
-                gap = 3.dp,
+                iconSize = 17.dp * contentScale,
+                gap = 3.dp * contentScale,
+                textModifier = Modifier.padding(horizontal = 5.dp * contentScale),
             )
         }
     }
@@ -558,9 +560,10 @@ fun VerticalColorTempSlider(
  * the accent. Works for any [T]; render each with [label] and an optional per-option [icon]
  * ([contentLayout] stacks it above or beside the text).
  *
- * Takes 2–6 options. Rather than squeezing them into a fixed footprint, the control keeps every
+ * Takes 1–8 options. Rather than squeezing them into a fixed footprint, the control keeps every
  * segment [segmentHeight] tall and grows downward — so the caller only sets its width; the height
- * follows the option count.
+ * follows the option count. Its outer radius follows the live width and the highlight radius is
+ * derived from it so both curves remain concentric; [cornerRadius] can override the outer radius.
  */
 @Composable
 fun <T> VerticalSegmentedSelector(
@@ -575,8 +578,7 @@ fun <T> VerticalSegmentedSelector(
     icon: (T) -> ImageVector? = { null },
     contentLayout: ControlContentLayout = ControlContentLayout.Vertical,
     enabled: Boolean = true,
-    shape: Shape = ControlSquircle,
-    highlightShape: Shape = innerCorner(5.dp),
+    cornerRadius: Dp? = null,
     segmentHeight: Dp = SegmentHeight,
     segmentPadding: Dp = 0.dp,
 ) {
@@ -596,12 +598,27 @@ fun <T> VerticalSegmentedSelector(
     val haptic = LocalHapticFeedback.current
 
     BoxWithConstraints(
-        modifier
-            // Self-sizing height: one segment per option. Caller controls width only.
-            .height(segmentHeight * options.size)
-            .clip(shape)
+        modifier = modifier.height(segmentHeight * options.size),
+    ) {
+        // By default the selector's corners scale with its live width. The moving highlight
+        // follows the concentric-corner rule: inner radius = outer radius - actual inset.
+        // A selected segment can be shorter than the selector is wide (notably with 5–6
+        // options). Keep the outer radius within half a segment so Compose never has to clamp
+        // the inner curve independently, which would break the parallel inset and appear to
+        // pinch against the container edge.
+        val radiusFromWidth = cornerRadius ?: maxWidth * 0.30f
+        val outerRadius = minOf(radiusFromWidth, segmentHeight / 2)
+        val outerShape = RoundedCornerShape(outerRadius)
+        val highlightShape = RoundedCornerShape(
+            (outerRadius - highlightInset).coerceAtLeast(0.dp),
+        )
+
+        BoxWithConstraints(
+            Modifier
+            .fillMaxSize()
+            .clip(outerShape)
             .background(AppleColors.frostedFill)
-            .border(0.5.dp, AppleColors.frostedBorder, shape)
+            .border(0.5.dp, AppleColors.frostedBorder, outerShape)
             .then(
                 if (!enabled) Modifier else Modifier.pointerInput(options) {
                     fun indexAt(y: Float) =
@@ -638,7 +655,7 @@ fun <T> VerticalSegmentedSelector(
                     )
                 },
             ),
-    ) {
+        ) {
         val segmentHeight = maxHeight / options.size
         val highlightOffset by animateDpAsState(
             segmentHeight * selectedIndex, AppleMotion.spring(), label = "segmentOffset",
@@ -652,16 +669,27 @@ fun <T> VerticalSegmentedSelector(
             tween(200), label = "segmentColor",
         )
 
-        val iconGap = 5.dp
-        val iconSize = 18.dp
+        val measuredContentScale = minOf(
+            maxWidth / 88.dp,
+            segmentHeight / 55.dp,
+        )
+        // Multi-option labels should grow more slowly than the control itself: preserve the
+        // spatial hierarchy and leave breathing room around the moving highlight.
+        val contentScale = (1f + (measuredContentScale - 1f) * 0.45f).coerceIn(0.8f, 1.2f)
+        val iconGap = 5.dp * contentScale
+        val iconSize = 18.dp * contentScale
+        val scaledTextPadding = textPadding * contentScale
         val labels = options.map(label)
         val anyHorizontalIcon = contentLayout == ControlContentLayout.Horizontal && options.any { icon(it) != null }
         val density = LocalDensity.current
         val measurer = rememberTextMeasurer()
-        val fittedStyle = remember(labels, maxWidth, anyHorizontalIcon, density) {
+        val fittedStyle = remember(labels, maxWidth, anyHorizontalIcon, density, contentScale) {
             // Measure at the selected weight (SemiBold) so the bold row never overflows.
-            val base = AppleTypography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
-            val reserved = textPadding * 2 + if (anyHorizontalIcon) iconSize + iconGap else 0.dp
+            val base = AppleTypography.bodyLarge.copy(
+                fontSize = AppleTypography.bodyLarge.fontSize * contentScale,
+                fontWeight = FontWeight.SemiBold,
+            )
+            val reserved = scaledTextPadding * 2 + if (anyHorizontalIcon) iconSize + iconGap else 0.dp
             val availablePx = with(density) { (maxWidth - reserved).toPx() }
             val widest = labels.maxOfOrNull {
                 measurer.measure(it, base, maxLines = 1, softWrap = false).size.width
@@ -709,7 +737,7 @@ fun <T> VerticalSegmentedSelector(
                         // Keep the stacked icon+text clear of the moving highlight's top/bottom
                         // edges. Horizontal spacing is handled by textPadding below.
                         modifier = Modifier.padding(vertical = stackClearance),
-                        textModifier = Modifier.padding(horizontal = textPadding),
+                        textModifier = Modifier.padding(horizontal = scaledTextPadding),
                     )
 
                     // Hairline divider below this row, hidden when it touches the highlight.
@@ -725,6 +753,164 @@ fun <T> VerticalSegmentedSelector(
                                     AppleColors.quaternary.copy(alpha = if (dividerVisible) 1f else 0f),
                                 ),
                         )
+                    }
+                }
+            }
+        }
+        }
+    }
+}
+
+/**
+ * Compact Apple Home-style mode picker. Options share one quiet capsule; the selected option is
+ * the only raised surface, so the control reads as one choice instead of a row of unrelated
+ * buttons. Backend-specific values and labels remain the caller's responsibility.
+ */
+@Composable
+fun <T> HorizontalSegmentedSelector(
+    options: List<T>,
+    selected: T,
+    onSelect: (T) -> Unit,
+    label: (T) -> String,
+    modifier: Modifier = Modifier,
+    icon: (T) -> ImageVector? = { null },
+    accent: Color = AppleColors.accent,
+    neutralColor: Color = ControlNeutral,
+    isNeutral: (T) -> Boolean = { false },
+    contentLayout: ControlContentLayout = ControlContentLayout.Vertical,
+    enabled: Boolean = true,
+    cornerRadius: Dp? = null,
+    controlHeight: Dp = 62.dp,
+) {
+    require(options.size in 1..MaxSegments) {
+        "HorizontalSegmentedSelector takes 1–$MaxSegments options, got ${options.size}"
+    }
+    var dragIndex by remember { mutableStateOf<Int?>(null) }
+    val selectedIndex = (dragIndex ?: options.indexOf(selected)).coerceAtLeast(0)
+    val highlightInset = 4.dp
+    val haptic = LocalHapticFeedback.current
+
+    BoxWithConstraints(
+        modifier = modifier
+            .height(controlHeight),
+    ) {
+        val segmentWidth = maxWidth / options.size
+        val radiusFromHeight = cornerRadius ?: maxHeight * 0.30f
+        val outerRadius = minOf(radiusFromHeight, segmentWidth / 2)
+        val outerShape = RoundedCornerShape(outerRadius)
+        val highlightShape = RoundedCornerShape(
+            (outerRadius - highlightInset).coerceAtLeast(0.dp),
+        )
+        val highlightOffset by animateDpAsState(
+            segmentWidth * selectedIndex, AppleMotion.spring(), label = "horizontalSegmentOffset",
+        )
+        val effectiveSelection = options[selectedIndex]
+        val contentScale = minOf(
+            maxHeight / 62.dp,
+            segmentWidth / 88.dp,
+        ).coerceIn(0.65f, 1.5f)
+        val highlightColor by animateColorAsState(
+            when {
+                !enabled -> AppleColors.inactive
+                isNeutral(effectiveSelection) -> neutralColor
+                else -> accent
+            },
+            tween(200), label = "horizontalSegmentColor",
+        )
+
+        Box(
+            Modifier
+            .fillMaxSize()
+            .clip(outerShape)
+            .background(AppleColors.frostedFill)
+            .border(0.5.dp, AppleColors.frostedBorder, outerShape)
+            .then(
+                if (!enabled) Modifier else Modifier.pointerInput(options) {
+                    fun indexAt(x: Float) =
+                        (x / (size.width.toFloat() / options.size)).toInt().coerceIn(0, options.lastIndex)
+                    detectTapGestures { onSelect(options[indexAt(it.x)]) }
+                },
+            )
+            .then(
+                if (!enabled) Modifier else Modifier.pointerInput(options) {
+                    fun indexAt(x: Float) =
+                        (x / (size.width.toFloat() / options.size)).toInt().coerceIn(0, options.lastIndex)
+                    var emitted = -1
+                    detectHorizontalDragGestures(
+                        onDragStart = {
+                            emitted = indexAt(it.x)
+                            dragIndex = emitted
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        },
+                        onHorizontalDrag = { change, _ ->
+                            val index = indexAt(change.position.x)
+                            if (index != emitted) {
+                                emitted = index
+                                dragIndex = index
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            }
+                        },
+                        onDragEnd = {
+                            if (emitted >= 0) onSelect(options[emitted])
+                            dragIndex = null
+                        },
+                        onDragCancel = { dragIndex = null },
+                    )
+                },
+            ),
+        ) {
+            Box(
+                Modifier
+                    .align(Alignment.CenterStart)
+                    .offset(x = highlightOffset)
+                    .width(segmentWidth)
+                    .fillMaxHeight()
+                    .padding(highlightInset)
+                    .clip(highlightShape)
+                    .background(highlightColor.copy(alpha = if (enabled) 1f else 0.4f)),
+            )
+
+            Row(Modifier.fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
+                options.forEachIndexed { index, option ->
+                    val active = index == selectedIndex
+                    val content by animateColorAsState(
+                        if (active) contentColorOn(highlightColor) else AppleColors.secondary,
+                        tween(180), label = "horizontalSegmentContent",
+                    )
+                    Box(
+                        Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .semantics { contentDescription = label(option) },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        ControlLabel(
+                            icon = icon(option),
+                            text = label(option),
+                            color = content,
+                            textStyle = AppleTypography.labelSmall.copy(
+                                fontSize = 10.sp * contentScale,
+                                fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal,
+                            ),
+                            layout = contentLayout,
+                            iconSize = 19.dp * contentScale,
+                            gap = 2.dp * contentScale,
+                            textModifier = Modifier.padding(horizontal = 6.dp * contentScale),
+                        )
+
+                        if (index < options.lastIndex) {
+                            val dividerVisible = index != selectedIndex && index + 1 != selectedIndex
+                            Box(
+                                Modifier
+                                    .align(Alignment.CenterEnd)
+                                    .padding(vertical = 14.dp * contentScale)
+                                    .width(0.5.dp)
+                                    .fillMaxHeight()
+                                    .background(
+                                        AppleColors.quaternary.copy(alpha = if (dividerVisible) 1f else 0f),
+                                    ),
+                            )
+                        }
                     }
                 }
             }
@@ -754,7 +940,7 @@ fun VerticalSwitch(
     label: (Boolean) -> String? = { null },
     contentLayout: ControlContentLayout = ControlContentLayout.Vertical,
     enabled: Boolean = true,
-    shape: Shape = ControlSquircle,
+    shape: Shape = VerticalSliderSquircle,
 ) {
     val inset = 6.dp
     val haptic = LocalHapticFeedback.current
@@ -819,7 +1005,20 @@ fun VerticalSwitch(
             dragFraction ?: restingFraction, AppleMotion.spring(), label = "switchFraction",
         )
         val fraction = dragFraction ?: settledFraction
-        val thumbShape = innerCorner(inset)
+        val outerRadius = maxWidth * 0.30f
+        val thumbRadius = minOf(
+            (outerRadius - inset).coerceAtLeast(0.dp),
+            thumbWidth / 2,
+            thumbHeight / 2,
+        )
+        val thumbShape = RoundedCornerShape(thumbRadius)
+        // Scale the thumb content from the canonical 88 × 220 control. Width and height both
+        // participate so compact or unusually proportioned switches cannot overflow.
+        val contentScale = minOf(
+            maxWidth / 88.dp,
+            thumbWidth / 76.dp,
+            thumbHeight / 110.dp,
+        ).coerceIn(0.55f, 1.5f)
         Box(
             Modifier
                 .align(Alignment.TopCenter)
@@ -835,9 +1034,13 @@ fun VerticalSwitch(
                 icon = icon(effectiveChecked),
                 text = label(effectiveChecked),
                 color = contentColorOn(thumbColor),
-                textStyle = AppleTypography.labelSmall,
+                textStyle = AppleTypography.labelSmall.copy(
+                    fontSize = AppleTypography.labelSmall.fontSize * contentScale,
+                ),
                 layout = contentLayout,
-                iconSize = 20.dp,
+                iconSize = 20.dp * contentScale,
+                gap = 5.dp * contentScale,
+                textModifier = Modifier.padding(horizontal = 6.dp * contentScale),
             )
         }
     }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
@@ -100,6 +100,9 @@ private val ControlCornerRadius: Dp = 26.dp
 /** Continuous-corner squircle used by the pill-shaped controls. */
 private val ControlSquircle: Shape = RoundedCornerShape(ControlCornerRadius)
 
+/** Slider-only corners scale with the control width instead of staying frozen at 26 dp. */
+private val VerticalSliderSquircle: Shape = RoundedCornerShape(percent = 30)
+
 /**
  * Concentric-corner rule (Apple HIG): a shape nested inside another, [inset] away from its
  * edge, must round by `outer − inset` so the curves stay parallel. Never reuse the outer radius.
@@ -205,7 +208,7 @@ fun VerticalFillSlider(
     icon: ImageVector? = null,
     label: ((Float) -> String)? = { percentLabel(it, valueRange) },
     contentLayout: ControlContentLayout = ControlContentLayout.Vertical,
-    shape: Shape = ControlSquircle,
+    shape: Shape = VerticalSliderSquircle,
     onValueChangeFinished: ((Float) -> Unit)? = null,
 ) {
     val haptic = LocalHapticFeedback.current
@@ -290,18 +293,35 @@ fun VerticalFillSlider(
                 .background(fillColor.copy(alpha = if (enabled) 0.95f else 0.5f)),
         )
 
-        // Grip line, parked on the fill edge.
+        // Keep the grip slightly inside the coloured fill, like Apple's vertical controls,
+        // instead of letting it straddle the hard boundary between fill and track.
         val edgeFromTop = when (origin) {
             FillOrigin.BOTTOM -> trackHeight * (1f - animatedFraction)
             FillOrigin.TOP -> trackHeight * animatedFraction
         }
+        // All grip geometry follows the slider width, preserving the reference 88 dp control's
+        // proportions when the cover panel scales it up or down.
+        val gripInset = maxWidth * (8f / 88f)
+        val gripWidth = maxWidth * (30f / 88f)
+        val gripHeight = maxWidth * (4f / 88f)
+        val gripTopLimit = maxWidth * (8f / 88f)
+        val gripBottomClearance = maxWidth * (12f / 88f)
+        val gripCenterFromTop = when (origin) {
+            FillOrigin.BOTTOM -> edgeFromTop + gripInset
+            FillOrigin.TOP -> edgeFromTop - gripInset
+        }
         Box(
             Modifier
                 .align(Alignment.TopCenter)
-                .offset(y = (edgeFromTop - 2.dp).coerceIn(8.dp, (trackHeight - 12.dp).coerceAtLeast(8.dp)))
+                .offset(
+                    y = (gripCenterFromTop - gripHeight / 2f).coerceIn(
+                        gripTopLimit,
+                        (trackHeight - gripBottomClearance).coerceAtLeast(gripTopLimit),
+                    ),
+                )
                 .graphicsLayer { scaleX = gripScale }
-                .width(30.dp)
-                .height(4.dp)
+                .width(gripWidth)
+                .height(gripHeight)
                 .clip(CircleShape)
                 .background(contentColorOn(fillColor).copy(alpha = 0.55f)),
         )

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
@@ -329,13 +329,18 @@ fun VerticalFillSlider(
         // Base caption (+ optional icon). Contrast follows whichever tone sits behind the base.
         val baseIsFilled = origin == FillOrigin.BOTTOM && targetFraction > 0.14f
         val captionColor = if (baseIsFilled) contentColorOn(fillColor) else AppleColors.secondary
-        Box(Modifier.align(Alignment.BottomCenter).padding(bottom = 16.dp)) {
+        val contentScale = (maxWidth / 88.dp).coerceAtLeast(0.75f)
+        Box(Modifier.align(Alignment.BottomCenter).padding(bottom = 16.dp * contentScale)) {
             ControlLabel(
                 icon = icon,
                 text = label?.invoke(valueOf(targetFraction, valueRange)),
                 color = captionColor,
-                textStyle = AppleTypography.bodySmall,
+                textStyle = AppleTypography.bodySmall.copy(
+                    fontSize = AppleTypography.bodySmall.fontSize * contentScale,
+                ),
                 layout = contentLayout,
+                iconSize = 18.dp * contentScale,
+                gap = 5.dp * contentScale,
             )
         }
     }
@@ -401,12 +406,11 @@ fun VerticalGradientSlider(
     icon: ((Float) -> ImageVector?)? = null,
     label: ((Float) -> String)? = { percentLabel(it, valueRange) },
     contentLayout: ControlContentLayout = ControlContentLayout.Vertical,
-    shape: Shape = ControlSquircle,
+    shape: Shape = VerticalSliderSquircle,
     thumbColor: ((Float) -> Color)? = null,
     onValueChangeFinished: ((Float) -> Unit)? = null,
 ) {
     require(colors.isNotEmpty()) { "VerticalGradientSlider needs at least one colour" }
-    val inset = 6.dp
     val haptic = LocalHapticFeedback.current
     val fraction = fractionOf(value, valueRange)
     var dragging by remember { mutableStateOf(false) }
@@ -477,9 +481,10 @@ fun VerticalGradientSlider(
             ),
     ) {
         // Thumb: inset from the track edge, rounded concentrically — same rule as the switch.
-        val thumbHeight = (maxHeight * 0.26f).coerceIn(44.dp, 64.dp)
+        val inset = maxWidth * (6f / 88f)
+        val thumbHeight = (maxWidth * (57f / 88f)).coerceAtMost((maxHeight - inset * 2).coerceAtLeast(0.dp))
         val travel = (maxHeight - thumbHeight - inset * 2).coerceAtLeast(0.dp)
-        val thumbShape = innerCorner(inset)
+        val thumbShape = RoundedCornerShape(percent = 30)
         val contentColor = contentColorOn(markerColor)
         Box(
             Modifier
@@ -518,7 +523,7 @@ fun VerticalColorTempSlider(
     maxKelvin: Int,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    shape: Shape = ControlSquircle,
+    shape: Shape = VerticalSliderSquircle,
     onKelvinChangeFinished: ((Int) -> Unit)? = null,
 ) {
     val range = minKelvin.toFloat()..maxKelvin.toFloat()

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
@@ -576,6 +576,7 @@ fun <T> VerticalSegmentedSelector(
     contentLayout: ControlContentLayout = ControlContentLayout.Vertical,
     enabled: Boolean = true,
     shape: Shape = ControlSquircle,
+    highlightShape: Shape = innerCorner(5.dp),
     segmentHeight: Dp = SegmentHeight,
     segmentPadding: Dp = 0.dp,
 ) {
@@ -677,7 +678,7 @@ fun <T> VerticalSegmentedSelector(
                 .fillMaxWidth()
                 .height(segmentHeight)
                 .padding(highlightInset)
-                .clip(innerCorner(highlightInset))
+                .clip(highlightShape)
                 .background(highlightColor.copy(alpha = if (enabled) 1f else 0.4f)),
         )
 

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalKeypad.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalKeypad.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -47,6 +48,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.ui.theme.AppleColors
@@ -140,10 +142,15 @@ fun PinKeypad(
         }
     }
 
-    Column(
+    BoxWithConstraints(
         modifier
             .fillMaxWidth()
             .then(if (!enabled) Modifier.alpha(0.35f) else Modifier),
+    ) {
+        val keyDiameter = ((maxWidth - 40.dp) / 3).coerceIn(48.dp, 74.dp)
+        val contentScale = (keyDiameter / 74.dp).coerceIn(0.65f, 1f)
+        Column(
+        modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         if (title != null) {
@@ -152,13 +159,13 @@ fun PinKeypad(
                 style = AppleTypography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
                 color = AppleColors.primary,
             )
-            Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(4.dp * contentScale))
         }
         if (subtitle != null) {
             Text(subtitle, style = AppleTypography.bodySmall, color = AppleColors.secondary)
-            Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(4.dp * contentScale))
         }
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(16.dp * contentScale))
 
         // Entry dots, riding the shake.
         val dotCount = if (fixed) codeLength else code.length.coerceAtLeast(1)
@@ -177,7 +184,7 @@ fun PinKeypad(
         )
         Row(
             modifier = Modifier.offset { IntOffset(shake.value.roundToInt(), 0) },
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp * contentScale),
         ) {
             repeat(dotCount) { i ->
                 val on = i < code.length
@@ -186,7 +193,7 @@ fun PinKeypad(
                 val pulse = if (loading) (1f - pulseDistance).coerceIn(0f, 1f) else 0f
                 Box(
                     Modifier
-                        .size(13.dp)
+                        .size(13.dp * contentScale)
                         .graphicsLayer {
                             scaleX = 1f + pulse * 0.28f
                             scaleY = 1f + pulse * 0.28f
@@ -200,7 +207,7 @@ fun PinKeypad(
                 )
             }
         }
-        Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(24.dp * contentScale))
 
         // Keys. Bottom row depends on the mode.
         val bottomRow = when {
@@ -214,23 +221,24 @@ fun PinKeypad(
             bottomRow,
         )
         rows.forEachIndexed { index, row ->
-            Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(20.dp * contentScale)) {
                 row.forEach { key ->
                     KeypadKey(
                         key = key,
                         accent = accent,
                         showLetters = showLetters,
+                        diameter = keyDiameter,
                         enabled = inputEnabled && (key != "ok" || code.isNotEmpty()),
                         onClick = { press(key) },
                     )
                 }
             }
-            if (index < rows.lastIndex) Spacer(Modifier.height(16.dp))
+            if (index < rows.lastIndex) Spacer(Modifier.height(16.dp * contentScale))
         }
 
         // Variable length spends its bottom row on ⌫ / ✓, so cancelling gets its own line.
         if (!fixed && onCancel != null) {
-            Spacer(Modifier.height(14.dp))
+            Spacer(Modifier.height(14.dp * contentScale))
             Text(
                 stringResource(R.string.keypad_cancel),
                 style = AppleTypography.bodyLarge,
@@ -243,9 +251,10 @@ fun PinKeypad(
                         enabled = inputEnabled,
                         onClick = onCancel,
                     )
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                    .padding(horizontal = 16.dp * contentScale, vertical = 8.dp * contentScale),
             )
         }
+    }
     }
 }
 
@@ -254,10 +263,11 @@ private fun KeypadKey(
     key: String,
     accent: Color,
     showLetters: Boolean,
+    diameter: Dp,
     enabled: Boolean,
     onClick: () -> Unit,
 ) {
-    val diameter = 74.dp
+    val contentScale = (diameter / 74.dp).coerceIn(0.65f, 1f)
 
     // "cancel" / empty slots stay the grid's size but carry no circle.
     if (key.isEmpty()) {
@@ -277,7 +287,7 @@ private fun KeypadKey(
                         indication = null,
                         onClick = onClick,
                     )
-                    .padding(8.dp),
+                    .padding(8.dp * contentScale),
             )
         }
         return
@@ -313,15 +323,18 @@ private fun KeypadKey(
         contentAlignment = Alignment.Center,
     ) {
         when (key) {
-            "back" -> Icon(Icons.Outlined.Backspace, null, tint = AppleColors.secondary, modifier = Modifier.size(26.dp))
-            "ok" -> Icon(Icons.Outlined.Check, null, tint = if (enabled) accent else AppleColors.tertiary, modifier = Modifier.size(28.dp))
+            "back" -> Icon(Icons.Outlined.Backspace, null, tint = AppleColors.secondary, modifier = Modifier.size(26.dp * contentScale))
+            "ok" -> Icon(Icons.Outlined.Check, null, tint = if (enabled) accent else AppleColors.tertiary, modifier = Modifier.size(28.dp * contentScale))
             else -> Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(key, style = AppleTypography.titleLarge.copy(fontSize = 30.sp, fontWeight = FontWeight.Normal), color = AppleColors.primary)
+                Text(key, style = AppleTypography.titleLarge.copy(fontSize = 30.sp * contentScale, fontWeight = FontWeight.Normal), color = AppleColors.primary)
                 val letters = KeypadLetters[key.firstOrNull()]
                 if (showLetters && letters != null) {
                     Text(
                         letters,
-                        style = AppleTypography.labelSmall.copy(fontSize = 9.sp, letterSpacing = 1.5.sp),
+                        style = AppleTypography.labelSmall.copy(
+                            fontSize = 9.sp * contentScale,
+                            letterSpacing = 1.5.sp * contentScale,
+                        ),
                         color = AppleColors.tertiary,
                     )
                 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalKeypad.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalKeypad.kt
@@ -3,6 +3,10 @@ package com.iblu01.portallauncher.ui.components.controls
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -35,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -48,6 +53,8 @@ import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 import com.iblu01.portallauncher.R
 import androidx.compose.ui.res.stringResource
+import kotlin.math.abs
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 /** iOS lock-screen letter groups shown under each digit. */
@@ -80,6 +87,7 @@ fun PinKeypad(
     error: Boolean = false,
     onErrorConsumed: () -> Unit = {},
     enabled: Boolean = true,
+    loading: Boolean = false,
     showLetters: Boolean = true,
     haptics: Boolean = true,
     onCancel: (() -> Unit)? = null,
@@ -89,6 +97,7 @@ fun PinKeypad(
     var code by remember { mutableStateOf("") }
     var errored by remember { mutableStateOf(false) }
     val shake = remember { Animatable(0f) }
+    val inputEnabled = enabled && !loading
 
     fun tick() { if (haptics) haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove) }
 
@@ -114,7 +123,7 @@ fun PinKeypad(
         }
     }
     val press: (String) -> Unit = press@{ key ->
-        if (!enabled) return@press
+        if (!inputEnabled) return@press
         when (key) {
             "back" -> if (code.isNotEmpty()) { tick(); code = code.dropLast(1) }
             "ok" -> submit()
@@ -156,15 +165,33 @@ fun PinKeypad(
         val filledColor by animateColorAsState(
             if (errored) AppleColors.error else dotColor, tween(120), label = "dotFill",
         )
+        val loadingTransition = rememberInfiniteTransition(label = "keypadLoading")
+        val loadingPhase by loadingTransition.animateFloat(
+            initialValue = 0f,
+            targetValue = dotCount.toFloat(),
+            animationSpec = infiniteRepeatable(
+                animation = tween(dotCount * 180, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart,
+            ),
+            label = "keypadLoadingPhase",
+        )
         Row(
             modifier = Modifier.offset { IntOffset(shake.value.roundToInt(), 0) },
             horizontalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             repeat(dotCount) { i ->
                 val on = i < code.length
+                val directDistance = abs(loadingPhase - i)
+                val pulseDistance = min(directDistance, dotCount - directDistance)
+                val pulse = if (loading) (1f - pulseDistance).coerceIn(0f, 1f) else 0f
                 Box(
                     Modifier
                         .size(13.dp)
+                        .graphicsLayer {
+                            scaleX = 1f + pulse * 0.28f
+                            scaleY = 1f + pulse * 0.28f
+                            alpha = if (loading) 0.55f + pulse * 0.45f else 1f
+                        }
                         .clip(CircleShape)
                         .then(
                             if (on) Modifier.background(filledColor, CircleShape)
@@ -193,7 +220,7 @@ fun PinKeypad(
                         key = key,
                         accent = accent,
                         showLetters = showLetters,
-                        enabled = enabled && (key != "ok" || code.isNotEmpty()),
+                        enabled = inputEnabled && (key != "ok" || code.isNotEmpty()),
                         onClick = { press(key) },
                     )
                 }
@@ -213,6 +240,7 @@ fun PinKeypad(
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
+                        enabled = inputEnabled,
                         onClick = onCancel,
                     )
                     .padding(horizontal = 16.dp, vertical = 8.dp),

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalThermostat.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalThermostat.kt
@@ -2,11 +2,12 @@ package com.iblu01.portallauncher.ui.components.controls
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,26 +22,33 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
+import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 import kotlin.math.atan2
+import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.math.sin
+import java.util.Locale
 
 /** Thermostat operating mode. [HEAT_COOL] is Apple's "Auto" — a low/high range with two handles. */
-enum class ThermostatMode { OFF, HEAT, COOL, HEAT_COOL }
+enum class ThermostatMode { OFF, HEAT, COOL, AUTO, HEAT_COOL }
+
+/** Optional backend-reported activity. Null lets the generic control infer it from temperatures. */
+enum class ThermostatActivity { OFF, IDLE, HEATING, COOLING }
 
 // The C-shaped track: a 270° sweep starting bottom-left, leaving a gap at the bottom.
 private const val ARC_START = 135f
@@ -60,6 +68,7 @@ private const val ARC_SWEEP = 270f
 @Composable
 fun ThermostatArc(
     mode: ThermostatMode,
+    activity: ThermostatActivity? = null,
     target: Float,
     onTargetChange: (Float) -> Unit,
     modifier: Modifier = Modifier,
@@ -70,16 +79,14 @@ fun ThermostatArc(
     step: Float = 1f,
     current: Float? = null,
     unit: String = "°",
-    heatColor: Color = Color(0xFFFF9F0A),
-    coolColor: Color = Color(0xFF0A84FF),
+    heatColor: Color = AppleColors.thermostatHeat,
+    coolColor: Color = AppleColors.thermostatCool,
     trackColor: Color = Color.White.copy(alpha = 0.13f),
     onCommit: () -> Unit = {},
 ) {
     val haptic = LocalHapticFeedback.current
-    val strokeDp = 26.dp
-    val handleDp = 18.dp
     val span = (valueRange.endInclusive - valueRange.start).coerceAtLeast(1e-3f)
-    val minGap = step.coerceAtLeast(1f)
+    val minGap = step.coerceAtLeast(0.1f)
 
     fun toFrac(v: Float) = ((v - valueRange.start) / span).coerceIn(0f, 1f)
     fun toValue(frac: Float): Float {
@@ -87,18 +94,25 @@ fun ThermostatArc(
         return (((raw - valueRange.start) / step).roundToInt() * step + valueRange.start)
             .coerceIn(valueRange.start, valueRange.endInclusive)
     }
+    fun displayValue(value: Float): String = if (abs(value - value.roundToInt()) < 0.01f) {
+        value.roundToInt().toString()
+    } else {
+        String.format(Locale.getDefault(), "%.1f", value)
+    }
 
     // Live status derived from the room temperature vs the setpoint(s).
-    val heating = current != null && when (mode) {
+    val inferredHeating = current != null && when (mode) {
         ThermostatMode.HEAT -> current < target
         ThermostatMode.HEAT_COOL -> current < lowTarget
         else -> false
     }
-    val cooling = current != null && when (mode) {
+    val inferredCooling = current != null && when (mode) {
         ThermostatMode.COOL -> current > target
         ThermostatMode.HEAT_COOL -> current > highTarget
         else -> false
     }
+    val heating = activity?.let { it == ThermostatActivity.HEATING } ?: inferredHeating
+    val cooling = activity?.let { it == ThermostatActivity.COOLING } ?: inferredCooling
     // Setpoint reached: the system is calling for nothing → dim the fill a touch.
     val settled = mode != ThermostatMode.OFF && current != null && !heating && !cooling
     val fillAlpha = if (settled) 0.4f else 1f
@@ -113,7 +127,10 @@ fun ThermostatArc(
     val onRange by rememberUpdatedState(onRangeChange)
     val onCommitState by rememberUpdatedState(onCommit)
 
-    Box(modifier) {
+    BoxWithConstraints(modifier) {
+        val contentScale = (minOf(maxWidth, maxHeight) / 300.dp).coerceIn(0.65f, 1.35f)
+        val strokeDp = 26.dp * contentScale
+        val handleDp = 18.dp * contentScale
         Canvas(
             Modifier
                 .fillMaxSize()
@@ -136,7 +153,7 @@ fun ThermostatArc(
                     fun apply(handle: Int, frac: Float) {
                         val v = toValue(frac)
                         when (mode) {
-                            ThermostatMode.HEAT, ThermostatMode.COOL -> onTarget(v)
+                            ThermostatMode.HEAT, ThermostatMode.COOL, ThermostatMode.AUTO -> onTarget(v)
                             ThermostatMode.HEAT_COOL ->
                                 if (handle == 0) onRange(min(v, highState - minGap), highState)
                                 else onRange(lowState, max(v, lowState + minGap))
@@ -164,7 +181,7 @@ fun ThermostatArc(
             val strokePx = strokeDp.toPx()
             val handlePx = handleDp.toPx()
             val center = Offset(size.width / 2f, size.height / 2f)
-            val radius = min(size.width, size.height) / 2f - max(handlePx, strokePx / 2f) - 2.dp.toPx()
+            val radius = min(size.width, size.height) / 2f - max(handlePx, strokePx / 2f) - (2.dp * contentScale).toPx()
             val arcTopLeft = Offset(center.x - radius, center.y - radius)
             val arcSize = Size(radius * 2f, radius * 2f)
 
@@ -192,6 +209,7 @@ fun ThermostatArc(
             when (mode) {
                 ThermostatMode.HEAT -> segment(0f, toFrac(target), heatColor.copy(alpha = fillAlpha), StrokeCap.Round)
                 ThermostatMode.COOL -> segment(toFrac(target), 1f, coolColor.copy(alpha = fillAlpha), StrokeCap.Round)
+                ThermostatMode.AUTO -> segment(0f, toFrac(target), AppleColors.active.copy(alpha = fillAlpha), StrokeCap.Round)
                 ThermostatMode.HEAT_COOL -> {
                     val fl = toFrac(lowTarget)
                     val fh = toFrac(highTarget)
@@ -207,16 +225,20 @@ fun ThermostatArc(
             }
 
             // Live-temperature marker.
-            current?.let { drawCircle(AppleColors.primary.copy(alpha = 0.85f), 4.dp.toPx(), pointAt(toFrac(it))) }
+            current?.let { drawCircle(AppleColors.primary.copy(alpha = 0.85f), (4.dp * contentScale).toPx(), pointAt(toFrac(it))) }
 
             // Handles.
             fun handle(frac: Float) {
                 val p = pointAt(frac)
-                drawCircle(Color.Black.copy(alpha = 0.22f), handlePx + 3.dp.toPx(), p + Offset(0f, 2.5.dp.toPx()))
+                drawCircle(
+                    Color.Black.copy(alpha = 0.22f),
+                    handlePx + (3.dp * contentScale).toPx(),
+                    p + Offset(0f, (2.5.dp * contentScale).toPx()),
+                )
                 drawCircle(Color.White, handlePx, p)
             }
             when (mode) {
-                ThermostatMode.HEAT, ThermostatMode.COOL -> handle(toFrac(target))
+                ThermostatMode.HEAT, ThermostatMode.COOL, ThermostatMode.AUTO -> handle(toFrac(target))
                 ThermostatMode.HEAT_COOL -> { handle(toFrac(lowTarget)); handle(toFrac(highTarget)) }
                 ThermostatMode.OFF -> Unit
             }
@@ -227,10 +249,10 @@ fun ThermostatArc(
         val statusColor: Color
         when {
             mode == ThermostatMode.OFF -> { statusText = null; statusColor = AppleColors.secondary }
-            heating -> { statusText = "Chauffage en cours"; statusColor = heatColor }
-            cooling -> { statusText = "Refroidissement en cours"; statusColor = coolColor }
-            settled -> { statusText = "Température atteinte"; statusColor = AppleColors.secondary }
-            mode == ThermostatMode.HEAT_COOL -> { statusText = "MAINTENIR ENTRE"; statusColor = AppleColors.tertiary }
+            heating -> { statusText = stringResource(R.string.thermostat_status_heating); statusColor = heatColor }
+            cooling -> { statusText = stringResource(R.string.thermostat_status_cooling); statusColor = coolColor }
+            settled -> { statusText = stringResource(R.string.thermostat_status_reached); statusColor = AppleColors.secondary }
+            mode == ThermostatMode.HEAT_COOL -> { statusText = stringResource(R.string.thermostat_status_hold_between); statusColor = AppleColors.tertiary }
             else -> { statusText = null; statusColor = AppleColors.tertiary }
         }
 
@@ -241,46 +263,60 @@ fun ThermostatArc(
             if (statusText != null) {
                 Text(
                     statusText,
-                    style = AppleTypography.labelSmall.copy(letterSpacing = 1.2.sp),
+                    modifier = Modifier.fillMaxWidth(0.58f),
+                    style = AppleTypography.labelSmall.copy(
+                        fontSize = 10.sp * contentScale,
+                    ),
                     color = statusColor,
+                    maxLines = 1,
+                    textAlign = TextAlign.Center,
                 )
-                Spacer(Modifier.height(6.dp))
+                Spacer(Modifier.height(10.dp * contentScale))
             }
             when (mode) {
                 ThermostatMode.OFF -> Text(
-                    "Éteint",
-                    style = AppleTypography.headlineLarge,
+                    stringResource(R.string.hvac_mode_off),
+                    style = AppleTypography.headlineLarge.copy(
+                        fontSize = AppleTypography.headlineLarge.fontSize * contentScale,
+                    ),
                     color = AppleColors.secondary,
                 )
                 ThermostatMode.HEAT_COOL -> Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        "${lowTarget.roundToInt()}",
-                        style = AppleTypography.displayLarge.copy(fontSize = 60.sp, fontWeight = FontWeight.Medium),
+                        displayValue(lowTarget),
+                        style = AppleTypography.displayLarge.copy(fontSize = 52.sp * contentScale, fontWeight = FontWeight.Medium),
                         color = AppleColors.primary,
                     )
                     Text(
                         "  –  ",
-                        style = AppleTypography.displayLarge.copy(fontSize = 44.sp),
+                        style = AppleTypography.displayLarge.copy(fontSize = 44.sp * contentScale),
                         color = AppleColors.tertiary,
                     )
                     Text(
-                        "${highTarget.roundToInt()}",
-                        style = AppleTypography.displayLarge.copy(fontSize = 60.sp, fontWeight = FontWeight.Medium),
+                        displayValue(highTarget),
+                        style = AppleTypography.displayLarge.copy(fontSize = 52.sp * contentScale, fontWeight = FontWeight.Medium),
                         color = AppleColors.primary,
                     )
                 }
                 else -> Text(
-                    "${target.roundToInt()}$unit",
-                    style = AppleTypography.displayLarge.copy(fontSize = 76.sp, fontWeight = FontWeight.Medium),
+                    "${displayValue(target)}$unit",
+                    // Keep a consistent optical gutter between wide decimal values and the dial.
+                    // Integer setpoints can stay slightly larger without approaching the arc.
+                    style = AppleTypography.displayLarge.copy(
+                        fontSize = (if (abs(target - target.roundToInt()) < 0.01f) 70.sp else 62.sp) * contentScale,
+                        fontWeight = FontWeight.Medium,
+                    ),
                     color = AppleColors.primary,
                 )
             }
             // Room temperature, when known.
             if (current != null && mode != ThermostatMode.OFF) {
-                Spacer(Modifier.height(10.dp))
+                Spacer(Modifier.height(10.dp * contentScale))
                 Text(
-                    "Pièce · ${current.roundToInt()}$unit",
-                    style = AppleTypography.bodyLarge,
+                    stringResource(R.string.thermostat_room_temperature_format, displayValue(current), unit),
+                    style = AppleTypography.bodyLarge.copy(
+                        fontSize = AppleTypography.bodyLarge.fontSize * contentScale,
+                    ),
                     color = AppleColors.secondary,
                 )
             }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalThreeWayControl.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalThreeWayControl.kt
@@ -1,0 +1,146 @@
+package com.iblu01.portallauncher.ui.components.controls
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.iblu01.portallauncher.ui.theme.AppleColors
+import com.iblu01.portallauncher.ui.theme.AppleShapes
+import com.iblu01.portallauncher.ui.theme.AppleTypography
+
+/** Visual density for [PortalThreeWayControl]. */
+enum class ThreeWayControlSize { Compact, Regular }
+
+/**
+ * Shared three-action capsule used by media playback and directional devices such as covers.
+ *
+ * This component owns presentation only: callers provide icons, accessible descriptions and
+ * callbacks. Optional side labels create the cover variation without coupling it to a domain.
+ */
+@Composable
+fun PortalThreeWayControl(
+    leadingIcon: ImageVector,
+    leadingContentDescription: String,
+    onLeadingClick: () -> Unit,
+    centerIcon: ImageVector,
+    centerContentDescription: String,
+    onCenterClick: () -> Unit,
+    trailingIcon: ImageVector,
+    trailingContentDescription: String,
+    onTrailingClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    leadingLabel: String? = null,
+    trailingLabel: String? = null,
+    size: ThreeWayControlSize = ThreeWayControlSize.Regular,
+) {
+    val metrics = when (size) {
+        ThreeWayControlSize.Compact -> ThreeWayMetrics(
+            sideButton = 40.dp, centerButton = 50.dp, sideIcon = 22.dp,
+            centerIcon = 28.dp, horizontalPadding = 10.dp, verticalPadding = 6.dp, gap = 14.dp,
+        )
+        ThreeWayControlSize.Regular -> ThreeWayMetrics(
+            sideButton = 46.dp, centerButton = 58.dp, sideIcon = 26.dp,
+            centerIcon = 32.dp, horizontalPadding = 14.dp, verticalPadding = 8.dp, gap = 18.dp,
+        )
+    }
+
+    Row(
+        modifier = modifier
+            .clip(AppleShapes.pill)
+            .background(AppleColors.frostedFill, AppleShapes.pill)
+            .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.pill)
+            .padding(horizontal = metrics.horizontalPadding, vertical = metrics.verticalPadding),
+        horizontalArrangement = Arrangement.spacedBy(metrics.gap),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SideAction(
+            icon = leadingIcon,
+            contentDescription = leadingContentDescription,
+            label = leadingLabel,
+            onClick = onLeadingClick,
+            buttonSize = metrics.sideButton,
+            iconSize = metrics.sideIcon,
+        )
+        IconButton(
+            onClick = onCenterClick,
+            modifier = Modifier
+                .size(metrics.centerButton)
+                .background(Color.White, CircleShape),
+        ) {
+            Icon(
+                centerIcon,
+                contentDescription = centerContentDescription,
+                tint = Color.Black,
+                modifier = Modifier.size(metrics.centerIcon),
+            )
+        }
+        SideAction(
+            icon = trailingIcon,
+            contentDescription = trailingContentDescription,
+            label = trailingLabel,
+            onClick = onTrailingClick,
+            buttonSize = metrics.sideButton,
+            iconSize = metrics.sideIcon,
+        )
+    }
+}
+
+@Composable
+private fun SideAction(
+    icon: ImageVector,
+    contentDescription: String,
+    label: String?,
+    onClick: () -> Unit,
+    buttonSize: Dp,
+    iconSize: Dp,
+) {
+    IconButton(onClick = onClick, modifier = Modifier.size(buttonSize)) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy((-2).dp),
+        ) {
+            Icon(
+                icon,
+                contentDescription = contentDescription,
+                tint = AppleColors.primary,
+                modifier = Modifier.size(iconSize),
+            )
+            if (label != null) {
+                Text(
+                    text = label,
+                    color = AppleColors.primary,
+                    style = AppleTypography.bodySmall.copy(fontSize = 9.sp),
+                    maxLines = 1,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+private data class ThreeWayMetrics(
+    val sideButton: Dp,
+    val centerButton: Dp,
+    val sideIcon: Dp,
+    val centerIcon: Dp,
+    val horizontalPadding: Dp,
+    val verticalPadding: Dp,
+    val gap: Dp,
+)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalVacuum.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalVacuum.kt
@@ -41,6 +41,15 @@ import androidx.compose.ui.res.stringResource
 /** A room the robot knows about. [icon] is optional. */
 data class VacuumRoom(val id: String, val name: String, val icon: ImageVector? = null)
 
+/** Secondary vacuum command rendered by [VacuumActionChips]. */
+data class VacuumAction(
+    val id: String,
+    val label: String,
+    val icon: ImageVector,
+    val active: Boolean = false,
+    val onClick: () -> Unit,
+)
+
 /** Cleaning mode, à la Roborock / iOS Home. */
 enum class VacuumMode { VACUUM, VACUUM_AND_MOP, VACUUM_THEN_MOP, MOP }
 
@@ -108,6 +117,44 @@ fun VacuumStatusChip(
             style = AppleTypography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
             color = if (prominent) AppleColors.primary else AppleColors.secondary,
         )
+    }
+}
+
+/** Reusable secondary command strip for stop, dock, locate and integration-specific actions. */
+@Composable
+fun VacuumActionChips(
+    actions: List<VacuumAction>,
+    modifier: Modifier = Modifier,
+    accent: Color = AppleColors.accent,
+) {
+    Row(
+        modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        actions.forEach { action ->
+            val background = if (action.active) accent else AppleColors.frostedFill
+            val content = if (action.active) contentColorOn(accent) else AppleColors.secondary
+            Row(
+                Modifier
+                    .clip(AppleShapes.pill)
+                    .background(background, AppleShapes.pill)
+                    .border(0.5.dp, if (action.active) accent else AppleColors.frostedBorder, AppleShapes.pill)
+                    .appleClickable(action.onClick)
+                    .padding(horizontal = 14.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(7.dp),
+            ) {
+                Icon(action.icon, null, tint = content, modifier = Modifier.size(18.dp))
+                Text(
+                    action.label,
+                    style = AppleTypography.bodyLarge.copy(
+                        fontWeight = if (action.active) FontWeight.SemiBold else FontWeight.Normal,
+                    ),
+                    color = content,
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalWheelPicker.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalWheelPicker.kt
@@ -53,6 +53,7 @@ fun <T> WheelPicker(
     itemHeight: Dp = 40.dp,
     accent: Color = AppleColors.primary,
 ) {
+    val contentScale = (itemHeight / 40.dp).coerceIn(0.7f, 1.5f)
     val rows = (visibleCount.coerceIn(3, 9)).let { if (it % 2 == 0) it + 1 else it }
     val edge = rows / 2
     val initialIndex = options.indexOf(selected).coerceAtLeast(0)
@@ -68,8 +69,10 @@ fun <T> WheelPicker(
             info.visibleItemsInfo.minByOrNull { abs((it.offset + it.size / 2f) - mid) }?.index ?: initialIndex
         }
     }
-    LaunchedEffect(centeredIndex) {
-        options.getOrNull(centeredIndex)?.let(onSelect)
+    LaunchedEffect(centeredIndex, state.isScrollInProgress) {
+        // Commit only once the wheel settles; scrolling across several rows must not emit one
+        // backend action per transiently centered option.
+        if (!state.isScrollInProgress) options.getOrNull(centeredIndex)?.let(onSelect)
     }
 
     LazyColumn(
@@ -101,7 +104,7 @@ fun <T> WheelPicker(
                         scaleX = s; scaleY = s
                         cameraDistance = 12f * density
                     }
-                    .clip(RoundedCornerShape(12.dp))
+                    .clip(RoundedCornerShape(percent = 30))
                     .then(if (isCentered) Modifier.background(Color.White.copy(alpha = 0.08f)) else Modifier)
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
@@ -112,6 +115,7 @@ fun <T> WheelPicker(
                 Text(
                     label(option),
                     style = AppleTypography.titleLarge.copy(
+                        fontSize = AppleTypography.titleLarge.fontSize * contentScale,
                         fontWeight = if (isCentered) FontWeight.SemiBold else FontWeight.Normal,
                     ),
                     color = textColor,

--- a/app/src/main/java/com/iblu01/portallauncher/ui/panel/PanelState.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/panel/PanelState.kt
@@ -19,17 +19,25 @@ sealed interface PanelRequest {
     }
 }
 
-/** Who opened the panel — an AUTO (media) open must never clobber a USER intent. */
-enum class PanelSource { USER, AUTO }
+/**
+ * Who opened the panel. Precedence is AUTO < USER < ALERT: an AUTO (media) open must never clobber
+ * a USER intent, and an ALERT (alarm entry delay / triggered) outranks both — the disarm keypad has
+ * to be on screen before the siren fires, whatever the user was doing.
+ */
+enum class PanelSource { USER, AUTO, ALERT }
 
 /**
  * @param dismissedAutoKey the media key the user dismissed; auto-open is suppressed for it until
  *   the session stops ([PanelEvent.MediaStopped] rearms). Mirrors the old `mediaPlayerDismissed`.
+ * @param dismissedAlertKey the alarm key the user dismissed; the alert panel stays closed for it
+ *   until the alarm leaves its alerting state ([PanelEvent.AlarmCleared] rearms). Without this a
+ *   dismiss would be undone on the next state push.
  */
 data class PanelState(
     val request: PanelRequest? = null,
     val source: PanelSource = PanelSource.USER,
     val dismissedAutoKey: String? = null,
+    val dismissedAlertKey: String? = null,
 )
 
 /**
@@ -43,6 +51,12 @@ sealed interface PanelEvent {
     data object WeatherTap : PanelEvent
     data class MediaAutoOpen(val key: String) : PanelEvent
     data object MediaStopped : PanelEvent
+
+    /** The alarm entered `pending` (entry delay) or `triggered`: force its keypad panel up. */
+    data class AlarmAlert(val request: PanelRequest.Chip) : PanelEvent
+
+    /** The alarm left its alerting states (disarmed, or armed again): drop the forced panel. */
+    data object AlarmCleared : PanelEvent
     data object Dismiss : PanelEvent
 }
 
@@ -73,14 +87,31 @@ fun reduce(state: PanelState, event: PanelEvent): PanelState = when (event) {
     }
 
     // Session ended: close if we were showing media, and rearm auto-open (clear the dismiss guard).
+    // The alert guard is carried over — it belongs to the alarm episode, not to the media session.
     PanelEvent.MediaStopped ->
-        if (state.request is PanelRequest.Media) PanelState()
+        if (state.request is PanelRequest.Media) PanelState(dismissedAlertKey = state.dismissedAlertKey)
         else state.copy(dismissedAutoKey = null)
 
-    // Dismiss: remember a dismissed media key so it won't auto-reopen while it keeps playing.
+    // Alarm alerting: opens over anything, including a USER panel — this is the one case where the
+    // user's current panel is overridden, because the entry delay is running out. Only an explicit
+    // dismissal of this very alarm holds it back.
+    is PanelEvent.AlarmAlert ->
+        if (event.request.key == state.dismissedAlertKey) state
+        else state.copy(request = event.request, source = PanelSource.ALERT)
+
+    // Alarm back to a calm state: close the forced panel and rearm the alert for the next episode.
+    PanelEvent.AlarmCleared ->
+        if (state.source == PanelSource.ALERT) PanelState(dismissedAutoKey = state.dismissedAutoKey)
+        else state.copy(dismissedAlertKey = null)
+
+    // Dismiss: remember a dismissed media/alert key so it won't reopen while the cause persists.
     PanelEvent.Dismiss -> {
         val req = state.request
-        if (req is PanelRequest.Media) state.copy(request = null, dismissedAutoKey = req.key)
-        else state.copy(request = null)
+        when {
+            req is PanelRequest.Media -> state.copy(request = null, dismissedAutoKey = req.key)
+            req != null && state.source == PanelSource.ALERT ->
+                state.copy(request = null, source = PanelSource.USER, dismissedAlertKey = req.key)
+            else -> state.copy(request = null)
+        }
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/PlaygroundScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/PlaygroundScreen.kt
@@ -22,13 +22,19 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.DirectionsRun
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.PowerSettingsNew
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.WbSunny
 import androidx.compose.material.icons.outlined.Bathtub
 import androidx.compose.material.icons.outlined.Bed
 import androidx.compose.material.icons.outlined.Blinds
 import androidx.compose.material.icons.outlined.Kitchen
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.Lightbulb
 import androidx.compose.material.icons.outlined.Power
 import androidx.compose.material.icons.outlined.Weekend
@@ -55,6 +61,7 @@ import com.iblu01.portallauncher.ui.components.controls.AccessoryItem
 import com.iblu01.portallauncher.ui.components.controls.ControlContentLayout
 import com.iblu01.portallauncher.ui.components.controls.FillOrigin
 import com.iblu01.portallauncher.ui.components.controls.PinKeypad
+import com.iblu01.portallauncher.ui.components.controls.PortalThreeWayControl
 import com.iblu01.portallauncher.ui.components.controls.ThermostatArc
 import com.iblu01.portallauncher.ui.components.controls.ThermostatMode
 import com.iblu01.portallauncher.ui.components.controls.VacuumMode
@@ -178,6 +185,45 @@ fun PlaygroundScreen(onBack: () -> Unit) {
                     value = disabled, onValueChange = { disabled = it },
                     accent = accent, enabled = false,
                     modifier = Modifier.controlSize(),
+                )
+            }
+        }
+
+        Spacer(Modifier.height(28.dp))
+
+        // Three-way controls — the same shell, specialised by content for each domain.
+        SectionTitle(stringResource(R.string.playground_section_three_way_control))
+        var mediaPlaying by remember { mutableStateOf(true) }
+        Row(
+            Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            LabeledControl(stringResource(R.string.playground_three_way_media)) {
+                PortalThreeWayControl(
+                    leadingIcon = Icons.Filled.SkipPrevious,
+                    leadingContentDescription = stringResource(R.string.media_previous_track_desc),
+                    onLeadingClick = {},
+                    centerIcon = if (mediaPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                    centerContentDescription = if (mediaPlaying) stringResource(R.string.media_pause_desc) else stringResource(R.string.media_play_desc),
+                    onCenterClick = { mediaPlaying = !mediaPlaying },
+                    trailingIcon = Icons.Filled.SkipNext,
+                    trailingContentDescription = stringResource(R.string.media_next_track_desc),
+                    onTrailingClick = {},
+                )
+            }
+            LabeledControl(stringResource(R.string.playground_three_way_cover)) {
+                PortalThreeWayControl(
+                    leadingIcon = Icons.Outlined.KeyboardArrowDown,
+                    leadingContentDescription = stringResource(R.string.cover_button_close),
+                    leadingLabel = stringResource(R.string.cover_button_close),
+                    onLeadingClick = {},
+                    centerIcon = Icons.Filled.Pause,
+                    centerContentDescription = stringResource(R.string.cover_button_stop),
+                    onCenterClick = {},
+                    trailingIcon = Icons.Outlined.KeyboardArrowUp,
+                    trailingContentDescription = stringResource(R.string.cover_button_open),
+                    trailingLabel = stringResource(R.string.cover_button_open),
+                    onTrailingClick = {},
                 )
             }
         }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/PlaygroundScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/PlaygroundScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -17,6 +18,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Block
@@ -41,6 +44,7 @@ import androidx.compose.material.icons.outlined.Weekend
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -55,11 +59,26 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.iblu01.portallauncher.R
+import com.iblu01.portallauncher.HaEntity
+import com.iblu01.portallauncher.LauncherChip
+import com.iblu01.portallauncher.PillKind
+import com.iblu01.portallauncher.domain.model.PillDetail
+import com.iblu01.portallauncher.domain.model.MediaPlayerVolume
+import com.iblu01.portallauncher.domain.model.PlayingMedia
+import com.iblu01.portallauncher.ui.CallService
+import com.iblu01.portallauncher.ui.LocalAreas
+import com.iblu01.portallauncher.ui.LocalCallService
+import com.iblu01.portallauncher.ui.LocalHaStates
+import com.iblu01.portallauncher.ui.components.ChipActionsPanel
+import com.iblu01.portallauncher.ui.components.MediaPlayerView
+import com.iblu01.portallauncher.ui.components.StatusChip
+import com.iblu01.portallauncher.ui.components.launcherIcon
 import com.iblu01.portallauncher.ui.components.appleClickable
 import com.iblu01.portallauncher.ui.components.controls.AccessoryGrid
 import com.iblu01.portallauncher.ui.components.controls.AccessoryItem
 import com.iblu01.portallauncher.ui.components.controls.ControlContentLayout
 import com.iblu01.portallauncher.ui.components.controls.FillOrigin
+import com.iblu01.portallauncher.ui.components.controls.HorizontalSegmentedSelector
 import com.iblu01.portallauncher.ui.components.controls.PinKeypad
 import com.iblu01.portallauncher.ui.components.controls.PortalThreeWayControl
 import com.iblu01.portallauncher.ui.components.controls.ThermostatArc
@@ -77,10 +96,17 @@ import com.iblu01.portallauncher.ui.components.controls.VerticalSegmentedSelecto
 import com.iblu01.portallauncher.ui.components.controls.VerticalSwitch
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
+import org.json.JSONObject
 
 /** Named accents so adaptivity is obvious at a glance. */
 
 private enum class Presence { HOME, AWAY, OFF }
+
+private sealed interface FakePanelSelection {
+    val id: String
+    data class Chip(val chip: LauncherChip) : FakePanelSelection { override val id = chip.id }
+    data class Media(val media: PlayingMedia) : FakePanelSelection { override val id = "media_group" }
+}
 
 /**
  * Dev-only gallery: every reusable control from
@@ -99,11 +125,18 @@ fun PlaygroundScreen(onBack: () -> Unit) {
         stringResource(R.string.playground_swatch_gray) to Color(0xFFD8D8DA),
     )
     var accent by remember { mutableStateOf(accentSwatches.first().second) }
+    var selectedFakePanel by remember { mutableStateOf<FakePanelSelection?>(null) }
+    val contentWidth by animateFloatAsState(
+        targetValue = if (selectedFakePanel == null) 1f else 0.67f,
+        animationSpec = tween(500),
+        label = "playgroundPanelWidth",
+    )
 
+    Box(Modifier.fillMaxSize().background(AppleColors.background)) {
     Column(
         Modifier
-            .fillMaxSize()
-            .background(AppleColors.background)
+            .fillMaxHeight()
+            .fillMaxWidth(contentWidth)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 20.dp, vertical = 16.dp),
     ) {
@@ -156,6 +189,13 @@ fun PlaygroundScreen(onBack: () -> Unit) {
                 }
             }
         }
+
+        Spacer(Modifier.height(28.dp))
+
+        FakePanelLab(
+            selected = selectedFakePanel,
+            onSelect = { next -> selectedFakePanel = next.takeUnless { it.id == selectedFakePanel?.id } },
+        )
 
         Spacer(Modifier.height(28.dp))
 
@@ -304,6 +344,35 @@ fun PlaygroundScreen(onBack: () -> Unit) {
                 )
             }
         }
+        Spacer(Modifier.height(16.dp))
+        var horizontalSelection by remember { mutableStateOf(Presence.HOME) }
+        val horizontalHomeLabel = stringResource(R.string.playground_presence_home)
+        val horizontalAwayLabel = stringResource(R.string.playground_presence_away)
+        val horizontalOffLabel = stringResource(R.string.playground_presence_off)
+        LabeledControl(stringResource(R.string.playground_selector_horizontal)) {
+            HorizontalSegmentedSelector(
+                options = Presence.entries.toList(),
+                selected = horizontalSelection,
+                onSelect = { horizontalSelection = it },
+                label = {
+                    when (it) {
+                        Presence.HOME -> horizontalHomeLabel
+                        Presence.AWAY -> horizontalAwayLabel
+                        Presence.OFF -> horizontalOffLabel
+                    }
+                },
+                icon = {
+                    when (it) {
+                        Presence.HOME -> Icons.Filled.Home
+                        Presence.AWAY -> Icons.Filled.DirectionsRun
+                        Presence.OFF -> Icons.Filled.Block
+                    }
+                },
+                accent = accent,
+                isNeutral = { it == Presence.OFF },
+                modifier = Modifier.width(280.dp),
+            )
+        }
 
         Spacer(Modifier.height(28.dp))
 
@@ -392,7 +461,7 @@ fun PlaygroundScreen(onBack: () -> Unit) {
             label = {
                 when (it) {
                     ThermostatMode.OFF -> thermoOffLabel; ThermostatMode.COOL -> thermoCoolLabel
-                    ThermostatMode.HEAT -> thermoHeatLabel; ThermostatMode.HEAT_COOL -> thermoAutoLabel
+                    ThermostatMode.HEAT -> thermoHeatLabel; ThermostatMode.AUTO, ThermostatMode.HEAT_COOL -> thermoAutoLabel
                 }
             },
             accent = accent,
@@ -504,7 +573,127 @@ fun PlaygroundScreen(onBack: () -> Unit) {
 
         Spacer(Modifier.height(40.dp))
     }
+
+        selectedFakePanel?.let { selection ->
+            val entities = rememberFakePanelEntities()
+            val noOpService = remember {
+                object : CallService {
+                    override fun invoke(domain: String, service: String, entityId: String?, data: Map<String, Any>?) = Unit
+                }
+            }
+            CompositionLocalProvider(
+                LocalCallService provides noOpService,
+                LocalHaStates provides entities,
+                LocalAreas provides emptyMap(),
+            ) {
+                when (selection) {
+                    is FakePanelSelection.Chip -> ChipActionsPanel(
+                        chip = selection.chip,
+                        onDismiss = { selectedFakePanel = null },
+                        modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight().fillMaxWidth(0.33f),
+                    )
+                    is FakePanelSelection.Media -> MediaPlayerView(
+                        media = selection.media,
+                        secondaryMedia = emptyList(),
+                        haToken = "",
+                        onPlayPause = {}, onPrevious = {}, onNext = {},
+                        onVolumeChange = { _, _ -> },
+                        onSecondaryPlayPause = {}, onSecondaryPrevious = {}, onSecondaryNext = {},
+                        onSelectSecondary = {}, onSwipePlayer = {}, onJoinPlayer = {}, onUnjoinPlayer = {},
+                        onDismiss = { selectedFakePanel = null },
+                        modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight().fillMaxWidth(0.33f),
+                    )
+                }
+            }
+        }
+    }
 }
+
+/** Real side-panel routing fed by local fake HA entities, for interaction testing offline. */
+@Composable
+private fun FakePanelLab(selected: FakePanelSelection?, onSelect: (FakePanelSelection) -> Unit) {
+    val chips = remember {
+        listOf(
+            LauncherChip("lights_group", "light", "Lumières", "3 allumées", "active", details = listOf(
+                PillDetail("Salon", "72 %", "light.salon", true),
+                PillDetail("Cuisine", "Éteinte", "light.cuisine", false),
+            ), kind = PillKind.LIGHTS),
+            LauncherChip("purifier_group", "air", "Purificateur", "Auto · air bon", "active", entityId = "fan.purificateur", kind = PillKind.PURIFIER,
+                details = listOf(PillDetail("Filtre", "82 %"))),
+            LauncherChip("scenes_group", "scene", "Scènes", "4 ambiances", "ok", kind = PillKind.SCENE, details = listOf(
+                PillDetail("Soirée", "", "scene.soiree"), PillDetail("Lecture", "", "scene.lecture"),
+                PillDetail("Cinéma", "", "scene.cinema"), PillDetail("Tout éteindre", "", "script.tout_eteindre"),
+            )),
+            LauncherChip("lock_test", "lock", "Porte d’entrée", "Verrouillée", "ok", entityId = "lock.entree", kind = PillKind.LOCK),
+            LauncherChip("cover_test", "cover", "Volet salon", "64 %", "active", entityId = "cover.salon", kind = PillKind.COVER),
+            LauncherChip("thermostat_test", "temperature", "Thermostat", "21,5 °C", "active", entityId = "climate.salon", kind = PillKind.THERMOSTAT),
+            LauncherChip("vacuum_test", "vacuum", "Aspirateur", "Nettoyage", "active", entityId = "vacuum.romy", kind = PillKind.VACUUM, batteryPercent = 78),
+            LauncherChip("fan_test", "fan", "Ventilateur %", "40 %", "active", entityId = "fan.chambre", kind = PillKind.FAN),
+            LauncherChip("fan_on_off_test", "fan", "Ventilateur simple", "Allumé", "active", entityId = "fan.bureau", kind = PillKind.FAN),
+            LauncherChip("fan_modes_test", "fan", "Ventilateur 3 vitesses", "Niveau 2", "active", entityId = "fan.plafond", kind = PillKind.FAN),
+            LauncherChip("switch_test", "switch", "Prise TV", "Allumée", "active", entityId = "switch.tv", kind = PillKind.SWITCH),
+            LauncherChip("alarm_test", "shield", "Alarme", "Désarmée", "info", entityId = "alarm_control_panel.maison", kind = PillKind.SAFETY),
+            LauncherChip("washer_test", "washer", "Machine à laver", "Rinçage", "active", entityId = "sensor.lave_linge_state", kind = PillKind.APPLIANCE,
+                progress = 0.62f, details = listOf(PillDetail("Cycle", "Coton"), PillDetail("Fin estimée", "14:35"), PillDetail("Essorage", "1 200 tr/min"))),
+            LauncherChip("air_group", "air", "Qualité de l’air", "Bonne · 620 ppm", "active", details = listOf(
+                PillDetail("CO₂", "620 ppm"), PillDetail("Humidité", "46 %"), PillDetail("PM2.5", "4 µg/m³"),
+            ), kind = PillKind.AIR),
+            LauncherChip("generic_test", "sensor", "Capteur balcon", "18,2 °C", "info", kind = PillKind.GENERIC,
+                details = listOf(PillDetail("Température", "18,2 °C"), PillDetail("Humidité", "61 %"))),
+            LauncherChip("media_group", "media", "Musique", "Midnight City", "active", entityId = "media_player.salon", kind = PillKind.MEDIA),
+        )
+    }
+    val fakeMedia = remember {
+        PlayingMedia(
+            entityId = "media_player.salon", title = "Midnight City", artist = "M83",
+            album = "Hurry Up, We're Dreaming", state = "playing", coverUrl = null,
+            volumePercent = 38, isMuted = false, playerNames = listOf("Salon"),
+            players = listOf(MediaPlayerVolume("media_player.salon", "Salon", 38, false)),
+        )
+    }
+    SectionTitle(stringResource(R.string.playground_section_fake_panels))
+    Text(stringResource(R.string.playground_fake_panels_hint), style = AppleTypography.bodySmall, color = AppleColors.secondary)
+    Spacer(Modifier.height(14.dp))
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        chips.chunked(3).forEach { row ->
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally)) {
+                row.forEach { chip ->
+                    StatusChip(
+                        chip = chip,
+                        selected = selected?.id == chip.id,
+                        onClick = {
+                            onSelect(if (chip.id == "media_group") FakePanelSelection.Media(fakeMedia) else FakePanelSelection.Chip(chip))
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberFakePanelEntities(): Map<String, HaEntity> = remember {
+    listOf(
+        fakeEntity("light.salon", "on", "Salon", "{\"brightness\":184,\"color_temp_kelvin\":3800,\"supported_color_modes\":[\"color_temp\"]}"),
+        fakeEntity("light.cuisine", "off", "Cuisine", "{\"brightness\":0}"),
+        fakeEntity("fan.purificateur", "on", "Purificateur", "{\"preset_mode\":\"auto\",\"preset_modes\":[\"auto\",\"sleep\",\"manual\",\"pet\"]}"),
+        fakeEntity("person.alex", "home", "Alex", "{}"),
+        fakeEntity("sensor.house_power", "846", "Puissance maison", "{\"unit_of_measurement\":\"W\"}"),
+        fakeEntity("lock.entree", "locked", "Porte d’entrée", "{}"),
+        fakeEntity("cover.salon", "open", "Volet salon", "{\"current_position\":64,\"supported_features\":15}"),
+        fakeEntity("climate.salon", "heat", "Thermostat", "{\"current_temperature\":20.8,\"temperature\":21.5,\"min_temp\":7,\"max_temp\":35,\"hvac_modes\":[\"off\",\"heat\",\"cool\",\"heat_cool\"]}"),
+        fakeEntity("vacuum.romy", "cleaning", "Romy", "{\"battery_level\":78,\"fan_speed\":\"standard\",\"fan_speed_list\":[\"silent\",\"standard\",\"turbo\"]}"),
+        fakeEntity("fan.chambre", "on", "Ventilateur", "{\"percentage\":40,\"percentage_step\":10,\"supported_features\":1}"),
+        fakeEntity("fan.bureau", "on", "Ventilateur bureau", "{}"),
+        fakeEntity("fan.plafond", "on", "Ventilateur plafond", "{\"preset_mode\":\"2\",\"preset_modes\":[\"1\",\"2\",\"3\"],\"supported_features\":8}"),
+        fakeEntity("switch.tv", "on", "Prise TV", "{}"),
+        fakeEntity("alarm_control_panel.maison", "disarmed", "Alarme maison", "{\"code_format\":\"number\",\"code_arm_required\":false,\"supported_features\":15}"),
+        fakeEntity("sensor.lave_linge_state", "rinse", "Machine à laver", "{}"),
+    ).associateBy { it.entityId }
+}
+
+private fun fakeEntity(id: String, state: String, name: String, attributes: String): HaEntity =
+    HaEntity(id, state, JSONObject(attributes).put("friendly_name", name))
 
 @Composable
 private fun SectionTitle(text: String) {

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.outlined.Build
 import androidx.compose.material.icons.outlined.Dashboard
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Wallpaper
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.AlertDialog
@@ -149,13 +150,14 @@ interface SettingsCallbacks {
     fun onConnectionEdited()
     fun onGrantPermissions()
     fun onSetBackgroundMode(mode: String)
+    fun onOpenSystemWallpaperPicker()
     fun onOpenOpacityPreview()
     fun onOpenClockTheme()
     fun onLoadPillEntities()
     fun onSetPillEnabled(candidates: List<PillCandidate>, enabled: Boolean)
 }
 
-private enum class SettingsPage { MAIN, HOME, PILLS, APPLICATION, DEVELOPER, INFORMATION }
+private enum class SettingsPage { MAIN, HOME, PILLS, WALLPAPER, APPLICATION, DEVELOPER, INFORMATION }
 private enum class UpdateState { IDLE, CHECKING, UP_TO_DATE, DOWNLOADING, ERROR }
 
 /** Best-effort host extraction used to pre-fill the MQTT broker from the HA address. */
@@ -368,6 +370,16 @@ fun SettingsScreen(
                 onBack = { currentPage = SettingsPage.MAIN },
                 showBack = showBack,
             )
+            SettingsPage.WALLPAPER -> WallpaperPage(
+                prefs = prefs,
+                bgMode = bgMode,
+                onBgModeChange = { bgMode = it; callbacks.onSetBackgroundMode(it) },
+                bgOverlayOpacity = bgOverlayOpacity,
+                onOpenOpacityPreview = callbacks::onOpenOpacityPreview,
+                onOpenSystemWallpaperPicker = callbacks::onOpenSystemWallpaperPicker,
+                onBack = { currentPage = SettingsPage.MAIN },
+                showBack = showBack,
+            )
             SettingsPage.PILLS -> PillsSettingsPage(
                 uiState = uiState,
                 onRefresh = callbacks::onLoadPillEntities,
@@ -404,6 +416,7 @@ fun SettingsScreen(
                     val sidebarItems = listOf(
                         Triple(SettingsPage.HOME, Icons.Outlined.Home, stringResource(R.string.settings_tile_home_title)),
                         Triple(SettingsPage.PILLS, Icons.Outlined.Dashboard, stringResource(R.string.settings_tile_pills_title)),
+                        Triple(SettingsPage.WALLPAPER, Icons.Outlined.Wallpaper, stringResource(R.string.settings_tile_wallpaper_title)),
                         Triple(SettingsPage.APPLICATION, Icons.Outlined.Settings, stringResource(R.string.settings_tile_app_title)),
                         Triple(SettingsPage.DEVELOPER, Icons.Outlined.Build, stringResource(R.string.settings_tile_dev_title)),
                         Triple(SettingsPage.INFORMATION, Icons.Outlined.Info, stringResource(R.string.settings_tile_info_title)),
@@ -457,6 +470,7 @@ private fun MainPage(homeSubtitle: String, onNavigate: (SettingsPage) -> Unit) {
     val tiles = listOf(
         TileDef(SettingsPage.HOME, Icons.Outlined.Home, stringResource(R.string.settings_tile_home_title), homeSubtitle),
         TileDef(SettingsPage.PILLS, Icons.Outlined.Dashboard, stringResource(R.string.settings_tile_pills_title), stringResource(R.string.settings_tile_pills_subtitle)),
+        TileDef(SettingsPage.WALLPAPER, Icons.Outlined.Wallpaper, stringResource(R.string.settings_tile_wallpaper_title), stringResource(R.string.settings_tile_wallpaper_subtitle)),
         TileDef(SettingsPage.APPLICATION, Icons.Outlined.Settings, stringResource(R.string.settings_tile_app_title), stringResource(R.string.settings_tile_app_subtitle)),
         TileDef(SettingsPage.DEVELOPER, Icons.Outlined.Build, stringResource(R.string.settings_tile_dev_title), stringResource(R.string.settings_tile_dev_subtitle)),
         TileDef(SettingsPage.INFORMATION, Icons.Outlined.Info, stringResource(R.string.settings_tile_info_title), stringResource(R.string.settings_tile_info_subtitle)),
@@ -679,22 +693,9 @@ private fun AppPage(
             )
         }
 
-        SettingsSection(title = stringResource(R.string.settings_app_section_wallpaper)) {
-            backgroundModes.forEach { (key, label) ->
-                SettingsRow(label = stringResource(label), value = if (key == bgMode) "✓" else "", onClick = { onBgModeChange(key) })
-                if (key != backgroundModes.last().first) SettingsDivider()
-            }
-            if (bgMode != "neutral") {
-                SettingsDivider()
-                SettingsRow(
-                    label = stringResource(R.string.settings_app_label_overlay_opacity),
-                    value = "${(bgOverlayOpacity * 100).toInt()} %",
-                    onClick = onOpenOpacityPreview,
-                )
-            }
-        }
-
-        if (bgMode == "immich") {
+        // Wallpaper owns its own top-level settings destination. Keep the legacy Immich editor
+        // unreachable here until its remaining state is fully moved out of this composable.
+        if (false && bgMode == "immich") {
             SettingsSection(title = stringResource(R.string.settings_immich_section)) {
                 SettingsTextField(
                     label = stringResource(R.string.settings_immich_url),
@@ -925,7 +926,7 @@ private fun SessionClassificationDialog(
 }
 
 @Composable
-private fun ImmichAlbumPickerDialog(
+internal fun ImmichAlbumPickerDialog(
     albums: List<PhotoAlbum>,
     selected: Set<String>,
     onDismiss: () -> Unit,
@@ -987,7 +988,7 @@ private fun ImmichAlbumPickerDialog(
 }
 
 @Composable
-private fun IntPresetDialog(
+internal fun IntPresetDialog(
     title: String,
     values: List<Int>,
     suffix: String,
@@ -1197,4 +1198,3 @@ private fun InformationPage(
         }
     }
 }
-

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/WallpaperPage.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/WallpaperPage.kt
@@ -1,5 +1,6 @@
 package com.iblu01.portallauncher.ui.screens
 
+import android.app.WallpaperManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -34,6 +35,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.iblu01.portallauncher.PortalApp
 import com.iblu01.portallauncher.Prefs
 import com.iblu01.portallauncher.R
@@ -72,6 +74,7 @@ internal fun WallpaperPage(
     onBgModeChange: (String) -> Unit,
     bgOverlayOpacity: Float,
     onOpenOpacityPreview: () -> Unit,
+    onOpenSystemWallpaperPicker: () -> Unit,
     onBack: () -> Unit,
     showBack: Boolean = true,
 ) {
@@ -196,6 +199,13 @@ internal fun WallpaperPage(
             showBack = showBack,
         )
 
+        Text(
+            text = stringResource(R.string.settings_wallpaper_sources_hint),
+            style = AppleTypography.bodyLarge,
+            color = AppleColors.secondary,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
+
         WallpaperSourceGrid(
             bgMode = bgMode,
             hasPhoto = hasPhoto,
@@ -206,6 +216,15 @@ internal fun WallpaperPage(
                 if (mode == BG_CUSTOM && !hasPhoto) picker.launch("image/*") else onBgModeChange(mode)
             },
         )
+
+        if (bgMode == "system") {
+            SettingsSection(title = stringResource(R.string.settings_wallpaper_android_section)) {
+                SettingsRow(
+                    label = stringResource(R.string.settings_wallpaper_android_change),
+                    onClick = onOpenSystemWallpaperPicker,
+                )
+            }
+        }
 
         if (bgMode == BG_CUSTOM || hasPhoto) {
             SettingsSection(title = stringResource(R.string.bg_mode_custom)) {
@@ -369,7 +388,7 @@ internal fun WallpaperPage(
 
 private const val BG_CUSTOM = "custom"
 
-/** The four sources, each shown as what it will actually put behind the apps. */
+/** The wallpaper sources, each shown as what it will actually put behind the apps. */
 @Composable
 private fun WallpaperSourceGrid(
     bgMode: String,
@@ -407,7 +426,24 @@ private fun WallpaperSourceGrid(
 
 @Composable
 private fun SourcePreview(mode: String, hasPhoto: Boolean, wallpaperVersion: Int) {
+    val context = LocalContext.current
     when {
+        mode == "system" -> {
+            val drawable = remember(context, wallpaperVersion) {
+                runCatching { WallpaperManager.getInstance(context).drawable }.getOrNull()
+            }
+            if (drawable == null) {
+                PlaceholderPreview { }
+            } else {
+                AsyncImage(
+                    model = drawable,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+
         mode == BG_CUSTOM && !hasPhoto -> PlaceholderPreview {
             Icon(
                 Icons.Outlined.AccountCircle,

--- a/app/src/main/java/com/iblu01/portallauncher/ui/theme/DesignTokens.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/theme/DesignTokens.kt
@@ -42,6 +42,10 @@ object AppleColors {
 
     // Accent
     val accent = Color(0xFF0A84FF)       // iOS blue
+    val lockAccent = Color(0xFF00C8BE)
+    val fanAccent = Color(0xFF64D1FC)
+    val thermostatCool = Color(0xFF33AEE0)
+    val thermostatHeat = Color(0xFFFE9709)
 
     // State indicators
     val active = Color(0xFF30D158)       // iOS green

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -285,7 +285,7 @@
     <string name="light_open_color_wheel_desc">Ouvrir la roue chromatique</string>
     <string name="light_color_active_desc">Couleur active</string>
     <string name="light_color_apply_desc">Appliquer cette couleur</string>
-    <string name="light_mode_brightness">Luminosité</string>
+    <string name="light_mode_brightness">Couleur</string>
     <string name="light_mode_temperature">Température</string>
     <string name="light_color_wheel_title">Couleur</string>
     <string name="light_color_wheel_close_desc">Fermer</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -359,6 +359,8 @@
     <!-- ===== PANEL HELPERS / SHARED ===== -->
     <string name="panel_device_unavailable">Appareil indisponible</string>
     <string name="side_panel_close_desc">Fermer le panneau</string>
+    <string name="side_panel_battery_desc">Batterie à %1$d pour cent</string>
+    <string name="side_panel_battery_value">%1$d%%</string>
 
     <!-- ===== KEYPAD ===== -->
     <string name="keypad_cancel">Annuler</string>
@@ -390,6 +392,9 @@
     <string name="playground_slider_from_top">Depuis le haut</string>
     <string name="playground_slider_disabled">Désactivé</string>
     <string name="playground_section_gradient_slider">Curseur dégradé</string>
+    <string name="playground_section_three_way_control">Contrôle à trois actions</string>
+    <string name="playground_three_way_media">Média</string>
+    <string name="playground_three_way_cover">Stores et volets</string>
     <string name="playground_slider_temperature">Température</string>
     <string name="playground_section_selector">Sélecteur</string>
     <string name="playground_selector_2_options">2 options</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -298,6 +298,7 @@
     <string name="alarm_mode_home">Présence</string>
     <string name="alarm_mode_night">Nuit</string>
     <string name="alarm_mode_vacation">Vacances</string>
+    <string name="alarm_mode_off">Désactivée</string>
     <string name="alarm_disarm_button">Désarmer</string>
 
     <!-- ===== COVER PANEL (Blinds) ===== -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -183,6 +183,7 @@
     <string name="header_settings_content_desc">Réglages</string>
     <string name="auto_return_pill_label">Fermeture auto</string>
     <string name="auto_return_cancel_desc">Annuler</string>
+    <string name="bg_mode_system">Fond d’écran Android</string>
     <string name="bg_mode_neutral">Neutre</string>
     <string name="bg_mode_nature">Nature (Unsplash)</string>
     <string name="bg_mode_custom">Photo perso</string>
@@ -311,13 +312,18 @@
     <string name="cover_button_close">Fermer</string>
 
     <!-- ===== THERMOSTAT PANEL ===== -->
-    <string name="thermostat_current_temp_format">actuel %1$s</string>
     <string name="hvac_mode_off">Éteint</string>
     <string name="hvac_mode_heat">Chauffe</string>
     <string name="hvac_mode_cool">Froid</string>
     <string name="hvac_mode_auto">Auto</string>
     <string name="hvac_mode_dry">Sec</string>
     <string name="hvac_mode_fan_only">Ventil.</string>
+    <string name="thermostat_status_heating">Chauffage en cours</string>
+    <string name="thermostat_status_cooling">Refroidissement en cours</string>
+    <string name="thermostat_status_reached">Température atteinte</string>
+    <string name="thermostat_status_hold_between">MAINTENIR ENTRE</string>
+    <string name="thermostat_room_temperature">Température ambiante</string>
+    <string name="thermostat_room_temperature_format">Pièce · %1$s%2$s</string>
 
     <!-- ===== VACUUM PANEL ===== -->
     <string name="vacuum_button_start">Démarrer</string>
@@ -389,6 +395,8 @@
     <string name="playground_subtitle">Banc d\'essai des contrôles</string>
     <string name="playground_accent_color_label">Couleur d\'accent</string>
     <string name="playground_section_vertical_slider">Curseur vertical</string>
+    <string name="playground_section_fake_panels">Laboratoire de panneaux</string>
+    <string name="playground_fake_panels_hint">Touchez un faux appareil pour ouvrir son vrai panneau latéral. Les actions restent locales et ne contactent jamais Home Assistant.</string>
     <string name="playground_slider_from_bottom">Depuis le bas</string>
     <string name="playground_slider_from_top">Depuis le haut</string>
     <string name="playground_slider_disabled">Désactivé</string>
@@ -402,6 +410,7 @@
     <string name="playground_selector_auto">Auto</string>
     <string name="playground_selector_manual">Manuel</string>
     <string name="playground_selector_icon_stacked">Icône empilée</string>
+    <string name="playground_selector_horizontal">Sélecteur horizontal</string>
     <string name="playground_presence_home">Au domicile</string>
     <string name="playground_presence_away">Absent</string>
     <string name="playground_presence_off">Désactivée</string>
@@ -450,6 +459,7 @@
     <string name="toast_app_not_found_label_format">Application introuvable : %1$s</string>
     <string name="toast_cannot_open_app_format">Impossible d\'ouvrir %1$s</string>
     <string name="toast_choose_wallpaper">Choisir un fond d\'écran</string>
+    <string name="toast_cannot_open_wallpaper_picker">Aucun sélecteur de fond d’écran n’est disponible sur cet appareil</string>
     <string name="toast_permissions_ok">Permissions OK</string>
     <string name="toast_shortcut_added_format">Raccourci ajouté : %1$s</string>
 
@@ -873,4 +883,7 @@
     <string name="settings_wallpaper_replace_photo">Remplacer la photo</string>
     <string name="settings_wallpaper_photo_missing">Aucune photo choisie</string>
     <string name="settings_wallpaper_photo_error">Cette image n\'a pas pu être lue. Essayez-en une autre.</string>
+    <string name="settings_wallpaper_android_section">ANDROID</string>
+    <string name="settings_wallpaper_android_change">Choisir un autre fond d’écran Android</string>
+    <string name="settings_wallpaper_sources_hint">Choisissez l’ambiance affichée derrière l’horloge et les apps.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,7 +290,7 @@
     <string name="light_open_color_wheel_desc">Open color wheel</string>
     <string name="light_color_active_desc">Active color</string>
     <string name="light_color_apply_desc">Apply this color</string>
-    <string name="light_mode_brightness">Brightness</string>
+    <string name="light_mode_brightness">Color</string>
     <string name="light_mode_temperature">Temperature</string>
     <string name="light_color_wheel_title">Color</string>
     <string name="light_color_wheel_close_desc">Close</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,6 +364,8 @@
     <!-- ===== PANEL HELPERS / SHARED ===== -->
     <string name="panel_device_unavailable">Device unavailable</string>
     <string name="side_panel_close_desc">Close panel</string>
+    <string name="side_panel_battery_desc">Battery at %1$d percent</string>
+    <string name="side_panel_battery_value">%1$d%%</string>
 
     <!-- ===== KEYPAD ===== -->
     <string name="keypad_cancel">Cancel</string>
@@ -395,6 +397,9 @@
     <string name="playground_slider_from_top">From top</string>
     <string name="playground_slider_disabled">Disabled</string>
     <string name="playground_section_gradient_slider">Gradient slider</string>
+    <string name="playground_section_three_way_control">Three-action control</string>
+    <string name="playground_three_way_media">Media</string>
+    <string name="playground_three_way_cover">Blinds and covers</string>
     <string name="playground_slider_temperature">Temperature</string>
     <string name="playground_section_selector">Selector</string>
     <string name="playground_selector_2_options">2 options</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,7 @@
     <string name="header_settings_content_desc">Settings</string>
     <string name="auto_return_pill_label">Auto close</string>
     <string name="auto_return_cancel_desc">Cancel</string>
+    <string name="bg_mode_system">Android wallpaper</string>
     <string name="bg_mode_neutral">Neutral</string>
     <string name="bg_mode_nature">Nature (Unsplash)</string>
     <string name="bg_mode_custom">Custom photo</string>
@@ -316,13 +317,18 @@
     <string name="cover_button_close">Close</string>
 
     <!-- ===== THERMOSTAT PANEL ===== -->
-    <string name="thermostat_current_temp_format">current %1$s</string>
     <string name="hvac_mode_off">Off</string>
     <string name="hvac_mode_heat">Heating</string>
     <string name="hvac_mode_cool">Cooling</string>
     <string name="hvac_mode_auto">Auto</string>
     <string name="hvac_mode_dry">Dry</string>
     <string name="hvac_mode_fan_only">Fan only</string>
+    <string name="thermostat_status_heating">Heating</string>
+    <string name="thermostat_status_cooling">Cooling</string>
+    <string name="thermostat_status_reached">Temperature reached</string>
+    <string name="thermostat_status_hold_between">HOLD BETWEEN</string>
+    <string name="thermostat_room_temperature">Room temperature</string>
+    <string name="thermostat_room_temperature_format">Room · %1$s%2$s</string>
 
     <!-- ===== VACUUM PANEL ===== -->
     <string name="vacuum_button_start">Start</string>
@@ -394,6 +400,8 @@
     <string name="playground_subtitle">Control test bench</string>
     <string name="playground_accent_color_label">Accent color</string>
     <string name="playground_section_vertical_slider">Vertical slider</string>
+    <string name="playground_section_fake_panels">Interactive panel lab</string>
+    <string name="playground_fake_panels_hint">Tap a fake device to open its real side panel. Actions stay local and never reach Home Assistant.</string>
     <string name="playground_slider_from_bottom">From bottom</string>
     <string name="playground_slider_from_top">From top</string>
     <string name="playground_slider_disabled">Disabled</string>
@@ -407,6 +415,7 @@
     <string name="playground_selector_auto">Auto</string>
     <string name="playground_selector_manual">Manual</string>
     <string name="playground_selector_icon_stacked">Stacked icon</string>
+    <string name="playground_selector_horizontal">Horizontal selector</string>
     <string name="playground_presence_home">At home</string>
     <string name="playground_presence_away">Away</string>
     <string name="playground_presence_off">Disabled</string>
@@ -455,6 +464,7 @@
     <string name="toast_app_not_found_label_format">App not found: %1$s</string>
     <string name="toast_cannot_open_app_format">Could not open %1$s</string>
     <string name="toast_choose_wallpaper">Choose wallpaper</string>
+    <string name="toast_cannot_open_wallpaper_picker">No wallpaper picker is available on this device</string>
     <string name="toast_permissions_ok">Permissions OK</string>
     <string name="toast_shortcut_added_format">Shortcut added: %1$s</string>
 
@@ -878,4 +888,7 @@
     <string name="settings_wallpaper_replace_photo">Replace the photo</string>
     <string name="settings_wallpaper_photo_missing">No photo chosen yet</string>
     <string name="settings_wallpaper_photo_error">This image could not be read. Try another one.</string>
+    <string name="settings_wallpaper_android_section">ANDROID</string>
+    <string name="settings_wallpaper_android_change">Choose another Android wallpaper</string>
+    <string name="settings_wallpaper_sources_hint">Choose the atmosphere shown behind your clock and apps.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,6 +303,7 @@
     <string name="alarm_mode_home">Home</string>
     <string name="alarm_mode_night">Night</string>
     <string name="alarm_mode_vacation">Vacation</string>
+    <string name="alarm_mode_off">Disabled</string>
     <string name="alarm_disarm_button">Disarm</string>
 
     <!-- ===== COVER PANEL (Blinds) ===== -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.PortalLauncher" parent="android:style/Theme.Material.NoActionBar">
-        <item name="android:windowBackground">@color/black</item>
+        <!--
+            A home activity must let Android's WallpaperService own the layer behind its window.
+            Opaque in-app backgrounds still cover it; the "system" mode deliberately stays
+            transparent so static, live and OEM wallpapers all render through the native path.
+        -->
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowShowWallpaper">true</item>
         <item name="android:fontFamily">sans</item>
         <item name="android:colorAccent">#64B5F6</item>
     </style>

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/ClimateEntityContractTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/ClimateEntityContractTest.kt
@@ -1,0 +1,63 @@
+package com.iblu01.portallauncher.ui.components
+
+import com.iblu01.portallauncher.HaEntity
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClimateEntityContractTest {
+    @Test
+    fun `maps a full Home Assistant range thermostat contract`() {
+        val entity = HaEntity("climate.living_room", "heat_cool", JSONObject()
+            .put("supported_features", ClimateFeature.TARGET_TEMPERATURE_RANGE)
+            .put("hvac_modes", JSONArray(listOf("off", "heat", "heat_cool")))
+            .put("hvac_action", "heating")
+            .put("current_temperature", 20.4)
+            .put("target_temp_low", 19.5)
+            .put("target_temp_high", 22.5)
+            .put("min_temp", 7)
+            .put("max_temp", 30)
+            .put("target_temp_step", 0.5)
+            .put("temperature_unit", "°C"))
+
+        val contract = entity.toClimateContract()
+
+        assertEquals("heat_cool", contract.hvacMode)
+        assertEquals("heating", contract.hvacAction)
+        assertEquals(listOf("off", "heat", "heat_cool"), contract.availableModes)
+        assertEquals(19.5f, contract.targetLow)
+        assertEquals(22.5f, contract.targetHigh)
+        assertEquals("°C", contract.temperatureUnit)
+        assertTrue(contract.supportsTargetRange)
+        assertFalse(contract.supportsSingleTarget)
+    }
+
+    @Test
+    fun `infers legacy integration capabilities from exposed attributes`() {
+        val entity = HaEntity("climate.bedroom", "heat", JSONObject()
+            .put("temperature", 21.0)
+            .put("current_temperature", 20.0))
+
+        val contract = entity.toClimateContract()
+
+        assertTrue(contract.supportsSingleTarget)
+        assertFalse(contract.supportsTargetRange)
+        assertEquals(0.5f, contract.temperatureStep)
+        assertEquals("°", contract.temperatureUnit)
+    }
+
+    @Test
+    fun `keeps an integration without setpoints read only`() {
+        val entity = HaEntity("climate.ventilation", "fan_only", JSONObject()
+            .put("hvac_modes", JSONArray(listOf("off", "fan_only")))
+            .put("current_temperature", 23.0))
+
+        val contract = entity.toClimateContract()
+
+        assertFalse(contract.hasTemperatureControl)
+        assertEquals(listOf("off", "fan_only"), contract.availableModes)
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/FanEntityContractTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/FanEntityContractTest.kt
@@ -1,0 +1,35 @@
+package com.iblu01.portallauncher.ui.components
+
+import com.iblu01.portallauncher.HaEntity
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FanEntityContractTest {
+    @Test fun `plain fan maps to on off control`() {
+        val contract = HaEntity("fan.basic", "on", JSONObject()).toFanContract()
+        assertEquals(FanPrimaryControl.OnOff, contract.primaryControl)
+        assertTrue(contract.isOn)
+    }
+
+    @Test fun `percentage fan maps to vertical slider`() {
+        val entity = HaEntity("fan.variable", "on", JSONObject()
+            .put("supported_features", FanFeature.SET_SPEED)
+            .put("percentage", 40)
+            .put("percentage_step", 5))
+        assertEquals(FanPrimaryControl.Percentage(40, 5), entity.toFanContract().primaryControl)
+    }
+
+    @Test fun `preset modes take precedence and preserve exact Home Assistant values`() {
+        val entity = HaEntity("fan.levels", "on", JSONObject()
+            .put("percentage", 66)
+            .put("preset_mode", "level_2")
+            .put("preset_modes", JSONArray(listOf("level_1", "level_2", "level_3"))))
+        assertEquals(
+            FanPrimaryControl.Presets(listOf("level_1", "level_2", "level_3"), "level_2"),
+            entity.toFanContract().primaryControl,
+        )
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/ui/panel/PanelStateTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/panel/PanelStateTest.kt
@@ -113,6 +113,60 @@ class PanelStateTest {
         assertEquals(chip("light.a"), s.request)
     }
 
+    private fun alarm(key: String = "alarm") = PanelRequest.Chip(key, PanelKind.ALARM)
+
+    @Test fun `alarm alert opens over a user panel`() {
+        val userOpen = PanelState(request = chip("light.a"), source = PanelSource.USER)
+        val s = reduce(userOpen, PanelEvent.AlarmAlert(alarm()))
+        assertEquals(alarm(), s.request)
+        assertEquals(PanelSource.ALERT, s.source)
+    }
+
+    @Test fun `media auto-open never clobbers an alert panel`() {
+        val alerting = PanelState(request = alarm(), source = PanelSource.ALERT)
+        val s = reduce(alerting, PanelEvent.MediaAutoOpen("m1"))
+        assertEquals(alarm(), s.request)
+    }
+
+    @Test fun `alarm cleared closes the alert panel`() {
+        val alerting = PanelState(request = alarm(), source = PanelSource.ALERT)
+        val s = reduce(alerting, PanelEvent.AlarmCleared)
+        assertNull(s.request)
+    }
+
+    @Test fun `alarm cleared leaves a user panel untouched`() {
+        val userOpen = PanelState(request = chip("light.a"), source = PanelSource.USER)
+        val s = reduce(userOpen, PanelEvent.AlarmCleared)
+        assertEquals(chip("light.a"), s.request)
+    }
+
+    @Test fun `dismissed alert does not reopen while the alarm keeps alerting`() {
+        var s = reduce(PanelState(), PanelEvent.AlarmAlert(alarm()))
+        s = reduce(s, PanelEvent.Dismiss)
+        assertNull(s.request)
+        assertEquals("alarm", s.dismissedAlertKey)
+        s = reduce(s, PanelEvent.AlarmAlert(alarm()))
+        assertNull(s.request)
+    }
+
+    @Test fun `alarm cleared rearms the alert`() {
+        var s = PanelState(dismissedAlertKey = "alarm")
+        s = reduce(s, PanelEvent.AlarmCleared)
+        assertNull(s.dismissedAlertKey)
+        s = reduce(s, PanelEvent.AlarmAlert(alarm()))
+        assertEquals(alarm(), s.request)
+    }
+
+    @Test fun `alert panel is reopened after the user navigates away and closes`() {
+        var s = reduce(PanelState(), PanelEvent.AlarmAlert(alarm()))
+        s = reduce(s, PanelEvent.OpenChip(chip("lock.b", PanelKind.LOCK)))
+        assertEquals(PanelSource.USER, s.source)
+        s = reduce(s, PanelEvent.Dismiss)                 // closing a chip, not the alert
+        assertNull(s.dismissedAlertKey)
+        s = reduce(s, PanelEvent.AlarmAlert(alarm()))
+        assertEquals(alarm(), s.request)
+    }
+
     @Test fun `interleave - user opens over auto media then dismiss`() {
         var s = reduce(PanelState(), PanelEvent.MediaAutoOpen("m1"))       // AUTO media
         s = reduce(s, PanelEvent.OpenChip(chip("lock.b", PanelKind.LOCK))) // USER replaces


### PR DESCRIPTION
## Summary

UI redesign of all control panels with responsive scaling, new shared components, and entity contracts.

### Key changes
- **Entity contracts** — `ClimateEntityContract` + `FanEntityContract` extract HA capabilities
- **New controls** — `PortalThreeWayControl`, `PortalVacuum`, `HorizontalSegmentedSelector`
- **All panels responsive** — proportional scaling replaces fixed dp values across sliders, switches, selectors, keypad
- **Unified `PanelHeader`** — frosted header with battery indicator, used by all panels
- **Alarm alert** — new `PanelSource.ALERT` priority, `alarmHold` keeps screen on until disarmed
- **WallpaperPage** activated from `.disabled`, native Android wallpaper picker
- **Playground screen** — interactive panel lab with 14 fake entities
- **~30 new tests** — PanelState, entity contracts

Closes panel redesign