### PR TITLE
Release 1.0.2 — connection diagnostics, mDNS warnings and clock date formats

### DIFF
--- a/.agent/skills/portal-launcher-release/SKILL.md
+++ b/.agent/skills/portal-launcher-release/SKILL.md
@@ -98,10 +98,15 @@ Verify the signature with `apksigner`:
 ```bash
 cp app/build/outputs/apk/release/app-release.apk /tmp/portal-launcher-vX.Y.Z-beta.apk
 gh release create "vX.Y.Z-beta" \
-  --title "vX.Y.Z-beta — {short summary}" \
+  --title "vX.Y.Z-beta" \
   --notes "{CHANGELOG condensed into markdown}" \
   /tmp/portal-launcher-vX.Y.Z-beta.apk
 ```
+
+The GitHub release title must be **only the version tag** (`vX.Y.Z`, including a prerelease suffix
+only when the tag itself has one). Never add a product name, summary, dash, colon, or any other text.
+Before creating the release, verify that the value passed to `--title` is byte-for-byte identical to
+the tag passed as the first argument to `gh release create`.
 
 ### Step 10 — Cleanup
 
@@ -113,6 +118,7 @@ git remote prune origin
 ## Notes
 
 - **Release notes are always in English** — CHANGELOG entries, PR title/body, tag messages, and GitHub release notes/summaries must be written in English, without exception.
+- **GitHub release titles contain only the tag** — for example `v1.2.3`, never `v1.2.3 — New features`.
 - The keystore is the same for all releases (no rotation).
 - The APK uses the v2 signature only (no v1 JAR signing). This is sufficient for minSdk 28.
 - The local branch is deleted by `gh pr merge --delete-branch`; you only need to prune the remote tracking ref.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 1.0.2
+
+### Added
+
+- **Connection problem banner**: when Home Assistant is unreachable, a tappable banner on the home and clock screens explains the situation and opens the connection settings directly. A `.local` address gets a dedicated hint recommending the server's local IP.
+- **mDNS warnings**: `.local` hostnames are detected in onboarding, connection settings and the web config page, each warning that local DNS (mDNS) may not resolve on some panels and pointing to the local IP as a fallback.
+- **Staged web-config testing**: remote setup now splits Home Assistant and MQTT into separate steps, each validated live before saving — HA tests address, port and token; MQTT tests host, port and authentication. Per-section cards show "Configured" or "Waiting", and an offline view with retry replaces the silent failure.
+- **Clock date formats**: nine layouts (long, weekday variants, numeric and ISO) selectable from the clock theme, with a live localized preview rendered against a fixed reference date.
+- **Weather corrections**: deterministic weather-entity selection, forecast entries without a temperature are dropped instead of reading `0.0`, the real city is reverse-geocoded from the Home Assistant zone, and temperatures convert to the entity's `°C`/`°F` unit.
+- **Accessibility pass**: buttons, switches, sliders and selectors expose proper roles, hardware-key activation and larger touch targets; dialogs are announced as such.
+- **Discord community banner** in the README.
+
+### Changed
+
+- The clock colon is now drawn (two vertically-centered `Canvas` dots) instead of a text character, with an optional small AM/PM suffix; the date follows the selected format.
+- The single "Configuration saved" web-config screen becomes progress/completion states, and the `HomeConnectionPage` entry is promoted to a prominent tile at the top of the page.
+- Settings dialogs are constrained to a maximum size with scrollable content, and remaining hard-coded French strings moved to resources.
+- The clock-theme close button moved to the top-right corner, and mock pills were removed from the previews.
+- `SettingsActivity` guards against an outgoing composition's stale auto-save overwriting values just persisted by the web server.
+
+### Removed
+
+- `StaleBanner`, replaced by `ConnectionProblemBanner`.
+- Mock pill and weather preview constants in the clock theme and opacity previews.
+- The single `configurationSaved` boolean and the monolithic `onConfigSaved` callback, replaced by section-aware save states.
+- The `web_config_saved_title` / `web_config_saved_body` strings.
+
+### Performance
+
+- The clock colon and its semantics are GPU-drawn with a single content-description node.
+- Weather reverse-geocoding runs on a dedicated single-thread executor with a cache-validity key, off the main thread.
+- Forecast parsing no longer fabricates invalid entries.
+
+### i18n
+
+- New English and French strings for the connection banner, mDNS warnings, clock date-format selection, tint names, web-config progress/completion states and preview labels.
+
+### Tests
+
+- New suites: `ClockDateFormatTest`, `WeatherDataTest`, `WeatherTemperatureSummaryTest`, `ConnectionProblemBannerTest`, `WeatherCityTest` and `WeatherForecastLabelTest`; extended `WebConfigServerTest`, `IndividualPillPanelTest` and `OnboardingUrlsTest`.
+
 ## 1.0.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Home Assistant controls. It is built for landscape devices from compact 5-inch d
 > **Portal Launcher 1.0 is now available.** Download the APK from
 > [GitHub Releases](https://github.com/iblur01/portal-launcher/releases/latest).
 
+<p align="center">
+  <a href="https://discord.gg/m9CK4SXPJ">
+    <img src="https://img.shields.io/badge/Join_the_Portal_Launcher_community-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join the Portal Launcher community on Discord">
+  </a>
+</p>
+
+<p align="center">
+  Get help, share your setup and discuss new features with the community.
+</p>
+
 ## Highlights
 
 - Real Android home launcher with multiple pages, free icon placement, widgets, folders, shortcuts,

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ For detailed setup, permissions, ADB provisioning and local web configuration, r
 - [Architecture](docs/ARCHITECTURE.md)
 - [Development](docs/DEVELOPMENT.md)
 - [Testing](docs/TESTING.md)
+- [Next release: scenes and camera center](docs/NEXT_RELEASE_SCENES_CAMERAS_SPEC.md)
 - [Immich and photo sources](docs/photo-sources.md)
 - [Home pills technical specification](docs/PILLS_HOME_TECHNICAL_SPEC.md)
 - [MQTT session protocol](docs/session-protocol.md)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.iblu01.portallauncher"
         minSdk = 28
         targetSdk = 28
-        versionCode = 9
-        versionName = "1.0.1"
+        versionCode = 10
+        versionName = "1.0.2"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/iblu01/portallauncher/HaStateRepository.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/HaStateRepository.kt
@@ -28,6 +28,26 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.net.Proxy
 
+/** Stable weather selection: conventional HA id first, then lexical order. */
+internal fun selectWeatherEntityId(entityIds: Iterable<String>): String? {
+    val weatherIds = entityIds.filter { it.startsWith("weather.") }
+    return weatherIds.firstOrNull { it == "weather.home" }
+        ?: weatherIds.minOrNull()
+}
+
+/** Drops incomplete forecast entries instead of manufacturing a misleading 0°. */
+internal fun parseForecastPoints(arr: JSONArray): List<ForecastPoint> =
+    (0 until arr.length()).mapNotNull { arr.optJSONObject(it) }.mapNotNull { o ->
+        val temperature = o.optDouble("temperature", Double.NaN).takeUnless(Double::isNaN)
+            ?: return@mapNotNull null
+        ForecastPoint(
+            datetime = o.optString("datetime"),
+            temp = temperature,
+            tempLow = o.optDouble("templow", Double.NaN).takeUnless(Double::isNaN),
+            condition = o.optString("condition"),
+        )
+    }
+
 class HaStateRepository(appContext: Context, private val url: String, private val token: String) {
     fun interface Listener { fun onStates(states: Map<String, HaEntity>, connected: Boolean) }
     private val listeners = CopyOnWriteArraySet<Listener>()
@@ -74,7 +94,7 @@ class HaStateRepository(appContext: Context, private val url: String, private va
     @Volatile var lastUpdateAt = 0L
         private set
 
-    /** First weather.* entity found, and its subscribed forecasts. */
+    /** Deterministically selected weather entity, and its subscribed forecasts. */
     @Volatile var weatherEntityId: String? = null
         private set
     @Volatile var hourlyForecast: List<ForecastPoint> = emptyList()
@@ -282,15 +302,7 @@ class HaStateRepository(appContext: Context, private val url: String, private va
         val id = o.optString("entity_id"); if (id.isBlank()) return null
         return HaEntity(id, o.optString("state"), o.optJSONObject("attributes") ?: JSONObject(), o.optString("last_changed"))
     }
-    private fun parseForecast(arr: JSONArray): List<ForecastPoint> =
-        (0 until arr.length()).mapNotNull { arr.optJSONObject(it) }.map { o ->
-            ForecastPoint(
-                datetime = o.optString("datetime"),
-                temp = o.optDouble("temperature", Double.NaN).let { if (it.isNaN()) 0.0 else it },
-                tempLow = o.optDouble("templow", Double.NaN).let { if (it.isNaN()) null else it },
-                condition = o.optString("condition"),
-            )
-        }
+    private fun parseForecast(arr: JSONArray): List<ForecastPoint> = parseForecastPoints(arr)
     private inner class WsListener : WebSocketListener() {
         override fun onMessage(webSocket: WebSocket, text: String) {
             lastActivityAt = System.currentTimeMillis()
@@ -317,7 +329,7 @@ class HaStateRepository(appContext: Context, private val url: String, private va
                         Log.i(TAG, "received ${result.length()} states; subscribing to changes")
                         // Id must exceed the registry list ids (3,4,5) — HA requires per-connection ids to strictly increase.
                         notifyListeners(); webSocket.send("{\"id\":6,\"type\":\"subscribe_events\",\"event_type\":\"state_changed\"}")
-                        weatherEntityId = states.keys.firstOrNull { it.startsWith("weather.") }
+                        weatherEntityId = selectWeatherEntityId(states.keys)
                         weatherEntityId?.let { w ->
                             webSocket.send("{\"id\":$FORECAST_HOURLY_ID,\"type\":\"weather/subscribe_forecast\",\"forecast_type\":\"hourly\",\"entity_id\":\"$w\"}")
                             webSocket.send("{\"id\":$FORECAST_DAILY_ID,\"type\":\"weather/subscribe_forecast\",\"forecast_type\":\"daily\",\"entity_id\":\"$w\"}")

--- a/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/LauncherActivity.kt
@@ -109,6 +109,7 @@ import com.iblu01.portallauncher.ui.components.returnToClockPage
 import com.iblu01.portallauncher.ui.components.AutoReturnOverlay
 import com.iblu01.portallauncher.ui.components.ChipActionsPanel
 import com.iblu01.portallauncher.ui.components.ClockHeader
+import com.iblu01.portallauncher.ui.components.ConnectionProblemBanner
 import com.iblu01.portallauncher.ui.components.GroupBrowserPanel
 import com.iblu01.portallauncher.ui.components.HomePillActions
 import com.iblu01.portallauncher.ui.components.HomeHeaderActions
@@ -133,6 +134,7 @@ import com.iblu01.portallauncher.ui.components.panelPresentation
 import com.iblu01.portallauncher.ui.components.QuickActionsOverlay
 import com.iblu01.portallauncher.ui.components.WeatherController
 import com.iblu01.portallauncher.ui.components.WeatherPanel
+import com.iblu01.portallauncher.ui.onboarding.OnboardingUrls
 import com.iblu01.portallauncher.ui.onboarding.OnboardingActivity
 import com.iblu01.portallauncher.ui.onboarding.OnboardingStatus
 import com.iblu01.portallauncher.ui.onboarding.shouldRunOnboarding
@@ -227,6 +229,15 @@ class LauncherActivity : ComponentActivity() {
                     onUninstall = ::uninstallApp,
                     onStartShortcut = ::startShortcut,
                     onOpenHomeSettings = ::openHomeSettings,
+                    onOpenConnectionSettings = {
+                        openFromLauncher(
+                            Intent(this, SettingsActivity::class.java)
+                                .putExtra(
+                                    SettingsActivity.EXTRA_PAGE,
+                                    SettingsActivity.PAGE_CONNECTED_HOME_CONNECTION,
+                                )
+                        )
+                    },
                     onSetWallpaper = ::setWallpaper,
                     onAddWidget = ::addWidget,
                     onRemoveWidget = { widgets.release(it) },
@@ -503,6 +514,7 @@ private fun PortalLauncherApp(
     onUninstall: (String) -> Unit,
     onStartShortcut: (packageName: String, shortcutId: String) -> Unit,
     onOpenHomeSettings: () -> Unit,
+    onOpenConnectionSettings: () -> Unit,
     onSetWallpaper: () -> Unit,
     onAddWidget: (WidgetOffer) -> Unit,
     onRemoveWidget: (Int) -> Unit,
@@ -1361,6 +1373,17 @@ private fun PortalLauncherApp(
                     (panelContent ?: retainedPanelContent)?.let { sidePanel(it) }
                 },
             )
+
+            if (!haConnected && prefs.haToken.isNotBlank()) {
+                ConnectionProblemBanner(
+                    lastUpdateAt = haLastUpdateAt,
+                    usesMdnsAddress = OnboardingUrls.usesMdnsHostname(prefs.haUrl),
+                    onClick = onOpenConnectionSettings,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(horizontal = 20.dp, vertical = 18.dp),
+                )
+            }
         }
 
         QuickActionsOverlay(

--- a/app/src/main/java/com/iblu01/portallauncher/PillRepository.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/PillRepository.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.flow.scan
 import java.util.concurrent.CopyOnWriteArraySet
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -57,6 +58,9 @@ class PillRepository @Inject constructor(@ApplicationContext private val appCont
     // fresh instance on reconnect / config change via flatMapLatest (fixes the stale-capture bug).
     private val activeRepo = MutableStateFlow<HaStateRepository?>(null)
     private var repositoryConfig: String? = null
+    /** Changes whenever the backing HA server or credentials change. */
+    @Volatile var connectionGeneration: Long = 0L
+        private set
 
     // Trailing-edge debounce for the pull-consumer notifications: HA streams state_changed in
     // bursts, and each notify writes Compose state (the weather card). Coalesce to one per window
@@ -104,6 +108,7 @@ class PillRepository @Inject constructor(@ApplicationContext private val appCont
         }
         Log.i("PortalPills", "starting: ${prefs.pillRules.count { it.enabled }} enabled rules")
         activeRepo.value?.stop()
+        connectionGeneration++
         repositoryConfig = requestedConfig
         val repo = HaStateRepository(appContext, prefs.haUrl, prefs.haToken)
         // Lightweight listener: refresh the raw-state cache + one-time auto-init, then notify.
@@ -330,16 +335,41 @@ class PillRepository @Inject constructor(@ApplicationContext private val appCont
         )
     }
 
-    private fun temperatureSummary(rules: List<PillRule>, states: Map<String, HaEntity>): TemperatureSummary {
+    internal fun temperatureSummary(rules: List<PillRule>, states: Map<String, HaEntity>): TemperatureSummary {
+        val targetUnit = selectWeatherEntityId(states.keys)
+            ?.let(states::get)
+            ?.attributes
+            ?.optString("temperature_unit")
+            .toTemperatureUnit()
+            ?: TemperatureUnit.CELSIUS
         val readings = rules.filter { it.enabled && it.kind == PillKind.CLIMATE }.mapNotNull { rule ->
             val entity = states[rule.entityId] ?: return@mapNotNull null
             if (entity.deviceClass != "temperature") return@mapNotNull null
-            entity.state.toDoubleOrNull()?.let { Triple(entity, rule.label, it) }
+            val sourceUnit = entity.attributes.optString("unit_of_measurement").toTemperatureUnit()
+                ?: targetUnit
+            entity.state.toDoubleOrNull()?.let { Triple(entity, rule.label, convertTemperature(it, sourceUnit, targetUnit)) }
         }
         val outdoorTokens = Regex("extérieur|exterieur|outdoor|outside|dehors", RegexOption.IGNORE_CASE)
         val outdoor = readings.firstOrNull { (entity, label) -> outdoorTokens.containsMatchIn(entity.entityId) || outdoorTokens.containsMatchIn(label) }
         val indoor = readings.filterNot { it === outdoor }
-        fun fmt(value: Double?) = value?.let { if (it % 1.0 == 0.0) "${it.toInt()}°" else "%.1f°".format(it) } ?: "—"
+        fun fmt(value: Double?) = value?.let {
+            val number = if (it % 1.0 == 0.0) it.toInt().toString() else "%.1f".format(Locale.getDefault(), it)
+            "$number${targetUnit.symbol}"
+        } ?: "—"
         return TemperatureSummary(fmt(indoor.minOfOrNull { it.third }), fmt(indoor.maxOfOrNull { it.third }), fmt(outdoor?.third))
     }
+}
+
+internal enum class TemperatureUnit(val symbol: String) { CELSIUS("°C"), FAHRENHEIT("°F") }
+
+internal fun String?.toTemperatureUnit(): TemperatureUnit? = when (this?.trim()?.uppercase()) {
+    "°C", "C", "CELSIUS" -> TemperatureUnit.CELSIUS
+    "°F", "F", "FAHRENHEIT" -> TemperatureUnit.FAHRENHEIT
+    else -> null
+}
+
+internal fun convertTemperature(value: Double, from: TemperatureUnit, to: TemperatureUnit): Double = when {
+    from == to -> value
+    from == TemperatureUnit.FAHRENHEIT -> (value - 32.0) * 5.0 / 9.0
+    else -> value * 9.0 / 5.0 + 32.0
 }

--- a/app/src/main/java/com/iblu01/portallauncher/Prefs.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/Prefs.kt
@@ -10,6 +10,7 @@ import androidx.security.crypto.MasterKey
 import com.iblu01.portallauncher.domain.home.HomePillPreferences
 import com.iblu01.portallauncher.session.SessionAllowlist
 import com.iblu01.portallauncher.session.SessionAllowlistCodec
+import com.iblu01.portallauncher.ui.theme.ClockDateFormat
 import com.iblu01.portallauncher.ui.theme.ClockFont
 import com.iblu01.portallauncher.ui.theme.ClockTheme
 import com.iblu01.portallauncher.ui.theme.ClockTint
@@ -187,6 +188,10 @@ class Prefs(private val context: Context) {
         get() = sp.getBoolean("clock_format_24h", true)
         set(value) = sp.edit().putBoolean("clock_format_24h", value).apply()
 
+    var clockDateFormat: String
+        get() = sp.getString("clock_date_format", ClockDateFormat.LONG.key) ?: ClockDateFormat.LONG.key
+        set(value) = sp.edit().putString("clock_date_format", value).apply()
+
     var clockElementSpacing: Float
         get() = sp.getFloat("clock_element_spacing", 1f)
         set(value) = sp.edit().putFloat("clock_element_spacing", value.coerceIn(0.4f, 2f)).apply()
@@ -200,6 +205,7 @@ class Prefs(private val context: Context) {
             letterSpacing = clockLetterSpacing,
             tint = ClockTint.fromKey(clockTint),
             format24h = clockFormat24h,
+            dateFormat = ClockDateFormat.fromKey(clockDateFormat),
             elementSpacing = clockElementSpacing,
         )
         set(value) {
@@ -209,6 +215,7 @@ class Prefs(private val context: Context) {
             clockLetterSpacing = value.letterSpacing
             clockTint = value.tint.key
             clockFormat24h = value.format24h
+            clockDateFormat = value.dateFormat.key
             clockElementSpacing = value.elementSpacing
         }
 

--- a/app/src/main/java/com/iblu01/portallauncher/SettingsActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/SettingsActivity.kt
@@ -49,6 +49,7 @@ class SettingsActivity : ComponentActivity() {
 
     /** Last persisted MQTT-relevant values, to restart the bridge only when they actually change. */
     private var savedMqttSignature = ""
+    private var loadedWebConfigSignature = ""
 
     /**
      * Layout export / restore, through the storage picker rather than a fixed path: the app holds no
@@ -101,6 +102,7 @@ class SettingsActivity : ComponentActivity() {
         syncHomeSettingsFromRepository()
         refreshPillSettingsCatalog()
         savedMqttSignature = mqttSignature(prefs.brokerHost, prefs.brokerPort, prefs.username, prefs.password, prefs.deviceName)
+        loadedWebConfigSignature = webConfigSignature()
 
         val apps = resolveInstalledApps()
 
@@ -128,12 +130,22 @@ class SettingsActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+        if (loadedWebConfigSignature.isNotEmpty() && loadedWebConfigSignature != webConfigSignature()) {
+            recreate()
+            return
+        }
         syncHomeSettingsFromRepository()
         refreshPillSettingsCatalog()
         pills.addListener(pillListener)
         MqttBridgeService.start(this)
         autoReturnTimer.start()
     }
+
+    private fun webConfigSignature(): String = listOf(
+        prefs.haUrl,
+        prefs.haToken.hashCode().toString(),
+        mqttSignature(prefs.brokerHost, prefs.brokerPort, prefs.username, prefs.password, prefs.deviceName),
+    ).joinToString("|")
 
     override fun onPause() {
         pills.removeListener(pillListener)
@@ -150,6 +162,13 @@ class SettingsActivity : ComponentActivity() {
 
     private val callbacks = object : SettingsCallbacks {
         override fun onSave(form: SettingsForm) {
+            // Returning from remote configuration recreates this activity so Compose can rebuild
+            // every field from Prefs. The outgoing composition still runs its onDispose auto-save;
+            // never let that stale form overwrite the values the web server has just persisted.
+            if (
+                loadedWebConfigSignature.isNotEmpty() &&
+                loadedWebConfigSignature != webConfigSignature()
+            ) return
             prefs.homeAssistantPackage = form.haPackage
             prefs.brokerHost = form.host
             prefs.brokerPort = form.port
@@ -424,6 +443,7 @@ class SettingsActivity : ComponentActivity() {
         const val PAGE_HOME = "HOME_SCREEN"
         const val PAGE_APPEARANCE = "APPEARANCE"
         const val PAGE_CONNECTED_HOME = "CONNECTED_HOME"
+        const val PAGE_CONNECTED_HOME_CONNECTION = "CONNECTED_HOME_CONNECTION"
         const val PAGE_DEVICE = "DEVICE"
         const val PAGE_ABOUT = "ABOUT"
     }

--- a/app/src/main/java/com/iblu01/portallauncher/WebConfigActivity.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/WebConfigActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -23,6 +24,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.Wifi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,6 +40,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
@@ -71,7 +74,8 @@ class WebConfigActivity : ComponentActivity() {
 
     private var server: WebConfigServer? = null
     private var endpoint by mutableStateOf<Endpoint?>(null)
-    private var configurationSaved by mutableStateOf(false)
+    private var homeAssistantSaved by mutableStateOf(false)
+    private var mqttSaved by mutableStateOf(false)
 
     /** Address and access code of the running server; null while it is not listening. */
     data class Endpoint(val url: String, val code: String)
@@ -89,12 +93,10 @@ class WebConfigActivity : ComponentActivity() {
             PortalTheme {
                 WebConfigScreen(
                     endpoint = endpoint,
-                    configurationSaved = configurationSaved,
+                    homeAssistantSaved = homeAssistantSaved,
+                    mqttSaved = mqttSaved,
                     onBack = ::finish,
-                    onContinue = {
-                        setResult(RESULT_OK)
-                        finish()
-                    },
+                    onContinue = ::finish,
                 )
             }
         }
@@ -125,6 +127,11 @@ class WebConfigActivity : ComponentActivity() {
         super.onDestroy()
     }
 
+    override fun finish() {
+        if (homeAssistantSaved || mqttSaved) setResult(RESULT_OK)
+        super.finish()
+    }
+
     private fun startServer() {
         if (server != null) return
         val mainHandler = Handler(Looper.getMainLooper())
@@ -137,7 +144,19 @@ class WebConfigActivity : ComponentActivity() {
                     MqttBridgeService.start(this)
                 }
             },
-            onConfigSaved = { mainHandler.post { configurationSaved = true } },
+            onConfigSaved = { section ->
+                mainHandler.post {
+                    if (section == WebConfigSection.HOME_ASSISTANT || section == WebConfigSection.ALL) {
+                        homeAssistantSaved = true
+                    }
+                    if (section == WebConfigSection.MQTT || section == WebConfigSection.ALL) {
+                        mqttSaved = true
+                    }
+                    SettingsChangeBus.get().emit("haUrl")
+                    SettingsChangeBus.get().emit("haToken")
+                    SettingsChangeBus.get().emit("brokerHost")
+                }
+            },
         )
         val ip = localIpv4()
         if (started == null || ip == null) {
@@ -171,7 +190,8 @@ class WebConfigActivity : ComponentActivity() {
 @Composable
 private fun WebConfigScreen(
     endpoint: WebConfigActivity.Endpoint?,
-    configurationSaved: Boolean,
+    homeAssistantSaved: Boolean,
+    mqttSaved: Boolean,
     onBack: () -> Unit,
     onContinue: () -> Unit,
 ) {
@@ -196,39 +216,69 @@ private fun WebConfigScreen(
                 onBack = onBack,
             )
 
-            if (configurationSaved) {
+            if (homeAssistantSaved || mqttSaved) {
+                val complete = homeAssistantSaved && mqttSaved
                 Column(
                     modifier = Modifier.fillMaxWidth().weight(1f),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center,
                 ) {
-                    Icon(
-                        imageVector = Icons.Filled.Check,
-                        contentDescription = null,
-                        tint = AppleColors.active,
-                        modifier = Modifier.size(if (short) 48.dp else 64.dp),
-                    )
-                    Spacer(Modifier.height(if (short) 10.dp else 18.dp))
                     Text(
-                        stringResource(R.string.web_config_saved_title),
+                        stringResource(
+                            if (complete) R.string.web_config_complete_title
+                            else R.string.web_config_progress_title,
+                        ),
                         style = AppleTypography.headlineLarge,
                         color = AppleColors.primary,
                     )
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        stringResource(R.string.web_config_saved_body),
+                        stringResource(
+                            if (complete) R.string.web_config_complete_body
+                            else R.string.web_config_progress_body,
+                        ),
                         style = AppleTypography.bodyLarge,
                         color = AppleColors.secondary,
                     )
-                    Spacer(Modifier.height(if (short) 16.dp else 28.dp))
-                    BoxWithConstraints(
-                        Modifier.fillMaxWidth().widthIn(max = 420.dp),
-                        contentAlignment = Alignment.Center,
+                    Spacer(Modifier.height(if (short) 14.dp else 24.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth().widthIn(max = 620.dp),
+                        horizontalArrangement = Arrangement.spacedBy(14.dp),
                     ) {
+                        ConfigStatusCard(
+                            title = "Home Assistant",
+                            configured = homeAssistantSaved,
+                            modifier = Modifier.weight(1f),
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.ic_provider_homeassistant),
+                                    contentDescription = null,
+                                    tint = if (homeAssistantSaved) AppleColors.active else AppleColors.tertiary,
+                                    modifier = Modifier.size(30.dp),
+                                )
+                            },
+                        )
+                        ConfigStatusCard(
+                            title = "MQTT",
+                            configured = mqttSaved,
+                            modifier = Modifier.weight(1f),
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Wifi,
+                                    contentDescription = null,
+                                    tint = if (mqttSaved) AppleColors.active else AppleColors.tertiary,
+                                    modifier = Modifier.size(30.dp),
+                                )
+                            },
+                        )
+                    }
+                    if (complete) {
+                        Spacer(Modifier.height(if (short) 16.dp else 28.dp))
                         PillButton(
                             label = stringResource(R.string.web_config_saved_action),
                             onClick = onContinue,
                             primary = true,
+                            modifier = Modifier.fillMaxWidth().widthIn(max = 420.dp),
                         )
                     }
                 }
@@ -284,6 +334,42 @@ private fun WebConfigScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ConfigStatusCard(
+    title: String,
+    configured: Boolean,
+    icon: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(AppleShapes.card)
+            .background(
+                if (configured) AppleColors.active.copy(alpha = 0.14f) else AppleColors.elevated,
+                AppleShapes.card,
+            )
+            .border(
+                1.dp,
+                if (configured) AppleColors.active.copy(alpha = 0.65f) else AppleColors.frostedBorder,
+                AppleShapes.card,
+            )
+            .padding(18.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        icon()
+        Text(title, style = AppleTypography.titleMedium, color = AppleColors.primary)
+        Text(
+            stringResource(
+                if (configured) R.string.web_config_status_configured
+                else R.string.web_config_status_pending,
+            ),
+            style = AppleTypography.bodySmall,
+            color = if (configured) AppleColors.active else AppleColors.tertiary,
+        )
     }
 }
 

--- a/app/src/main/java/com/iblu01/portallauncher/WebConfigServer.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/WebConfigServer.kt
@@ -6,6 +6,15 @@ import org.json.JSONObject
 import java.io.IOException
 import java.security.MessageDigest
 import java.security.SecureRandom
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.URL
+import org.eclipse.paho.client.mqttv3.MqttClient
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
+
+enum class WebConfigSection { HOME_ASSISTANT, MQTT, ALL }
 
 /**
  * Applies a `{entity_id -> enabled}` selection onto [existing], mirroring what the Settings screen's
@@ -44,7 +53,7 @@ class WebConfigServer private constructor(
     port: Int,
     private val prefs: Prefs,
     private val onMqttConfigChanged: () -> Unit,
-    private val onConfigSaved: () -> Unit,
+    private val onConfigSaved: (WebConfigSection) -> Unit,
 ) : NanoHTTPD(BIND_ADDRESS, port) {
 
     val token: String = mintToken()
@@ -68,7 +77,12 @@ class WebConfigServer private constructor(
             when {
                 uri == "/" -> html(WebConfigPage.render(token))
                 uri == "/api/config" && session.method == Method.GET -> json(configJson())
+                uri == "/api/health" && session.method == Method.GET -> json("""{"ok":true}""")
                 uri == "/api/config" && session.method == Method.POST -> applyConfig(readBody(session))
+                uri == "/api/config/ha" && session.method == Method.POST -> applyHomeAssistantConfig(readBody(session))
+                uri == "/api/config/mqtt" && session.method == Method.POST -> applyMqttConfig(readBody(session))
+                uri == "/api/test-ha" && session.method == Method.POST -> testHomeAssistant(readBody(session))
+                uri == "/api/test-mqtt" && session.method == Method.POST -> testMqtt(readBody(session))
                 else -> text(Response.Status.NOT_FOUND, "not found")
             }
         }.getOrElse { failure ->
@@ -113,9 +127,136 @@ class WebConfigServer private constructor(
 
         val after = mqttSignature(prefs.brokerHost, prefs.brokerPort, prefs.username, prefs.password, prefs.deviceName)
         if (after != before) onMqttConfigChanged()
-        onConfigSaved()
+        onConfigSaved(WebConfigSection.ALL)
 
         return json("""{"ok":true}""")
+    }
+
+    private fun applyHomeAssistantConfig(body: String): Response {
+        val payload = runCatching { JSONObject(body) }.getOrNull()
+            ?: return errorJson(Response.Status.BAD_REQUEST, "invalid_json")
+        val haUrl = payload.optString("ha_url").trim().trimEnd('/')
+        val haToken = payload.optString("ha_token").trim()
+        if (!haUrl.startsWith("http://") && !haUrl.startsWith("https://")) {
+            return errorJson(Response.Status.BAD_REQUEST, "invalid_ha_url")
+        }
+        if (haToken.isBlank()) return errorJson(Response.Status.BAD_REQUEST, "token_required")
+        prefs.haUrl = haUrl
+        prefs.haToken = haToken
+        onConfigSaved(WebConfigSection.HOME_ASSISTANT)
+        return json("""{"ok":true}""")
+    }
+
+    private fun applyMqttConfig(body: String): Response {
+        val payload = runCatching { JSONObject(body) }.getOrNull()
+            ?: return errorJson(Response.Status.BAD_REQUEST, "invalid_json")
+        val host = payload.optString("broker_host").trim()
+        val port = payload.optInt("broker_port")
+        if (host.isBlank()) return errorJson(Response.Status.BAD_REQUEST, "invalid_broker_host")
+        if (port !in 1..65535) return errorJson(Response.Status.BAD_REQUEST, "invalid_broker_port")
+        val before = mqttSignature(prefs.brokerHost, prefs.brokerPort, prefs.username, prefs.password, prefs.deviceName)
+        prefs.brokerHost = host
+        prefs.brokerPort = port
+        prefs.username = payload.optString("username").trim()
+        prefs.password = payload.optString("password")
+        prefs.deviceName = payload.optString("device_name").trim().ifBlank { prefs.deviceName }
+        val after = mqttSignature(prefs.brokerHost, prefs.brokerPort, prefs.username, prefs.password, prefs.deviceName)
+        if (after != before) onMqttConfigChanged()
+        onConfigSaved(WebConfigSection.MQTT)
+        return json("""{"ok":true}""")
+    }
+
+    private fun testHomeAssistant(body: String): Response {
+        val payload = runCatching { JSONObject(body) }.getOrNull()
+            ?: return errorJson(Response.Status.BAD_REQUEST, "invalid_json")
+        val rawUrl = payload.optString("ha_url").trim().trimEnd('/')
+        val parsed = runCatching { URL(rawUrl) }.getOrNull()
+            ?.takeIf { it.protocol == "http" || it.protocol == "https" }
+            ?: return errorJson(Response.Status.BAD_REQUEST, "invalid_ha_url")
+        val host = parsed.host.takeIf { it.isNotBlank() }
+            ?: return errorJson(Response.Status.BAD_REQUEST, "invalid_ha_url")
+        val port = if (parsed.port != -1) parsed.port else parsed.defaultPort
+
+        return when (payload.optString("stage")) {
+            "host" -> {
+                val reachable = runCatching { InetAddress.getAllByName(host).isNotEmpty() }.getOrDefault(false)
+                if (reachable) json("""{"ok":true,"stage":"host"}""")
+                else errorJson(Response.Status.BAD_REQUEST, "host_unresolved")
+            }
+            "port" -> {
+                val reachable = runCatching {
+                    Socket().use { it.connect(InetSocketAddress(host, port), HA_TEST_TIMEOUT_MS) }
+                    true
+                }.getOrDefault(false)
+                if (reachable) json("""{"ok":true,"stage":"port"}""")
+                else errorJson(Response.Status.BAD_REQUEST, "port_unreachable")
+            }
+            "token" -> {
+                val accessToken = payload.optString("ha_token").trim()
+                if (accessToken.isBlank()) return errorJson(Response.Status.BAD_REQUEST, "token_required")
+                val result = HaApiClient(rawUrl, accessToken).testConnection()
+                when {
+                    result.ok -> json("""{"ok":true,"stage":"token"}""")
+                    result.statusCode == 401 || result.statusCode == 403 ->
+                        errorJson(Response.Status.BAD_REQUEST, "token_rejected")
+                    else -> errorJson(Response.Status.BAD_REQUEST, "api_unreachable")
+                }
+            }
+            else -> errorJson(Response.Status.BAD_REQUEST, "invalid_stage")
+        }
+    }
+
+    private fun testMqtt(body: String): Response {
+        val payload = runCatching { JSONObject(body) }.getOrNull()
+            ?: return errorJson(Response.Status.BAD_REQUEST, "invalid_json")
+        val host = payload.optString("broker_host").trim()
+        val port = payload.optInt("broker_port")
+        if (host.isBlank()) return errorJson(Response.Status.BAD_REQUEST, "invalid_broker_host")
+        if (port !in 1..65535) return errorJson(Response.Status.BAD_REQUEST, "invalid_broker_port")
+
+        return when (payload.optString("stage")) {
+            "host" -> {
+                val reachable = runCatching { InetAddress.getAllByName(host).isNotEmpty() }.getOrDefault(false)
+                if (reachable) json("""{"ok":true,"stage":"host"}""")
+                else errorJson(Response.Status.BAD_REQUEST, "mqtt_host_unresolved")
+            }
+            "port" -> {
+                val reachable = runCatching {
+                    Socket().use { it.connect(InetSocketAddress(host, port), HA_TEST_TIMEOUT_MS) }
+                    true
+                }.getOrDefault(false)
+                if (reachable) json("""{"ok":true,"stage":"port"}""")
+                else errorJson(Response.Status.BAD_REQUEST, "mqtt_port_unreachable")
+            }
+            "auth" -> {
+                val connected = runCatching {
+                    val client = MqttClient(
+                        "tcp://$host:$port",
+                        "portal-web-test-${System.currentTimeMillis()}",
+                        MemoryPersistence(),
+                    )
+                    client.timeToWait = 8_000L
+                    try {
+                        client.connect(MqttConnectOptions().apply {
+                            isCleanSession = true
+                            connectionTimeout = 6
+                            keepAliveInterval = 10
+                            payload.optString("username").trim().takeIf { it.isNotEmpty() }?.let {
+                                userName = it
+                                password = payload.optString("password").toCharArray()
+                            }
+                        })
+                        true
+                    } finally {
+                        if (client.isConnected) client.disconnect(1_000)
+                        client.close()
+                    }
+                }.getOrDefault(false)
+                if (connected) json("""{"ok":true,"stage":"auth"}""")
+                else errorJson(Response.Status.BAD_REQUEST, "mqtt_auth_failed")
+            }
+            else -> errorJson(Response.Status.BAD_REQUEST, "invalid_stage")
+        }
     }
 
     private fun readBody(session: IHTTPSession): String {
@@ -173,6 +314,7 @@ class WebConfigServer private constructor(
         private const val BIND_ADDRESS = "0.0.0.0"
         private const val PREFERRED_PORT = 8080
         private const val SOCKET_READ_TIMEOUT_MS = 15_000
+        private const val HA_TEST_TIMEOUT_MS = 5_000
 
         /** No O/0 or I/1: the code is read off a screen and typed by hand. */
         private const val ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
@@ -185,7 +327,7 @@ class WebConfigServer private constructor(
         fun launch(
             prefs: Prefs,
             onMqttConfigChanged: () -> Unit,
-            onConfigSaved: () -> Unit = {},
+            onConfigSaved: (WebConfigSection) -> Unit = {},
         ): WebConfigServer? {
             intArrayOf(PREFERRED_PORT, 0).forEach { port ->
                 val server = WebConfigServer(port, prefs, onMqttConfigChanged, onConfigSaved)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
@@ -2,6 +2,7 @@ package com.iblu01.portallauncher.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -45,9 +46,11 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.onLongClick
 import androidx.compose.ui.semantics.role
@@ -246,9 +249,7 @@ fun ClockHeader(
             }
         }
         Spacer(Modifier.height((if (compactScreen) 0.dp else 2.dp) * clockTheme.elementSpacing))
-        Text(
-            text = time,
-            style = AppleTypography.displayLarge.copy(
+        val timeStyle = AppleTypography.displayLarge.copy(
                 fontFamily = clockFontFamily(clockTheme.font, timeWeight),
                 fontSize = clockTheme.size.sp,
                 fontWeight = timeWeight,
@@ -258,16 +259,31 @@ fun ClockHeader(
                     offset = Offset(0f, 2f),
                     blurRadius = 12f
                 )
-            ),
-            color = clockTheme.tint.color,
-            maxLines = 1,
-            softWrap = false,
+            )
+        val timeParts = time.split(':', limit = 2)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
             // Reclaim the date's visual slot as it fades, so the minimal time sits at the same top
             // position it would have had if the date were not in the layout at all.
-            modifier = Modifier.graphicsLayer {
-                translationY = -COMPACT_DATE_LIFT.toPx() * collapse().coerceIn(0f, 1f)
-            },
-        )
+            modifier = Modifier
+                .graphicsLayer {
+                    translationY = -COMPACT_DATE_LIFT.toPx() * collapse().coerceIn(0f, 1f)
+                }
+                .clearAndSetSemantics { contentDescription = time },
+        ) {
+            Text(timeParts.first(), style = timeStyle, color = clockTheme.tint.color, maxLines = 1, softWrap = false)
+            if (timeParts.size == 2) {
+                val fontScale = LocalDensity.current.fontScale
+                val colonWidth = (clockTheme.size * fontScale * 0.18f).dp
+                val colonHeight = (clockTheme.size * fontScale * 0.64f).dp
+                Canvas(Modifier.size(colonWidth, colonHeight)) {
+                    val radius = size.width * 0.30f
+                    drawCircle(clockTheme.tint.color, radius, Offset(size.width / 2f, size.height * 0.34f))
+                    drawCircle(clockTheme.tint.color, radius, Offset(size.width / 2f, size.height * 0.66f))
+                }
+                Text(timeParts.last(), style = timeStyle, color = clockTheme.tint.color, maxLines = 1, softWrap = false)
+            }
+        }
         // Keep these nodes composed throughout the gesture. Removing them when alpha reaches zero
         // causes a structural recomposition and a text remeasure exactly halfway through the swipe.
         if (connected && !useCompactTemperatureHeader) {

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
@@ -198,8 +198,8 @@ fun ClockHeader(
 ) {
 
     val time by rememberClock(if (clockTheme.format24h) "HH:mm" else "h:mm a")
-    val date by rememberClock("EEEE d MMMM")
-    val compactDate by rememberClock("EEE d MMM")
+    val date by rememberClock(clockTheme.dateFormat.fullPattern)
+    val compactDate by rememberClock(clockTheme.dateFormat.compactPattern)
     val compactScreen = rememberCompactClockScreen()
     val useCompactTemperatureHeader = connected && compactScreen
     val compactTemperaturesAvailable = compactIndoorTemperature(

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Text
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.Icons
@@ -47,6 +48,7 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -141,6 +143,17 @@ fun ClockScreen(
             selectedChipKey = selectedChipKey,
             modifier = Modifier.align(Alignment.BottomCenter),
         )
+
+        if (!connected) {
+            ConnectionProblemBanner(
+                lastUpdateAt = lastUpdateAt,
+                usesMdnsAddress = false,
+                onClick = onTap,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(horizontal = 20.dp, vertical = 18.dp),
+            )
+        }
     }
 }
 
@@ -182,7 +195,7 @@ private fun rememberCompactClockScreen(): Boolean {
 }
 
 /**
- * The clock block (date, time, weather pill, stale banner). Pinned above the pager, it shrinks
+ * The clock block (date, time and weather pill). Pinned above the pager, it shrinks
  * toward the top as [collapse] goes 0→1 so the apps grid gets the room back.
  *
  * The shrink is a pure [graphicsLayer] transform (GPU, no relayout) — the Portal is API 28 with a
@@ -334,12 +347,6 @@ fun ClockHeader(
             ) {
                 Text(stringResource(R.string.clock_indoor_temp_format, temperatures.indoorMin, temperatures.indoorMax), style = AppleTypography.bodySmall.copy(fontSize = 15.sp), color = AppleColors.primary)
                 Text(stringResource(R.string.clock_outdoor_temp_format, temperatures.outdoor.takeUnless { it == "—" } ?: weather.temp), style = AppleTypography.bodySmall.copy(fontSize = 15.sp), color = AppleColors.secondary)
-            }
-        }
-        if (!connected && lastUpdateAt > 0L) {
-            Spacer(Modifier.height(8.dp * clockTheme.elementSpacing))
-            Box(Modifier.graphicsLayer { alpha = clockDetailAlpha(collapse()) }) {
-                StaleBanner(lastUpdateAt = lastUpdateAt)
             }
         }
     }
@@ -626,24 +633,46 @@ internal fun trayPillAccessibilityLabel(context: android.content.Context, pill: 
 }
 
 @Composable
-private fun StaleBanner(lastUpdateAt: Long) {
+fun ConnectionProblemBanner(
+    lastUpdateAt: Long,
+    usesMdnsAddress: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val elapsed by produceState(initialValue = 0L, lastUpdateAt) {
         while (true) {
-            value = (System.currentTimeMillis() - lastUpdateAt) / 1000L
+            value = if (lastUpdateAt > 0L) {
+                ((System.currentTimeMillis() - lastUpdateAt) / 1000L).coerceAtLeast(0L)
+            } else 0L
             kotlinx.coroutines.delay(1_000L)
         }
     }
     val ago = if (elapsed < 60) "${elapsed}s" else "${elapsed / 60}min"
-    Row(
-        modifier = Modifier.clip(AppleShapes.pill)
-            .background(Color(0x33FF9F0A), AppleShapes.pill)
-            .border(0.5.dp, Color(0x66FF9F0A), AppleShapes.pill)
-            .padding(horizontal = 14.dp, vertical = 5.dp),
+    Column(
+        modifier = modifier
+            .widthIn(max = 620.dp)
+            .fillMaxWidth()
+            .clip(AppleShapes.panel)
+            .background(Color(0xE6221B12), AppleShapes.panel)
+            .border(0.5.dp, Color(0x99FF9F0A), AppleShapes.panel)
+            .appleClickable(onClick)
+            .testTag("connectionProblemBanner")
+            .padding(horizontal = 18.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
     ) {
         Text(
-            stringResource(R.string.clock_stale_banner_format, ago),
-            style = AppleTypography.bodySmall.copy(fontSize = 13.sp),
+            if (lastUpdateAt > 0L) stringResource(R.string.clock_stale_banner_format, ago)
+            else stringResource(R.string.connection_banner_unreachable),
+            style = AppleTypography.titleMedium,
             color = Color(0xFFFFC062),
+        )
+        Text(
+            stringResource(
+                if (usesMdnsAddress) R.string.connection_banner_mdns_hint
+                else R.string.connection_banner_generic_hint,
+            ),
+            style = AppleTypography.bodySmall,
+            color = AppleColors.secondary,
         )
     }
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/ClockScreen.kt
@@ -271,7 +271,14 @@ fun ClockHeader(
                 }
                 .clearAndSetSemantics { contentDescription = time },
         ) {
-            Text(timeParts.first(), style = timeStyle, color = clockTheme.tint.color, maxLines = 1, softWrap = false)
+            Text(
+                timeParts.first(),
+                style = timeStyle,
+                color = clockTheme.tint.color,
+                maxLines = 1,
+                softWrap = false,
+                modifier = Modifier.alignByBaseline(),
+            )
             if (timeParts.size == 2) {
                 val fontScale = LocalDensity.current.fontScale
                 val colonWidth = (clockTheme.size * fontScale * 0.18f).dp
@@ -281,7 +288,33 @@ fun ClockHeader(
                     drawCircle(clockTheme.tint.color, radius, Offset(size.width / 2f, size.height * 0.34f))
                     drawCircle(clockTheme.tint.color, radius, Offset(size.width / 2f, size.height * 0.66f))
                 }
-                Text(timeParts.last(), style = timeStyle, color = clockTheme.tint.color, maxLines = 1, softWrap = false)
+                val trailing = timeParts.last()
+                val suffixStart = trailing.lastIndexOf(' ').takeIf { it >= 0 }
+                val minute = suffixStart?.let { trailing.substring(0, it) } ?: trailing
+                val dayPeriod = suffixStart?.let { trailing.substring(it + 1) }
+                Text(
+                    minute,
+                    style = timeStyle,
+                    color = clockTheme.tint.color,
+                    maxLines = 1,
+                    softWrap = false,
+                    modifier = Modifier.alignByBaseline(),
+                )
+                if (!dayPeriod.isNullOrBlank()) {
+                    Text(
+                        dayPeriod,
+                        style = timeStyle.copy(
+                            fontSize = (clockTheme.size * 0.28f).sp,
+                            letterSpacing = 0.sp,
+                        ),
+                        color = clockTheme.tint.color.copy(alpha = 0.78f),
+                        maxLines = 1,
+                        softWrap = false,
+                        modifier = Modifier
+                            .alignByBaseline()
+                            .padding(start = 6.dp),
+                    )
+                }
             }
         }
         // Keep these nodes composed throughout the gesture. Removing them when alpha reaches zero

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/FolderDialog.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/FolderDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -30,6 +31,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.dialog
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iblu01.portallauncher.R
@@ -74,13 +77,18 @@ fun FolderDialog(
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
-            ) { onDismiss() }
+                onClick = onDismiss,
+            )
+            .semantics { dialog() }
             .testTag("folderDialog"),
         contentAlignment = Alignment.Center,
     ) {
         Column(
             modifier = Modifier
-                .width(360.dp)
+                .padding(24.dp)
+                .widthIn(max = 360.dp)
+                .fillMaxWidth()
+                .heightIn(max = 560.dp)
                 .clip(AppleShapes.panel)
                 .background(AppleColors.elevated.copy(alpha = 0.97f), AppleShapes.panel)
                 .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.panel)
@@ -140,7 +148,9 @@ fun FolderDialog(
 
             LazyVerticalGrid(
                 columns = GridCells.Adaptive(minSize = 84.dp),
-                modifier = Modifier.heightIn(max = 320.dp).padding(horizontal = 12.dp),
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .padding(horizontal = 12.dp),
             ) {
                 items(folder.folderMembers, key = { it.key }) { member ->
                     Box(contentAlignment = Alignment.Center) {

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/HiddenAppsDialog.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/HiddenAppsDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
@@ -28,6 +29,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.semantics.dialog
+import androidx.compose.ui.semantics.semantics
 import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.ui.apps.GridItem
 import com.iblu01.portallauncher.ui.theme.AppleColors
@@ -55,12 +58,17 @@ fun HiddenAppsDialog(
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
-            ) { onDismiss() },
+                onClick = onDismiss,
+            )
+            .semantics { dialog() },
         contentAlignment = Alignment.Center,
     ) {
         Column(
             modifier = Modifier
-                .width(320.dp)
+                .padding(24.dp)
+                .widthIn(max = 320.dp)
+                .fillMaxWidth()
+                .heightIn(max = 560.dp)
                 .clip(AppleShapes.panel)
                 .background(AppleColors.elevated.copy(alpha = 0.97f), AppleShapes.panel)
                 .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.panel)
@@ -78,7 +86,7 @@ fun HiddenAppsDialog(
                 color = AppleColors.tertiary,
                 modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 8.dp),
             )
-            LazyColumn(modifier = Modifier.heightIn(max = 320.dp)) {
+            LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
                 items(items, key = { it.key }) { item ->
                     Row(
                         modifier = Modifier

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/Interactions.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/Interactions.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -14,7 +15,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.onLongClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import com.iblu01.portallauncher.ui.theme.AppleMotion
 
 /**
@@ -56,6 +67,7 @@ fun Modifier.nonConsumingClickable(onClick: () -> Unit): Modifier {
     val interaction = remember { MutableInteractionSource() }
     return this
         .pressScale(interaction)
+        .accessibleActivation(onClick)
         .pointerInput(onClick) {
             val longPressTimeout = viewConfiguration.longPressTimeoutMillis
             awaitEachGesture {
@@ -83,6 +95,7 @@ fun Modifier.appleClickable(onClick: () -> Unit, onLongPress: (() -> Unit)?): Mo
     val interaction = remember { MutableInteractionSource() }
     return this
         .pressScale(interaction)
+        .accessibleActivation(onClick, onLongPress)
         .pointerInput(onClick, onLongPress) {
             detectTapGestures(
                 onPress = { offset ->
@@ -99,3 +112,35 @@ fun Modifier.appleClickable(onClick: () -> Unit, onLongPress: (() -> Unit)?): Mo
             )
         }
 }
+
+/** Adds accessibility-service and hardware-key activation without changing pointer consumption. */
+private fun Modifier.accessibleActivation(
+    onClickAction: () -> Unit,
+    onLongClickAction: (() -> Unit)? = null,
+): Modifier = this
+    .semantics(mergeDescendants = true) {
+        role = Role.Button
+        onClick {
+            onClickAction()
+            true
+        }
+        onLongClickAction?.let { action ->
+            onLongClick {
+                action()
+                true
+            }
+        }
+    }
+    .onKeyEvent { event ->
+        val activationKey = event.key == Key.Enter ||
+            event.key == Key.NumPadEnter ||
+            event.key == Key.DirectionCenter ||
+            event.key == Key.Spacebar
+        if (activationKey && event.type == KeyEventType.KeyUp) {
+            onClickAction()
+            true
+        } else {
+            false
+        }
+    }
+    .focusable()

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/IosSwitch.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/IosSwitch.kt
@@ -3,8 +3,8 @@ package com.iblu01.portallauncher.ui.components
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -17,8 +17,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.minimumInteractiveComponentSize
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleMotion
 import com.iblu01.portallauncher.ui.theme.PortalTheme
@@ -51,22 +53,31 @@ fun IosSwitch(
 
     Box(
         modifier = modifier
-            .size(trackWidth, trackHeight)
-            .background(trackColor, CircleShape)
-            .clickable(
+            .minimumInteractiveComponentSize()
+            .toggleable(
+                value = checked,
+                role = Role.Switch,
                 interactionSource = remember { MutableInteractionSource() },
-                indication = null
-            ) { onCheckedChange(!checked) }
-            .padding(2.dp),
-        contentAlignment = Alignment.CenterStart
+                indication = null,
+                onValueChange = onCheckedChange,
+            ),
+        contentAlignment = Alignment.Center,
     ) {
         Box(
             modifier = Modifier
-                .offset(x = thumbOffset)
-                .size(thumbSize)
-                .shadow(2.dp, CircleShape, spotColor = Color.Black.copy(alpha = 0.2f))
-                .background(Color.White, CircleShape)
-        )
+                .size(trackWidth, trackHeight)
+                .background(trackColor, CircleShape)
+                .padding(2.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            Box(
+                modifier = Modifier
+                    .offset(x = thumbOffset)
+                    .size(thumbSize)
+                    .shadow(2.dp, CircleShape, spotColor = Color.Black.copy(alpha = 0.2f))
+                    .background(Color.White, CircleShape)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/QuickActionsOverlay.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/QuickActionsOverlay.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Settings
@@ -45,6 +46,8 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.dialog
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.iblu01.portallauncher.R
@@ -87,7 +90,7 @@ fun QuickActionsOverlay(
         var backdropRect by remember { mutableStateOf(Rect.Zero) }
         var panelRect by remember { mutableStateOf(Rect.Zero) }
 
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize().semantics { dialog() }) {
             // Blurred, dimmed backdrop — a SIBLING of the panel so the blur never
             // bleeds onto the menu. Tapping outside the panel dismisses.
             Box(
@@ -110,7 +113,9 @@ fun QuickActionsOverlay(
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Column(
                 modifier = Modifier
-                    .width(320.dp)
+                    .padding(24.dp)
+                    .widthIn(max = 320.dp)
+                    .fillMaxWidth()
                     .clip(AppleShapes.panel)
                     .background(AppleColors.elevated.copy(alpha = 0.96f), AppleShapes.panel)
                     .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.panel)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/SettingsComponents.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/SettingsComponents.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
@@ -254,9 +255,10 @@ fun SettingsSearchField(
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    placeholder: String = "Rechercher…",
+    placeholder: String? = null,
     container: Color = AppleColors.elevated,
 ) {
+    val resolvedPlaceholder = placeholder ?: stringResource(R.string.search_placeholder)
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -283,7 +285,7 @@ fun SettingsSearchField(
                 modifier = Modifier.weight(1f),
                 decorationBox = { inner ->
                     if (value.isEmpty()) {
-                        Text(placeholder, style = AppleTypography.titleMedium, color = AppleColors.tertiary)
+                        Text(resolvedPlaceholder, style = AppleTypography.titleMedium, color = AppleColors.tertiary)
                     }
                     inner()
                 }
@@ -305,8 +307,10 @@ fun SettingsInfoDialog(
     ) {
         Surface(
             modifier = Modifier
-                .fillMaxWidth()
                 .padding(24.dp)
+                .widthIn(max = 720.dp)
+                .fillMaxWidth()
+                .heightIn(max = 560.dp)
                 .clip(AppleShapes.panel)
                 .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.panel),
             color = AppleColors.elevated,
@@ -319,16 +323,18 @@ fun SettingsInfoDialog(
                     color = AppleColors.primary,
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
-                lines.forEach { line ->
-                    Text(
-                        line,
-                        style = AppleTypography.bodyMedium,
-                        color = AppleColors.secondary,
-                        modifier = Modifier.padding(bottom = 8.dp)
-                    )
+                LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
+                    items(lines) { line ->
+                        Text(
+                            line,
+                            style = AppleTypography.bodyMedium,
+                            color = AppleColors.secondary,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                    }
                 }
                 Spacer(Modifier.height(8.dp))
-                PillButton(label = "OK", primary = true, onClick = onDismiss)
+                PillButton(label = stringResource(R.string.dialog_button_ok), primary = true, onClick = onDismiss)
             }
         }
     }
@@ -629,8 +635,10 @@ fun AppPickerDialog(
     ) {
         Surface(
             modifier = Modifier
-                .fillMaxWidth()
                 .padding(24.dp)
+                .widthIn(max = 720.dp)
+                .fillMaxWidth()
+                .heightIn(max = 560.dp)
                 .clip(AppleShapes.panel)
                 .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.panel),
             color = AppleColors.elevated,
@@ -638,7 +646,7 @@ fun AppPickerDialog(
         ) {
             Column(modifier = Modifier.padding(20.dp)) {
                 Text(
-                    "Choisir une application",
+                    stringResource(R.string.app_picker_title),
                     style = AppleTypography.titleLarge,
                     color = AppleColors.primary,
                     modifier = Modifier.padding(bottom = 16.dp)
@@ -685,7 +693,7 @@ fun AppPickerDialog(
                     )
                 } else {
                     LazyColumn(
-                        modifier = Modifier.heightIn(max = 400.dp)
+                        modifier = Modifier.weight(1f, fill = false)
                     ) {
                         items(filtered, key = { it.packageName }) { app ->
                             val isSelected = app.packageName == selectedPackage
@@ -749,8 +757,10 @@ fun HaDiscoveryDialog(
     ) {
         Surface(
             modifier = Modifier
-                .fillMaxWidth()
                 .padding(24.dp)
+                .widthIn(max = 720.dp)
+                .fillMaxWidth()
+                .heightIn(max = 560.dp)
                 .clip(AppleShapes.panel)
                 .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.panel),
             color = AppleColors.elevated,
@@ -771,7 +781,7 @@ fun HaDiscoveryDialog(
                         modifier = Modifier.padding(vertical = 16.dp)
                     )
                 } else {
-                    LazyColumn(modifier = Modifier.heightIn(max = 400.dp)) {
+                    LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
                         items(instances, key = { it.url }) { instance ->
                             Row(
                                 modifier = Modifier

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherCard.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherCard.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.setValue
 import com.iblu01.portallauncher.domain.model.ForecastPoint
 import com.iblu01.portallauncher.HaEntity
 import com.iblu01.portallauncher.PillRepository
+import com.iblu01.portallauncher.TemperatureUnit
+import com.iblu01.portallauncher.toTemperatureUnit
 import java.util.Calendar
 import java.util.Locale
 import java.util.concurrent.Executors
@@ -24,6 +26,7 @@ data class WeatherUi(
     val glyph: WeatherGlyph = WeatherGlyph(),
     val hourly: List<ForecastPoint> = emptyList(),
     val daily: List<ForecastPoint> = emptyList(),
+    val temperatureUnit: String = TemperatureUnit.CELSIUS.symbol,
 )
 
 /**
@@ -40,25 +43,34 @@ class WeatherController(private val context: Context, private val pills: PillRep
         Thread(task, "weather-city").apply { isDaemon = true }
     }
     private var resolvedCity = ""
-    private var attemptedCoordinates: String? = null
+    private var attemptedLocationKey: String? = null
 
     fun start() { pills.addListener(listener) }
     fun stop() { pills.removeListener(listener) }
     fun refreshNow() = rebuild()
 
     private fun rebuild() {
-        val entity = pills.weatherEntityId?.let { pills.latestStates[it] } ?: return
+        val entity = pills.weatherEntityId?.let { pills.latestStates[it] }
+        if (entity == null) {
+            state = WeatherUi()
+            return
+        }
         val condition = entity.state
         val temp = entity.attributes.optDouble("temperature").let { if (it.isNaN()) null else it }
+        val unit = entity.attributes.optString("temperature_unit").toTemperatureUnit()
+            ?: TemperatureUnit.CELSIUS
         state = WeatherUi(
-            temp = temp?.let { "${it.roundToInt()}°" } ?: "--°",
+            temp = temp?.let { "${it.roundToInt()}${unit.symbol}" } ?: "--${unit.symbol}",
             city = explicitWeatherCity(entity).ifBlank { resolvedCity },
             condition = weatherLabel(context, condition),
             glyph = weatherGlyph(condition, isNight()),
             hourly = pills.hourlyForecast,
             daily = pills.dailyForecast,
+            temperatureUnit = unit.symbol,
         )
-        if (state.city.isBlank()) resolveHomeCity()
+        // Check the location key even while HA exposes an explicit city. If that attribute is
+        // removed later, the reverse-geocoded fallback must already belong to this server/home.
+        resolveHomeCity()
     }
 
     private fun isNight(): Boolean {
@@ -71,14 +83,24 @@ class WeatherController(private val context: Context, private val pills: PillRep
         val latitude = home.attributes.optDouble("latitude", Double.NaN)
         val longitude = home.attributes.optDouble("longitude", Double.NaN)
         if (latitude.isNaN() || longitude.isNaN()) return
-        val key = "$latitude,$longitude"
-        if (attemptedCoordinates == key) return
-        attemptedCoordinates = key
+        val key = "${pills.connectionGeneration}:$latitude,$longitude"
+        if (attemptedLocationKey == key) return
+        if (attemptedLocationKey != null) {
+            resolvedCity = ""
+            if (explicitWeatherCity(pills.weatherEntityId?.let { pills.latestStates[it] } ?: return).isBlank()) {
+                state = state.copy(city = "")
+            }
+        }
+        attemptedLocationKey = key
         cityExecutor.execute {
             val city = reverseGeocodeCity(context, latitude, longitude)
             if (city.isNotBlank()) mainHandler.post {
+                if (attemptedLocationKey != key) return@post
                 resolvedCity = city
-                if (state.city.isBlank()) state = state.copy(city = city)
+                val currentEntity = pills.weatherEntityId?.let { pills.latestStates[it] }
+                if (currentEntity == null || explicitWeatherCity(currentEntity).isBlank()) {
+                    state = state.copy(city = city)
+                }
             }
         }
     }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherCard.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherCard.kt
@@ -1,6 +1,9 @@
 package com.iblu01.portallauncher.ui.components
 
 import android.content.Context
+import android.location.Geocoder
+import android.os.Handler
+import android.os.Looper
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -8,6 +11,8 @@ import com.iblu01.portallauncher.domain.model.ForecastPoint
 import com.iblu01.portallauncher.HaEntity
 import com.iblu01.portallauncher.PillRepository
 import java.util.Calendar
+import java.util.Locale
+import java.util.concurrent.Executors
 import kotlin.math.roundToInt
 
 /** UI snapshot shown on the clock screen, sourced from the Home Assistant weather entity. */
@@ -30,6 +35,12 @@ class WeatherController(private val context: Context, private val pills: PillRep
         private set
 
     private val listener = PillRepository.Listener { rebuild() }
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val cityExecutor = Executors.newSingleThreadExecutor { task ->
+        Thread(task, "weather-city").apply { isDaemon = true }
+    }
+    private var resolvedCity = ""
+    private var attemptedCoordinates: String? = null
 
     fun start() { pills.addListener(listener) }
     fun stop() { pills.removeListener(listener) }
@@ -41,26 +52,59 @@ class WeatherController(private val context: Context, private val pills: PillRep
         val temp = entity.attributes.optDouble("temperature").let { if (it.isNaN()) null else it }
         state = WeatherUi(
             temp = temp?.let { "${it.roundToInt()}°" } ?: "--°",
-            city = weatherCity(entity),
+            city = explicitWeatherCity(entity).ifBlank { resolvedCity },
             condition = weatherLabel(context, condition),
             glyph = weatherGlyph(condition, isNight()),
             hourly = pills.hourlyForecast,
             daily = pills.dailyForecast,
         )
+        if (state.city.isBlank()) resolveHomeCity()
     }
 
     private fun isNight(): Boolean {
         val h = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
         return h < 7 || h >= 21
     }
+
+    private fun resolveHomeCity() {
+        val home = pills.latestStates["zone.home"] ?: return
+        val latitude = home.attributes.optDouble("latitude", Double.NaN)
+        val longitude = home.attributes.optDouble("longitude", Double.NaN)
+        if (latitude.isNaN() || longitude.isNaN()) return
+        val key = "$latitude,$longitude"
+        if (attemptedCoordinates == key) return
+        attemptedCoordinates = key
+        cityExecutor.execute {
+            val city = reverseGeocodeCity(context, latitude, longitude)
+            if (city.isNotBlank()) mainHandler.post {
+                resolvedCity = city
+                if (state.city.isBlank()) state = state.copy(city = city)
+            }
+        }
+    }
 }
 
-/** HA integrations may expose the place explicitly or use the entity's display name for it. */
-internal fun weatherCity(entity: HaEntity): String =
-    sequenceOf("city", "location", "friendly_name")
+/** Only real location attributes qualify; an entity name such as "Forecast Home" does not. */
+internal fun explicitWeatherCity(entity: HaEntity): String =
+    sequenceOf("city", "location")
         .map { entity.attributes.optString(it).trim() }
         .firstOrNull { it.isNotBlank() }
         .orEmpty()
+
+@Suppress("DEPRECATION")
+internal fun reverseGeocodeCity(context: Context, latitude: Double, longitude: Double): String {
+    if (!Geocoder.isPresent()) return ""
+    return runCatching {
+        Geocoder(context, Locale.getDefault())
+            .getFromLocation(latitude, longitude, 1)
+            ?.firstOrNull()
+            ?.let { address ->
+                sequenceOf(address.locality, address.subAdminArea, address.adminArea)
+                    .firstOrNull { !it.isNullOrBlank() }
+                    .orEmpty()
+            }
+    }.getOrNull().orEmpty()
+}
 
 /** Home Assistant condition → bundled Meteocons asset. */
 fun weatherGlyph(condition: String, night: Boolean): WeatherGlyph = when (condition.lowercase()) {

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherCard.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.iblu01.portallauncher.domain.model.ForecastPoint
+import com.iblu01.portallauncher.HaEntity
 import com.iblu01.portallauncher.PillRepository
 import java.util.Calendar
 import kotlin.math.roundToInt
@@ -40,6 +41,7 @@ class WeatherController(private val context: Context, private val pills: PillRep
         val temp = entity.attributes.optDouble("temperature").let { if (it.isNaN()) null else it }
         state = WeatherUi(
             temp = temp?.let { "${it.roundToInt()}°" } ?: "--°",
+            city = weatherCity(entity),
             condition = weatherLabel(context, condition),
             glyph = weatherGlyph(condition, isNight()),
             hourly = pills.hourlyForecast,
@@ -52,6 +54,13 @@ class WeatherController(private val context: Context, private val pills: PillRep
         return h < 7 || h >= 21
     }
 }
+
+/** HA integrations may expose the place explicitly or use the entity's display name for it. */
+internal fun weatherCity(entity: HaEntity): String =
+    sequenceOf("city", "location", "friendly_name")
+        .map { entity.attributes.optString(it).trim() }
+        .firstOrNull { it.isNotBlank() }
+        .orEmpty()
 
 /** Home Assistant condition → bundled Meteocons asset. */
 fun weatherGlyph(condition: String, night: Boolean): WeatherGlyph = when (condition.lowercase()) {

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherPanel.kt
@@ -210,6 +210,13 @@ private fun WeatherSummary(
                     color = AppleColors.secondary,
                 )
             }
+            if (weather.city.isNotBlank()) {
+                Text(
+                    weather.city,
+                    style = AppleTypography.bodyLarge.copy(fontSize = 17.sp),
+                    color = AppleColors.secondary,
+                )
+            }
         }
     } else {
         Row(
@@ -229,6 +236,9 @@ private fun WeatherSummary(
                 )
                 if (showCondition && weather.condition.isNotBlank()) {
                     Text(weather.condition, style = AppleTypography.bodyLarge, color = AppleColors.secondary)
+                }
+                if (weather.city.isNotBlank()) {
+                    Text(weather.city, style = AppleTypography.bodyLarge, color = AppleColors.secondary)
                 }
             }
         }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherPanel.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/WeatherPanel.kt
@@ -42,6 +42,12 @@ import com.iblu01.portallauncher.ui.theme.AppleShapes
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 import com.iblu01.portallauncher.R
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
+import com.iblu01.portallauncher.Prefs
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
 import kotlin.math.roundToInt
 
 /** Side panel opened from the clock's temperature pill: current condition + hourly & daily forecast. */
@@ -205,7 +211,7 @@ private fun WeatherSummary(
                         R.string.weather_today_range_format,
                         minimum.roundToInt(),
                         weather.daily.first().temp.roundToInt(),
-                    ),
+                    ).replace("°", weather.temperatureUnit),
                     style = AppleTypography.bodyLarge.copy(fontSize = 17.sp),
                     color = AppleColors.secondary,
                 )
@@ -266,6 +272,7 @@ private fun WeatherForecastSections(
     compactRows: Boolean,
     page: ForecastPage,
 ) {
+    val format24h = Prefs(LocalContext.current).clockTheme.format24h
     if (disclosure.emphasizeSummary && weather.hourly.isNotEmpty() && weather.daily.isNotEmpty()) {
         CompactForecastSwitcher(weather, disclosure, page)
         return
@@ -281,7 +288,9 @@ private fun WeatherForecastSections(
                 Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(if (compactRows) 14.dp else 18.dp),
             ) {
-                weather.hourly.take(disclosure.hourlyCount).forEach { HourTile(it, disclosure.emphasizeSummary) }
+                weather.hourly.take(disclosure.hourlyCount).forEach {
+                    HourTile(it, disclosure.emphasizeSummary, format24h, weather.temperatureUnit)
+                }
             }
         }
     }
@@ -292,7 +301,7 @@ private fun WeatherForecastSections(
                 style = AppleTypography.labelSmall.copy(fontSize = if (disclosure.emphasizeSummary) 14.sp else 12.sp),
                 color = AppleColors.tertiary,
             )
-            weather.daily.take(disclosure.dailyCount).forEach { DayRow(it, disclosure.emphasizeSummary) }
+            weather.daily.take(disclosure.dailyCount).forEach { DayRow(it, disclosure.emphasizeSummary, weather.temperatureUnit) }
         }
     }
 }
@@ -301,6 +310,7 @@ private enum class ForecastPage { HOURLY, DAILY }
 
 @Composable
 private fun CompactForecastSwitcher(weather: WeatherUi, disclosure: WeatherDisclosure, page: ForecastPage) {
+    val format24h = Prefs(LocalContext.current).clockTheme.format24h
     BoxWithConstraints(Modifier.fillMaxSize()) {
             val visibleItems = when (page) {
                 ForecastPage.HOURLY -> disclosure.hourlyCount
@@ -315,12 +325,12 @@ private fun CompactForecastSwitcher(weather: WeatherUi, disclosure: WeatherDiscl
                 when (page) {
                     ForecastPage.HOURLY -> weather.hourly.forEach { point ->
                         Box(Modifier.size(width = itemWidth, height = itemHeight), contentAlignment = Alignment.Center) {
-                            HourTile(point, enlarged = true)
+                            HourTile(point, enlarged = true, format24h = format24h, unit = weather.temperatureUnit)
                         }
                     }
                     ForecastPage.DAILY -> weather.daily.forEach { point ->
                         Box(Modifier.size(width = itemWidth, height = itemHeight), contentAlignment = Alignment.Center) {
-                            DayTile(point)
+                            DayTile(point, weather.temperatureUnit)
                         }
                     }
                 }
@@ -369,25 +379,25 @@ private fun ForecastPageButton(label: String, selected: Boolean, onClick: () -> 
 }
 
 @Composable
-private fun HourTile(p: ForecastPoint, enlarged: Boolean) {
+private fun HourTile(p: ForecastPoint, enlarged: Boolean, format24h: Boolean, unit: String) {
     Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(if (enlarged) 7.dp else 6.dp)) {
-        Text(forecastPointLabel(p.datetime, hourly = true), style = AppleTypography.bodySmall.copy(fontSize = if (enlarged) 14.sp else 12.sp), color = AppleColors.secondary)
+        Text(forecastPointLabel(p.datetime, hourly = true, format24h = format24h), style = AppleTypography.bodySmall.copy(fontSize = if (enlarged) 14.sp else 12.sp), color = AppleColors.secondary)
         WeatherIcon(weatherGlyph(p.condition, night = false), Modifier.size(if (enlarged) 40.dp else 30.dp))
-        Text("${p.temp.roundToInt()}°", style = AppleTypography.bodyLarge.copy(fontSize = if (enlarged) 20.sp else 17.sp), color = AppleColors.primary)
+        Text("${p.temp.roundToInt()}$unit", style = AppleTypography.bodyLarge.copy(fontSize = if (enlarged) 20.sp else 17.sp), color = AppleColors.primary)
     }
 }
 
 @Composable
-private fun DayTile(p: ForecastPoint) {
+private fun DayTile(p: ForecastPoint, unit: String) {
     Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(10.dp)) {
         Text(
-            forecastPointLabel(p.datetime, hourly = false),
+            forecastPointLabel(p.datetime, hourly = false, format24h = true),
             style = AppleTypography.bodyLarge.copy(fontSize = 18.sp),
             color = AppleColors.primary,
         )
         WeatherIcon(weatherGlyph(p.condition, night = false), Modifier.size(54.dp))
         Text(
-            p.tempLow?.let { "${p.temp.roundToInt()}° / ${it.roundToInt()}°" } ?: "${p.temp.roundToInt()}°",
+            p.tempLow?.let { "${p.temp.roundToInt()}$unit / ${it.roundToInt()}$unit" } ?: "${p.temp.roundToInt()}$unit",
             style = AppleTypography.bodyLarge.copy(fontSize = 20.sp),
             color = AppleColors.secondary,
         )
@@ -395,23 +405,28 @@ private fun DayTile(p: ForecastPoint) {
 }
 
 @Composable
-private fun DayRow(p: ForecastPoint, enlarged: Boolean) {
+private fun DayRow(p: ForecastPoint, enlarged: Boolean, unit: String) {
     Row(
         Modifier.fillMaxWidth().padding(vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(forecastPointLabel(p.datetime, hourly = false), style = AppleTypography.bodyLarge.copy(fontSize = if (enlarged) 19.sp else 17.sp), color = AppleColors.primary, modifier = Modifier.weight(1f))
+        Text(forecastPointLabel(p.datetime, hourly = false, format24h = true), style = AppleTypography.bodyLarge.copy(fontSize = if (enlarged) 19.sp else 17.sp), color = AppleColors.primary, modifier = Modifier.weight(1f))
         WeatherIcon(weatherGlyph(p.condition, night = false), Modifier.size(if (enlarged) 38.dp else 28.dp))
         Spacer(Modifier.size(16.dp))
         Text(
-            p.tempLow?.let { "${p.temp.roundToInt()}° / ${it.roundToInt()}°" } ?: "${p.temp.roundToInt()}°",
+            p.tempLow?.let { "${p.temp.roundToInt()}$unit / ${it.roundToInt()}$unit" } ?: "${p.temp.roundToInt()}$unit",
             style = AppleTypography.bodyLarge.copy(fontSize = if (enlarged) 19.sp else 17.sp), color = AppleColors.secondary,
         )
     }
 }
 
-private fun forecastPointLabel(datetime: String, hourly: Boolean): String = runCatching {
-    val odt = java.time.OffsetDateTime.parse(datetime)
-    if (hourly) "${odt.hour}h"
-    else odt.dayOfWeek.getDisplayName(java.time.format.TextStyle.SHORT, java.util.Locale.getDefault()).replaceFirstChar { it.uppercase() }
+internal fun forecastPointLabel(
+    datetime: String,
+    hourly: Boolean,
+    format24h: Boolean,
+    locale: Locale = Locale.getDefault(),
+): String = runCatching {
+    val local = java.time.OffsetDateTime.parse(datetime).atZoneSameInstant(ZoneId.systemDefault())
+    if (hourly) DateTimeFormatter.ofPattern(if (format24h) "HH:mm" else "h a", locale).format(local)
+    else local.dayOfWeek.getDisplayName(TextStyle.SHORT, locale).replaceFirstChar { it.titlecase(locale) }
 }.getOrDefault("")

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/WidgetPickerDialog.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/WidgetPickerDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -32,6 +33,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.dialog
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -63,12 +66,17 @@ fun WidgetPickerDialog(
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
-            ) { onDismiss() },
+                onClick = onDismiss,
+            )
+            .semantics { dialog() },
         contentAlignment = Alignment.Center,
     ) {
         Column(
             modifier = Modifier
-                .width(360.dp)
+                .padding(24.dp)
+                .widthIn(max = 360.dp)
+                .fillMaxWidth()
+                .heightIn(max = 560.dp)
                 .clip(AppleShapes.panel)
                 .background(AppleColors.elevated.copy(alpha = 0.97f), AppleShapes.panel)
                 .border(0.5.dp, AppleColors.frostedBorder, AppleShapes.panel)
@@ -87,7 +95,7 @@ fun WidgetPickerDialog(
                 color = AppleColors.tertiary,
                 modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 8.dp),
             )
-            LazyColumn(modifier = Modifier.heightIn(max = 360.dp)) {
+            LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
                 items(offers, key = { it.key }) { offer ->
                     Row(
                         modifier = Modifier

--- a/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/components/controls/PortalControls.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.aspectRatio
@@ -53,9 +54,24 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -252,7 +268,15 @@ fun VerticalFillSlider(
             .clip(shape)
             .background(trackColor)
             .border(0.5.dp, AppleColors.frostedBorder, shape)
-            .semantics { contentDescription = "Curseur ${(fraction * 100).roundToInt()} pour cent" }
+            .semantics {
+                progressBarRangeInfo = ProgressBarRangeInfo(value.coerceIn(valueRange), valueRange)
+                if (!enabled) disabled()
+                else setProgress { requested ->
+                    commit(fractionOf(requested.coerceIn(valueRange), valueRange), finished = true)
+                    true
+                }
+            }
+            .focusable(enabled)
             .then(
                 if (!enabled) Modifier else Modifier.pointerInput(origin, valueRange) {
                     fun fracAt(y: Float): Float {
@@ -465,7 +489,15 @@ fun VerticalGradientSlider(
                 alpha = if (enabled) 1f else 0.4f,
             )
             .border(0.5.dp, AppleColors.frostedBorder, shape)
-            .semantics { contentDescription = "Curseur ${(fraction * 100).roundToInt()} pour cent" }
+            .semantics {
+                progressBarRangeInfo = ProgressBarRangeInfo(value.coerceIn(valueRange), valueRange)
+                if (!enabled) disabled()
+                else setProgress { requested ->
+                    commit(fractionOf(requested.coerceIn(valueRange), valueRange), finished = true)
+                    true
+                }
+            }
+            .focusable(enabled)
             .then(
                 if (!enabled) Modifier else Modifier.pointerInput(valueRange) {
                     fun fracAt(y: Float): Float = 1f - (y / size.height).coerceIn(0f, 1f)
@@ -746,7 +778,23 @@ fun <T> VerticalSegmentedSelector(
                     Modifier
                         .fillMaxWidth()
                         .height(segmentHeight)
-                        .padding(vertical = segmentPadding),
+                        .padding(vertical = segmentPadding)
+                        .semantics {
+                            role = Role.RadioButton
+                            this.selected = isSelected
+                            if (!enabled) disabled()
+                            else onClick {
+                                onSelect(option)
+                                true
+                            }
+                        }
+                        .onKeyEvent { event ->
+                            if (enabled && event.isActivationKeyUp()) {
+                                onSelect(option)
+                                true
+                            } else false
+                        }
+                        .focusable(enabled),
                     contentAlignment = Alignment.Center,
                 ) {
                     ControlLabel(
@@ -906,7 +954,23 @@ fun <T> HorizontalSegmentedSelector(
                         Modifier
                             .weight(1f)
                             .fillMaxHeight()
-                            .semantics { contentDescription = label(option) },
+                            .semantics {
+                                contentDescription = label(option)
+                                role = Role.RadioButton
+                                this.selected = active
+                                if (!enabled) disabled()
+                                else onClick {
+                                    onSelect(option)
+                                    true
+                                }
+                            }
+                            .onKeyEvent { event ->
+                                if (enabled && event.isActivationKeyUp()) {
+                                    onSelect(option)
+                                    true
+                                } else false
+                            }
+                            .focusable(enabled),
                         contentAlignment = Alignment.Center,
                     ) {
                         ControlLabel(
@@ -942,6 +1006,12 @@ fun <T> HorizontalSegmentedSelector(
         }
     }
 }
+
+private fun androidx.compose.ui.input.key.KeyEvent.isActivationKeyUp(): Boolean =
+    type == KeyEventType.KeyUp && (
+        key == Key.Enter || key == Key.NumPadEnter ||
+            key == Key.DirectionCenter || key == Key.Spacebar
+        )
 
 // ---------------------------------------------------------------------------------------------
 // 4 · Vertical switch
@@ -1018,7 +1088,22 @@ fun VerticalSwitch(
                     )
                 },
             )
-            .semantics { contentDescription = if (effectiveChecked) "Activé" else "Désactivé" },
+            .semantics {
+                role = Role.Switch
+                toggleableState = ToggleableState(effectiveChecked)
+                if (!enabled) disabled()
+                else onClick {
+                    onCheckedChange(!checked)
+                    true
+                }
+            }
+            .onKeyEvent { event ->
+                if (enabled && event.isActivationKeyUp()) {
+                    onCheckedChange(!checked)
+                    true
+                } else false
+            }
+            .focusable(enabled),
     ) {
         // Thumb takes half the track's height and rides between the two insets.
         val thumbWidth = maxWidth - inset * 2

--- a/app/src/main/java/com/iblu01/portallauncher/ui/onboarding/OnboardingUrls.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/onboarding/OnboardingUrls.kt
@@ -44,6 +44,9 @@ object OnboardingUrls {
     fun hostOf(raw: String): String =
         runCatching { URI(normalizeHaUrl(raw)).host }.getOrNull().orEmpty()
 
+    /** `.local` relies on mDNS, which is unavailable on some Android-based panels. */
+    fun usesMdnsHostname(raw: String): Boolean = hostOf(raw).lowercase().endsWith(".local")
+
     /**
      * The broker address to pre-fill.
      *

--- a/app/src/main/java/com/iblu01/portallauncher/ui/onboarding/screens/HomeAssistantCredentialsStep.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/onboarding/screens/HomeAssistantCredentialsStep.kt
@@ -108,6 +108,15 @@ fun HomeAssistantCredentialsStep(
             }
         }
 
+        if (OnboardingUrls.usesMdnsHostname(state.haUrl)) {
+            Text(
+                text = stringResource(R.string.onb_ha_creds_warning_mdns),
+                style = AppleTypography.bodySmall,
+                color = AppleColors.warning,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+        }
+
         Column {
             SettingsTextField(
                 label = stringResource(R.string.onb_ha_creds_label_token),

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
@@ -252,7 +252,7 @@ fun ClockThemeScreen(
         // Close button.
         Box(
             modifier = Modifier
-                .align(Alignment.TopStart)
+                .align(Alignment.TopEnd)
                 .padding(24.dp)
                 .size(44.dp)
                 .clip(CircleShape)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -52,17 +53,20 @@ import com.iblu01.portallauncher.ui.components.WeatherUi
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 import com.iblu01.portallauncher.ui.theme.ClockFont
+import com.iblu01.portallauncher.ui.theme.ClockDateFormat
 import com.iblu01.portallauncher.ui.theme.ClockTheme
 import com.iblu01.portallauncher.ui.theme.ClockTint
 import com.iblu01.portallauncher.ui.theme.clockFontFamily
 import kotlin.math.roundToInt
 
-private val previewWeather = WeatherUi(temp = "19°", indoorTemp = "22°", city = "Appartement", condition = "Dégagé", glyph = WeatherGlyph("clear-day"))
+private val previewWeather = WeatherUi(temp = "19°", indoorTemp = "22°", glyph = WeatherGlyph("clear-day"))
 private val previewTemperatures = TemperatureSummary("22,5°", "24,5°", "19°")
-private val previewChips = listOf(
-    LauncherChip("doors", "door", "Portes & fenêtres", "2 ouvertes", "warning"),
-    LauncherChip("purifier", "air", "Purificateur", "En marche · auto", "active"),
-    LauncherChip("scenes", "scenes", "Scènes", "13 raccourcis", "ok"),
+
+@Composable
+private fun previewChips() = listOf(
+    LauncherChip("doors", "door", stringResource(R.string.pill_group_openings), stringResource(R.string.pill_openings_count_format, 2), "warning"),
+    LauncherChip("purifier", "air", stringResource(R.string.pill_group_purifier), pluralStringResource(R.plurals.pill_purifier_state, 1, stringResource(R.string.purifier_mode_auto)), "active"),
+    LauncherChip("scenes", "scenes", stringResource(R.string.pill_group_scenes), pluralStringResource(R.plurals.pill_scenes_count, 13, 13), "ok"),
 )
 
 /**
@@ -107,7 +111,7 @@ fun ClockThemeScreen(
             backgroundMode = backgroundMode,
             weather = previewWeather,
             temperatures = previewTemperatures,
-            chips = previewChips,
+            chips = previewChips(),
             onTap = {},
             onLongPress = {},
             pillsExpanded = false,
@@ -226,6 +230,32 @@ fun ClockThemeScreen(
                     onCheckedChange = { update(theme.copy(format24h = it)) },
                     colors = SwitchDefaults.colors(checkedTrackColor = AppleColors.accent),
                 )
+            }
+
+            ControlLabel(stringResource(R.string.clock_theme_label_date_format))
+            Row(
+                Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                ClockDateFormat.entries.forEach { format ->
+                    val selected = format == theme.dateFormat
+                    val label = when (format) {
+                        ClockDateFormat.LONG -> stringResource(R.string.clock_date_format_long)
+                        ClockDateFormat.DAY_MONTH_YEAR -> stringResource(R.string.clock_date_format_day_month_year)
+                        ClockDateFormat.MONTH_DAY_YEAR -> stringResource(R.string.clock_date_format_month_day_year)
+                        ClockDateFormat.ISO -> stringResource(R.string.clock_date_format_iso)
+                    }
+                    Box(
+                        Modifier
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(if (selected) AppleColors.accent else AppleColors.frostedFill)
+                            .border(0.5.dp, AppleColors.frostedBorder, RoundedCornerShape(14.dp))
+                            .clickable { update(theme.copy(dateFormat = format)) }
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                    ) {
+                        Text(label, style = AppleTypography.bodyLarge, color = if (selected) Color.White else AppleColors.primary)
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
@@ -39,11 +39,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.iblu01.portallauncher.LauncherChip
 import com.iblu01.portallauncher.R
 import com.iblu01.portallauncher.domain.model.TemperatureSummary
 import com.iblu01.portallauncher.ui.components.AmbientBackground
@@ -61,13 +59,6 @@ import kotlin.math.roundToInt
 
 private val previewWeather = WeatherUi(temp = "19°", indoorTemp = "22°", glyph = WeatherGlyph("clear-day"))
 private val previewTemperatures = TemperatureSummary("22,5°", "24,5°", "19°")
-
-@Composable
-private fun previewChips() = listOf(
-    LauncherChip("doors", "door", stringResource(R.string.pill_group_openings), stringResource(R.string.pill_openings_count_format, 2), "warning"),
-    LauncherChip("purifier", "air", stringResource(R.string.pill_group_purifier), pluralStringResource(R.plurals.pill_purifier_state, 1, stringResource(R.string.purifier_mode_auto)), "active"),
-    LauncherChip("scenes", "scenes", stringResource(R.string.pill_group_scenes), pluralStringResource(R.plurals.pill_scenes_count, 13, 13), "ok"),
-)
 
 /**
  * Full-screen live editor for the clock theme: the launcher home (frozen mock data) over the real
@@ -111,7 +102,7 @@ fun ClockThemeScreen(
             backgroundMode = backgroundMode,
             weather = previewWeather,
             temperatures = previewTemperatures,
-            chips = previewChips(),
+            chips = emptyList(),
             onTap = {},
             onLongPress = {},
             pillsExpanded = false,

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
@@ -55,6 +55,10 @@ import com.iblu01.portallauncher.ui.theme.ClockDateFormat
 import com.iblu01.portallauncher.ui.theme.ClockTheme
 import com.iblu01.portallauncher.ui.theme.ClockTint
 import com.iblu01.portallauncher.ui.theme.clockFontFamily
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.Locale
 import kotlin.math.roundToInt
 
 private val previewWeather = WeatherUi(temp = "19°", indoorTemp = "22°", glyph = WeatherGlyph("clear-day"))
@@ -230,12 +234,7 @@ fun ClockThemeScreen(
             ) {
                 ClockDateFormat.entries.forEach { format ->
                     val selected = format == theme.dateFormat
-                    val label = when (format) {
-                        ClockDateFormat.LONG -> stringResource(R.string.clock_date_format_long)
-                        ClockDateFormat.DAY_MONTH_YEAR -> stringResource(R.string.clock_date_format_day_month_year)
-                        ClockDateFormat.MONTH_DAY_YEAR -> stringResource(R.string.clock_date_format_month_day_year)
-                        ClockDateFormat.ISO -> stringResource(R.string.clock_date_format_iso)
-                    }
+                    val label = dateFormatExample(format)
                     Box(
                         Modifier
                             .clip(RoundedCornerShape(14.dp))
@@ -265,6 +264,12 @@ fun ClockThemeScreen(
             Icon(Icons.Filled.Close, stringResource(R.string.clock_theme_close), tint = AppleColors.secondary, modifier = Modifier.size(20.dp))
         }
     }
+}
+
+/** A fixed Tuesday makes every option self-explanatory while still following the app locale. */
+private fun dateFormatExample(format: ClockDateFormat): String {
+    val sample = GregorianCalendar(2026, Calendar.AUGUST, 18).time
+    return SimpleDateFormat(format.fullPattern, Locale.getDefault()).format(sample)
 }
 
 @Composable

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/ClockThemeScreen.kt
@@ -15,10 +15,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -39,6 +41,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -142,7 +148,12 @@ fun ClockThemeScreen(
                             .clip(RoundedCornerShape(14.dp))
                             .background(if (selected) AppleColors.accent else AppleColors.frostedFill)
                             .border(0.5.dp, AppleColors.frostedBorder, RoundedCornerShape(14.dp))
-                            .clickable { update(theme.copy(font = font)) }
+                            .selectable(
+                                selected = selected,
+                                role = Role.RadioButton,
+                                onClick = { update(theme.copy(font = font)) },
+                            )
+                            .sizeIn(minHeight = 48.dp)
                             .padding(horizontal = 16.dp, vertical = 12.dp),
                     ) {
                         Text(
@@ -198,9 +209,10 @@ fun ClockThemeScreen(
             Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
                 ClockTint.entries.forEach { tint ->
                     val selected = tint == theme.tint
+                    val tintName = tint.localizedName()
                     Box(
                         Modifier
-                            .size(38.dp)
+                            .size(48.dp)
                             .clip(CircleShape)
                             .background(tint.color)
                             .border(
@@ -208,7 +220,12 @@ fun ClockThemeScreen(
                                 color = if (selected) Color.White else AppleColors.frostedBorder,
                                 shape = CircleShape,
                             )
-                            .clickable { update(theme.copy(tint = tint)) },
+                            .selectable(
+                                selected = selected,
+                                role = Role.RadioButton,
+                                onClick = { update(theme.copy(tint = tint)) },
+                            )
+                            .semantics { contentDescription = tintName },
                     )
                 }
             }
@@ -240,7 +257,12 @@ fun ClockThemeScreen(
                             .clip(RoundedCornerShape(14.dp))
                             .background(if (selected) AppleColors.accent else AppleColors.frostedFill)
                             .border(0.5.dp, AppleColors.frostedBorder, RoundedCornerShape(14.dp))
-                            .clickable { update(theme.copy(dateFormat = format)) }
+                            .selectable(
+                                selected = selected,
+                                role = Role.RadioButton,
+                                onClick = { update(theme.copy(dateFormat = format)) },
+                            )
+                            .sizeIn(minHeight = 48.dp)
                             .padding(horizontal = 16.dp, vertical = 12.dp),
                     ) {
                         Text(label, style = AppleTypography.bodyLarge, color = if (selected) Color.White else AppleColors.primary)
@@ -254,7 +276,7 @@ fun ClockThemeScreen(
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .padding(24.dp)
-                .size(44.dp)
+                .size(48.dp)
                 .clip(CircleShape)
                 .background(AppleColors.frostedFill)
                 .border(0.5.dp, AppleColors.frostedBorder, CircleShape)
@@ -264,6 +286,16 @@ fun ClockThemeScreen(
             Icon(Icons.Filled.Close, stringResource(R.string.clock_theme_close), tint = AppleColors.secondary, modifier = Modifier.size(20.dp))
         }
     }
+}
+
+@Composable
+private fun ClockTint.localizedName(): String = when (this) {
+    ClockTint.WHITE -> stringResource(R.string.clock_tint_white)
+    ClockTint.AMBER -> stringResource(R.string.clock_tint_amber)
+    ClockTint.MINT -> stringResource(R.string.clock_tint_mint)
+    ClockTint.BLUE -> stringResource(R.string.clock_tint_blue)
+    ClockTint.PINK -> stringResource(R.string.clock_tint_pink)
+    ClockTint.VIOLET -> stringResource(R.string.clock_tint_violet)
 }
 
 /** A fixed Tuesday makes every option self-explanatory while still following the app locale. */

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/HomeConnectionPage.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/HomeConnectionPage.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.PhoneAndroid
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -33,6 +35,8 @@ import com.iblu01.portallauncher.ui.components.SettingsStatusRow
 import com.iblu01.portallauncher.ui.components.SettingsSubPageHeader
 import com.iblu01.portallauncher.ui.components.SettingsTextField
 import com.iblu01.portallauncher.ui.components.SettingsToggle
+import com.iblu01.portallauncher.ui.components.SettingsTile
+import com.iblu01.portallauncher.ui.onboarding.OnboardingUrls
 import com.iblu01.portallauncher.ui.theme.AppleColors
 import com.iblu01.portallauncher.ui.theme.AppleTypography
 
@@ -116,6 +120,7 @@ fun HomeConnectionPage(
             showBack = showBack,
             breadcrumb = "${stringResource(R.string.settings_main_title)}  ›  ${stringResource(R.string.settings_tile_home_title)}",
         )
+        WebConfigShortcut()
         Text(
             stringResource(R.string.home_connection_subtitle),
             style = AppleTypography.bodyLarge,
@@ -140,6 +145,14 @@ fun HomeConnectionPage(
                 onValueChange = onUrlChange,
                 placeholder = stringResource(R.string.home_connection_placeholder_address)
             )
+            if (OnboardingUrls.usesMdnsHostname(haUrl)) {
+                Text(
+                    text = stringResource(R.string.home_connection_warning_mdns),
+                    style = AppleTypography.bodySmall,
+                    color = AppleColors.warning,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
             SettingsDivider()
             SettingsRow(
                 label = stringResource(R.string.home_connection_label_scan_network),
@@ -159,13 +172,6 @@ fun HomeConnectionPage(
             )
             SettingsDivider()
             SettingsRow(label = stringResource(R.string.home_connection_label_key_help), onClick = { showKeyHelp = true })
-            SettingsDivider()
-            // Typing a long-lived token on a panel's on-screen keyboard is miserable; hand the
-            // whole form to a phone instead (see WebConfigActivity).
-            SettingsRow(
-                label = stringResource(R.string.home_connection_label_web_config),
-                onClick = { context.startActivity(Intent(context, WebConfigActivity::class.java)) },
-            )
         }
 
         SettingsSection(title = stringResource(R.string.home_connection_section_status)) {
@@ -240,4 +246,17 @@ fun HomeConnectionPage(
             )
         }
     }
+}
+
+/** Prominent handoff to the phone-friendly configuration server. */
+@Composable
+fun WebConfigShortcut(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    SettingsTile(
+        icon = Icons.Outlined.PhoneAndroid,
+        title = stringResource(R.string.home_connection_label_web_config),
+        subtitle = stringResource(R.string.home_connection_web_config_subtitle),
+        onClick = { context.startActivity(Intent(context, WebConfigActivity::class.java)) },
+        modifier = modifier,
+    )
 }

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/OpacityPreviewScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/OpacityPreviewScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.iblu01.portallauncher.LauncherChip
 import com.iblu01.portallauncher.domain.model.TemperatureSummary
 import com.iblu01.portallauncher.ui.components.AmbientBackground
 import com.iblu01.portallauncher.ui.components.ClockScreen
@@ -37,13 +36,7 @@ import com.iblu01.portallauncher.R
 import androidx.compose.ui.res.stringResource
 
 /** Frozen mock content used to judge the overlay against a real wallpaper — no HA dependency. */
-private val previewWeather = WeatherUi(temp = "19°", indoorTemp = "22°", city = "Appartement", condition = "Dégagé", glyph = WeatherGlyph("clear-day"))
 private val previewTemperatures = TemperatureSummary("22,5°", "24,5°", "19°")
-private val previewChips = listOf(
-    LauncherChip("doors", "door", "Portes & fenêtres", "2 ouvertes", "warning"),
-    LauncherChip("purifier", "air", "Purificateur", "En marche · auto", "active"),
-    LauncherChip("scenes", "scenes", "Scènes", "13 raccourcis", "ok"),
-)
 
 /**
  * Full-screen replica of the launcher home over the user's real wallpaper, with a big vertical
@@ -63,6 +56,13 @@ fun OpacityPreviewScreen(
     modifier: Modifier = Modifier,
 ) {
     var opacity by remember { mutableFloatStateOf(initialOpacity) }
+    val previewWeather = WeatherUi(
+        temp = "19°",
+        indoorTemp = "22°",
+        city = stringResource(R.string.opacity_preview_weather_city),
+        condition = stringResource(R.string.opacity_preview_weather_condition),
+        glyph = WeatherGlyph("clear-day"),
+    )
 
     Box(modifier.fillMaxSize()) {
         // 1 · Real wallpaper.
@@ -95,7 +95,7 @@ fun OpacityPreviewScreen(
             backgroundMode = backgroundMode,
             weather = previewWeather,
             temperatures = previewTemperatures,
-            chips = previewChips,
+            chips = emptyList(),
             onTap = {},
             onLongPress = {},
             pillsExpanded = false,
@@ -118,12 +118,12 @@ fun OpacityPreviewScreen(
                 .width(96.dp),
         )
 
-        // 6 · Close button, top-left (same visual as the side-panel dismiss).
+        // 6 · Close button, aligned with the clock editor.
         Box(
             modifier = Modifier
-                .align(Alignment.TopStart)
+                .align(Alignment.TopEnd)
                 .padding(24.dp)
-                .size(44.dp)
+                .size(48.dp)
                 .clip(CircleShape)
                 .background(AppleColors.frostedFill)
                 .border(0.5.dp, AppleColors.frostedBorder, CircleShape)

--- a/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/screens/SettingsScreen.kt
@@ -201,6 +201,7 @@ private data class TileDef(
 /** Keeps links emitted by older launcher versions working after the settings reorganisation. */
 private fun settingsPageFromRoute(route: String?): SettingsPage = when (route) {
     "HOME", SettingsActivity.PAGE_CONNECTED_HOME -> SettingsPage.CONNECTED_HOME
+    SettingsActivity.PAGE_CONNECTED_HOME_CONNECTION -> SettingsPage.CONNECTED_HOME_CONNECTION
     SettingsActivity.PAGE_HOME -> SettingsPage.HOME
     "PILLS" -> SettingsPage.HOME
     "WALLPAPER", SettingsActivity.PAGE_APPEARANCE -> SettingsPage.APPEARANCE
@@ -439,6 +440,7 @@ fun SettingsScreen(
                     CategoryEntry(stringResource(R.string.settings_connected_sessions_title), stringResource(R.string.settings_connected_sessions_subtitle), Icons.Outlined.Settings, SettingsPage.CONNECTED_HOME_SESSIONS),
                 ),
                 onNavigate = { currentPage = it }, onBack = { currentPage = SettingsPage.MAIN }, showBack = showBack,
+                leadingContent = { WebConfigShortcut() },
             )
             SettingsPage.CONNECTED_HOME_CONNECTION -> HomeConnectionPage(
                 uiState = uiState,
@@ -581,6 +583,7 @@ private fun CategoryPage(
     onNavigate: (SettingsPage) -> Unit,
     onBack: () -> Unit,
     showBack: Boolean,
+    leadingContent: (@Composable () -> Unit)? = null,
 ) {
     Column(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
@@ -592,6 +595,7 @@ private fun CategoryPage(
             showBack = showBack,
             breadcrumb = stringResource(R.string.settings_main_title),
         )
+        leadingContent?.invoke()
         SettingsSection(title = stringResource(R.string.settings_category_section)) {
             entries.forEachIndexed { index, entry ->
                 SettingsRow(label = entry.title, value = entry.subtitle, onClick = { onNavigate(entry.page) })

--- a/app/src/main/java/com/iblu01/portallauncher/ui/theme/ClockTheme.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/theme/ClockTheme.kt
@@ -34,6 +34,22 @@ enum class ClockTint(val key: String, val label: String, val color: Color) {
     }
 }
 
+/** User-selectable date layouts for the clock header. */
+enum class ClockDateFormat(
+    val key: String,
+    val fullPattern: String,
+    val compactPattern: String = fullPattern,
+) {
+    LONG("long", "EEEE d MMMM", "EEE d MMM"),
+    DAY_MONTH_YEAR("day_month_year", "dd/MM/yyyy"),
+    MONTH_DAY_YEAR("month_day_year", "MM/dd/yyyy"),
+    ISO("iso", "yyyy-MM-dd");
+
+    companion object {
+        fun fromKey(key: String): ClockDateFormat = entries.firstOrNull { it.key == key } ?: LONG
+    }
+}
+
 /**
  * The full clock styling. Defaults reproduce the launcher's current clock (Space Grotesk Black,
  * 138sp, white, 24h) so a defaulted [ClockTheme] leaves the historical look untouched.
@@ -47,6 +63,7 @@ data class ClockTheme(
     val letterSpacing: Float = 0f,
     val tint: ClockTint = ClockTint.WHITE,
     val format24h: Boolean = true,
+    val dateFormat: ClockDateFormat = ClockDateFormat.LONG,
     /** Multiplier on the vertical gaps between date/time/weather-pill rows (see ClockHeader). */
     val elementSpacing: Float = 1f,
 ) {

--- a/app/src/main/java/com/iblu01/portallauncher/ui/theme/ClockTheme.kt
+++ b/app/src/main/java/com/iblu01/portallauncher/ui/theme/ClockTheme.kt
@@ -41,6 +41,11 @@ enum class ClockDateFormat(
     val compactPattern: String = fullPattern,
 ) {
     LONG("long", "EEEE d MMMM", "EEE d MMM"),
+    WEEKDAY_MONTH_DAY("weekday_month_day", "EEEE, MMMM d", "EEE, MMM d"),
+    SHORT_WEEKDAY_DAY_MONTH("short_weekday_day_month", "EEE d MMMM", "EEE d MMM"),
+    SHORT_WEEKDAY_MONTH_DAY("short_weekday_month_day", "EEE, MMM d"),
+    MONTH_DAY_TEXT("month_day_text", "MMMM d", "MMM d"),
+    DAY_MONTH_TEXT("day_month_text", "d MMMM", "d MMM"),
     DAY_MONTH_YEAR("day_month_year", "dd/MM/yyyy"),
     MONTH_DAY_YEAR("month_day_year", "MM/dd/yyyy"),
     ISO("iso", "yyyy-MM-dd");

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -251,6 +251,11 @@
     <string name="clock_theme_label_element_spacing">Écart entre éléments</string>
     <string name="clock_theme_label_color">Couleur</string>
     <string name="clock_theme_label_format_24h">Format 24 h</string>
+    <string name="clock_theme_label_date_format">Format de date</string>
+    <string name="clock_date_format_long">Date longue</string>
+    <string name="clock_date_format_day_month_year">JJ/MM/AAAA</string>
+    <string name="clock_date_format_month_day_year">MM/JJ/AAAA</string>
+    <string name="clock_date_format_iso">AAAA-MM-JJ</string>
     <string name="clock_theme_close">Fermer</string>
 
     <!-- ===== LAUNCHER HOME SCREEN ===== -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -257,6 +257,12 @@
     <string name="clock_date_format_month_day_year">MM/JJ/AAAA</string>
     <string name="clock_date_format_iso">AAAA-MM-JJ</string>
     <string name="clock_theme_close">Fermer</string>
+    <string name="clock_tint_white">Blanc</string>
+    <string name="clock_tint_amber">Ambre</string>
+    <string name="clock_tint_mint">Vert</string>
+    <string name="clock_tint_blue">Bleu</string>
+    <string name="clock_tint_pink">Rose</string>
+    <string name="clock_tint_violet">Violet</string>
 
     <!-- ===== LAUNCHER HOME SCREEN ===== -->
     <string name="clock_indoor_temp_format">Appartement %1$s–%2$s</string>
@@ -597,6 +603,8 @@
 
     <!-- ===== OPACITY PREVIEW ===== -->
     <string name="opacity_preview_close_desc">Fermer</string>
+    <string name="opacity_preview_weather_city">Maison</string>
+    <string name="opacity_preview_weather_condition">Dégagé</string>
 
     <!-- ===== PLAYGROUND / DEV SCREEN ===== -->
     <string name="playground_swatch_blue">Bleu</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -37,6 +37,7 @@
     <string name="home_connection_ha_detected">Home Assistant détecté</string>
     <string name="home_connection_label_address">Adresse</string>
     <string name="home_connection_placeholder_address">http://homeassistant.local:8123</string>
+    <string name="home_connection_warning_mdns">Les adresses en .local utilisent le DNS local (mDNS), qui peut ne pas fonctionner sur certains écrans. Si la connexion échoue, utilisez plutôt l’adresse IP locale du serveur Home Assistant.</string>
     <string name="home_connection_label_scan_network">Chercher sur le réseau</string>
     <string name="home_connection_scanning">Recherche…</string>
     <string name="home_connection_scan_found_format">%1$d trouvé(s)</string>
@@ -46,6 +47,7 @@
     <string name="home_connection_label_key_help">Où trouver ma clé ?</string>
     <string name="home_connection_section_status">STATUT DE LA CONNEXION</string>
     <string name="home_connection_label_web_config">Configurer depuis un autre appareil</string>
+    <string name="home_connection_web_config_subtitle">Ouvrez un QR code et saisissez les réglages Home Assistant et MQTT depuis un téléphone ou un ordinateur.</string>
     <string name="web_config_title">Configuration à distance</string>
     <string name="web_config_subtitle">Scannez ce code avec votre téléphone pour configurer le panneau.</string>
     <string name="web_config_qr_description">QR code de la page de configuration</string>
@@ -54,8 +56,12 @@
     <string name="web_config_label_code">Code</string>
     <string name="web_config_same_network_note">Le téléphone et le panneau doivent utiliser le même réseau Wi-Fi. La page se ferme lorsque vous quittez cet écran.</string>
     <string name="web_config_unavailable">Configuration à distance indisponible : ce panneau n\'est pas sur un réseau.</string>
-    <string name="web_config_saved_title">Configuration enregistrée</string>
-    <string name="web_config_saved_body">Les réglages ont bien été reçus par ce panneau.</string>
+    <string name="web_config_progress_title">Configuration en cours</string>
+    <string name="web_config_progress_body">Continuez sur l’autre appareil pour configurer MQTT.</string>
+    <string name="web_config_complete_title">Configuration terminée</string>
+    <string name="web_config_complete_body">Home Assistant et MQTT sont prêts.</string>
+    <string name="web_config_status_configured">Configuré</string>
+    <string name="web_config_status_pending">En attente</string>
     <string name="web_config_saved_action">Tester et continuer</string>
     <string name="onb_common_action_web_config">Configurer depuis mon téléphone</string>
     <string name="home_connection_label_connection">Connexion</string>
@@ -271,7 +277,10 @@
     <string name="clock_expand_pills">Voir plus d\'informations</string>
     <string name="clock_collapse_content_desc">Replier</string>
     <string name="clock_expand_content_desc">Déplier</string>
-    <string name="clock_stale_banner_format">Hors ligne — infos figées depuis %1$s</string>
+    <string name="clock_stale_banner_format">Hors ligne : infos figées depuis %1$s</string>
+    <string name="connection_banner_unreachable">Home Assistant est inaccessible</string>
+    <string name="connection_banner_mdns_hint">Cette adresse en .local peut ne pas être résolue sur cet écran. Touchez ici et essayez l’adresse IP locale de Home Assistant.</string>
+    <string name="connection_banner_generic_hint">Vérifiez l’adresse et le réseau local. Touchez ici pour ouvrir les réglages de connexion.</string>
     <string name="header_hidden_apps_content_desc">Applications masquées (%1$d)</string>
     <string name="header_settings_content_desc">Réglages</string>
     <string name="home_header_title">Maison</string>
@@ -1059,6 +1068,7 @@
     <string name="onb_ha_creds_help_step4">4. Dans «&#160;Jetons d\'accès longue durée&#160;», créez un nouveau jeton.</string>
     <string name="onb_ha_creds_help_step5">5. Nommez-le «&#160;Portal&#160;», puis copiez-le ici.</string>
     <string name="onb_ha_creds_error_invalid_address">Adresse invalide.</string>
+    <string name="onb_ha_creds_warning_mdns">« .local » utilise le DNS local (mDNS), qui peut ne pas fonctionner sur cet écran. Si la connexion échoue, saisissez plutôt l’adresse IP locale de Home Assistant.</string>
     <string name="onb_ha_creds_error_token_required">Le jeton est requis.</string>
     <string name="onb_ha_creds_skip_dialog_title">Abandonner la connexion&#160;?</string>
     <string name="onb_ha_creds_skip_dialog_body">Les informations saisies ne seront pas enregistrées.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,6 +253,11 @@
     <string name="clock_theme_label_element_spacing">Element spacing</string>
     <string name="clock_theme_label_color">Color</string>
     <string name="clock_theme_label_format_24h">24-hour format</string>
+    <string name="clock_theme_label_date_format">Date format</string>
+    <string name="clock_date_format_long">Long</string>
+    <string name="clock_date_format_day_month_year">DD/MM/YYYY</string>
+    <string name="clock_date_format_month_day_year">MM/DD/YYYY</string>
+    <string name="clock_date_format_iso">YYYY-MM-DD</string>
     <string name="clock_theme_close">Close</string>
 
     <!-- ===== LAUNCHER HOME SCREEN ===== -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,6 +259,12 @@
     <string name="clock_date_format_month_day_year">MM/DD/YYYY</string>
     <string name="clock_date_format_iso">YYYY-MM-DD</string>
     <string name="clock_theme_close">Close</string>
+    <string name="clock_tint_white">White</string>
+    <string name="clock_tint_amber">Amber</string>
+    <string name="clock_tint_mint">Green</string>
+    <string name="clock_tint_blue">Blue</string>
+    <string name="clock_tint_pink">Pink</string>
+    <string name="clock_tint_violet">Violet</string>
 
     <!-- ===== LAUNCHER HOME SCREEN ===== -->
     <string name="clock_indoor_temp_format">Indoor %1$s–%2$s</string>
@@ -599,6 +605,8 @@
 
     <!-- ===== OPACITY PREVIEW ===== -->
     <string name="opacity_preview_close_desc">Close</string>
+    <string name="opacity_preview_weather_city">Home</string>
+    <string name="opacity_preview_weather_condition">Clear</string>
 
     <!-- ===== PLAYGROUND / DEV SCREEN ===== -->
     <string name="playground_swatch_blue">Blue</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="home_connection_ha_detected">Home Assistant detected</string>
     <string name="home_connection_label_address">Address</string>
     <string name="home_connection_placeholder_address">http://homeassistant.local:8123</string>
+    <string name="home_connection_warning_mdns">Addresses ending in .local use local DNS (mDNS), which may not work on some panels. If the connection fails, use your Home Assistant server’s local IP address instead.</string>
     <string name="home_connection_label_scan_network">Search the network</string>
     <string name="home_connection_scanning">Searching…</string>
     <string name="home_connection_scan_found_format">%1$d found</string>
@@ -48,6 +49,7 @@
     <string name="home_connection_label_key_help">Where to find my key?</string>
     <string name="home_connection_section_status">CONNECTION STATUS</string>
     <string name="home_connection_label_web_config">Set up from another device</string>
+    <string name="home_connection_web_config_subtitle">Open a QR code and enter Home Assistant and MQTT settings from a phone or computer.</string>
     <string name="web_config_title">Remote setup</string>
     <string name="web_config_subtitle">Scan this code with your phone to fill in this panel\'s settings from its keyboard.</string>
     <string name="web_config_qr_description">QR code for the setup page</string>
@@ -56,8 +58,12 @@
     <string name="web_config_label_code">Code</string>
     <string name="web_config_same_network_note">Your phone must be on the same Wi-Fi network. The page closes as soon as you leave this screen.</string>
     <string name="web_config_unavailable">Remote setup unavailable: this panel is not on a network.</string>
-    <string name="web_config_saved_title">Configuration saved</string>
-    <string name="web_config_saved_body">This panel has received the new settings.</string>
+    <string name="web_config_progress_title">Setup in progress</string>
+    <string name="web_config_progress_body">Continue on your other device to configure MQTT.</string>
+    <string name="web_config_complete_title">Setup complete</string>
+    <string name="web_config_complete_body">Home Assistant and MQTT are ready.</string>
+    <string name="web_config_status_configured">Configured</string>
+    <string name="web_config_status_pending">Waiting</string>
     <string name="web_config_saved_action">Test and continue</string>
     <string name="onb_common_action_web_config">Set up from my phone</string>
     <string name="home_connection_label_connection">Connection</string>
@@ -273,7 +279,10 @@
     <string name="clock_expand_pills">Show more info</string>
     <string name="clock_collapse_content_desc">Collapse</string>
     <string name="clock_expand_content_desc">Expand</string>
-    <string name="clock_stale_banner_format">Offline — info frozen since %1$s</string>
+    <string name="clock_stale_banner_format">Offline: info frozen since %1$s</string>
+    <string name="connection_banner_unreachable">Home Assistant is unreachable</string>
+    <string name="connection_banner_mdns_hint">This .local address may not resolve on this panel. Tap here and try Home Assistant’s local IP address.</string>
+    <string name="connection_banner_generic_hint">Check the address and local network. Tap here to open connection settings.</string>
     <string name="header_hidden_apps_content_desc">Hidden apps (%1$d)</string>
     <string name="header_settings_content_desc">Settings</string>
     <string name="home_header_title">Home</string>
@@ -1061,6 +1070,7 @@
     <string name="onb_ha_creds_help_step4">4. Under “Long-lived access tokens”, create a new token.</string>
     <string name="onb_ha_creds_help_step5">5. Name it “Portal”, then copy it here.</string>
     <string name="onb_ha_creds_error_invalid_address">Invalid address.</string>
+    <string name="onb_ha_creds_warning_mdns">“.local” uses local DNS (mDNS), which may not work on this panel. If the connection fails, enter Home Assistant’s local IP address instead.</string>
     <string name="onb_ha_creds_error_token_required">Token is required.</string>
     <string name="onb_ha_creds_skip_dialog_title">Discard this connection?</string>
     <string name="onb_ha_creds_skip_dialog_body">The information entered won\'t be saved.</string>

--- a/app/src/main/resources/webconfig/config.html
+++ b/app/src/main/resources/webconfig/config.html
@@ -32,8 +32,15 @@
           <div class="settings-group">
             <label class="wizard-field" for="ha_url"><span>Adresse</span><input id="ha_url" type="url" inputmode="url" placeholder="http://homeassistant.local:8123" required></label>
             <p id="ha_url_error" class="field-error hidden">Saisissez une adresse commençant par http:// ou https://.</p>
+            <p id="ha_mdns_warning" class="field-warning hidden">Les adresses en <strong>.local</strong> utilisent le DNS local (mDNS), qui peut ne pas fonctionner sur certains écrans. Si la connexion échoue, utilisez plutôt l’adresse IP locale du serveur.</p>
             <label class="wizard-field" for="ha_token"><span>Jeton longue durée</span><input id="ha_token" type="password" autocomplete="off" placeholder="Jeton Home Assistant" required></label>
             <p id="ha_token_error" class="field-error hidden">Le jeton d’accès est nécessaire.</p>
+          </div>
+          <div id="ha_test_status" class="connection-checks hidden" aria-live="polite">
+            <div class="connection-check" data-check="host"><span>Adresse</span><strong id="ha_check_host">En attente</strong></div>
+            <div class="connection-check" data-check="port"><span>Port</span><strong id="ha_check_port">En attente</strong></div>
+            <div class="connection-check" data-check="token"><span>Jeton</span><strong id="ha_check_token">En attente</strong></div>
+            <p id="ha_test_error" class="status"></p>
           </div>
           <button id="toggle-ha-token" class="text-action" type="button">Afficher le jeton</button>
         </section>
@@ -42,11 +49,18 @@
           <p class="step-note">Les identifiants MQTT sont distincts de ceux de Home Assistant.</p>
           <div class="settings-group">
             <label class="wizard-field" for="broker_host"><span>Serveur</span><input id="broker_host" type="text" autocomplete="off" placeholder="192.168.1.10" required></label>
+            <p id="mqtt_mdns_warning" class="field-warning hidden">Les adresses en <strong>.local</strong> utilisent le DNS local (mDNS), qui peut ne pas fonctionner sur certains écrans. Si la connexion échoue, utilisez plutôt l’adresse IP locale du serveur.</p>
             <label class="wizard-field" for="broker_port"><span>Port</span><input id="broker_port" type="number" min="1" max="65535" inputmode="numeric" required></label>
             <p id="mqtt_error" class="field-error hidden">Renseignez un serveur et un port compris entre 1 et 65535.</p>
             <label class="wizard-field" for="username"><span>Utilisateur</span><input id="username" type="text" autocomplete="off"></label>
             <label class="wizard-field" for="password"><span>Mot de passe</span><input id="password" type="password" autocomplete="off"></label>
             <label class="wizard-field" for="device_name"><span>Nom du panneau</span><input id="device_name" type="text" autocomplete="off" placeholder="Panneau salon"></label>
+          </div>
+          <div id="mqtt_test_status" class="connection-checks hidden" aria-live="polite">
+            <div class="connection-check" data-mqtt-check="host"><span>Serveur</span><strong id="mqtt_check_host">En attente</strong></div>
+            <div class="connection-check" data-mqtt-check="port"><span>Port</span><strong id="mqtt_check_port">En attente</strong></div>
+            <div class="connection-check" data-mqtt-check="auth"><span>Authentification</span><strong id="mqtt_check_auth">En attente</strong></div>
+            <p id="mqtt_test_error" class="status"></p>
           </div>
         </section>
 
@@ -65,6 +79,13 @@
         <h1>Configuration enregistrée</h1>
         <p>Le panneau a bien reçu les nouveaux réglages.</p>
         <strong>Vous pouvez fermer cet onglet.</strong>
+      </section>
+
+      <section id="server-offline-view" class="completion-view hidden" aria-live="assertive">
+        <div class="offline-symbol" aria-hidden="true">!</div>
+        <h1>Le launcher n’est pas en mode configuration</h1>
+        <p>Rouvrez « Configurer depuis un autre appareil » sur le panneau, puis scannez le nouveau QR code.</p>
+        <button id="retry-server" type="button" class="secondary-button">Réessayer</button>
       </section>
 
       <footer class="wizard-navigation">

--- a/app/src/main/resources/webconfig/config.js
+++ b/app/src/main/resources/webconfig/config.js
@@ -11,12 +11,21 @@
   var sample = { ha_url: 'http://homeassistant.local:8123', ha_token: 'demo-token', broker_host: '192.168.1.10', broker_port: 1883, username: 'portal', password: '', device_name: 'Panneau salon' };
   var current = 0;
   var saving = false;
+  var checkingAvailability = false;
 
   function el(id) { return document.getElementById(id); }
   function url(path) { return path + '?t=' + encodeURIComponent(token); }
   function say(id, message, kind) { var node = el(id); node.textContent = message; node.className = 'status ' + (kind || ''); }
   function fill(data) { fields.forEach(function (field) { el(field).value = data[field] === undefined ? '' : data[field]; }); }
   function setHidden(node, hidden) { node.classList.toggle('hidden', hidden); }
+  function updateMdnsWarning() {
+    var value = el('ha_url').value.trim().toLowerCase();
+    setHidden(el('ha_mdns_warning'), !/^https?:\/\/[^/?#]*\.local(?::\d+)?(?:[/?#]|$)/.test(value));
+  }
+  function updateMqttMdnsWarning() {
+    var value = el('broker_host').value.trim().toLowerCase();
+    setHidden(el('mqtt_mdns_warning'), !value.endsWith('.local'));
+  }
 
   function buildProgress() {
     var host = el('progress-dots');
@@ -60,6 +69,147 @@
     el('summary-device').textContent = el('device_name').value || 'Portal';
   }
 
+  function setHaCheck(stage, state, label) {
+    var row = document.querySelector('[data-check="' + stage + '"]');
+    row.className = 'connection-check ' + (state || '');
+    el('ha_check_' + stage).textContent = label;
+  }
+
+  function resetHaChecks() {
+    setHidden(el('ha_test_status'), false);
+    ['host', 'port', 'token'].forEach(function (stage) { setHaCheck(stage, '', 'En attente'); });
+    say('ha_test_error', '', '');
+  }
+
+  function runHaCheck(stage) {
+    setHaCheck(stage, 'testing', 'Vérification…');
+    return fetch(url('/api/test-ha'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ stage: stage, ha_url: el('ha_url').value.trim(), ha_token: el('ha_token').value.trim() })
+    }).then(function (response) {
+      return response.json().then(function (result) {
+        if (!response.ok || !result.ok) { var failure = new Error(result.error || 'test_failed'); failure.code = result.error; throw failure; }
+        setHaCheck(stage, 'ok', 'Validé');
+      });
+    });
+  }
+
+  function saveSection(path, body) {
+    el('next').textContent = 'Enregistrement…';
+    return fetch(url(path), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    }).then(function (response) {
+      return response.json().then(function (result) {
+        if (!response.ok || !result.ok) { var failure = new Error('save_failed'); failure.code = 'save_failed'; throw failure; }
+      });
+    });
+  }
+
+  function haFailureMessage(code) {
+    if (code === 'host_unresolved') return 'Adresse introuvable. Si elle se termine par .local, essayez l’adresse IP locale.';
+    if (code === 'port_unreachable') return 'Adresse trouvée, mais le port Home Assistant est inaccessible.';
+    if (code === 'token_required') return 'Le jeton d’accès est nécessaire.';
+    if (code === 'token_rejected') return 'Home Assistant refuse ce jeton. Vérifiez qu’il s’agit d’un jeton longue durée valide.';
+    if (code === 'api_unreachable') return 'Le serveur répond, mais l’API Home Assistant est inaccessible.';
+    return 'Le test de connexion a échoué.';
+  }
+
+  function testHomeStep() {
+    if (saving) return;
+    if (demo) { showStep(1); return; }
+    saving = true;
+    resetHaChecks();
+    el('next').disabled = true;
+    el('next').textContent = 'Test en cours…';
+    var activeStage = 'host';
+    runHaCheck('host')
+      .then(function () { activeStage = 'port'; return runHaCheck('port'); })
+      .then(function () { activeStage = 'token'; return runHaCheck('token'); })
+      .then(function () { return saveSection('/api/config/ha', { ha_url: el('ha_url').value.trim(), ha_token: el('ha_token').value.trim() }); })
+      .then(function () { saving = false; el('next').disabled = false; showStep(1); })
+      .catch(function (failure) {
+        if (!failure.code || failure.code === 'server_unavailable') { saving = false; showServerUnavailable(); return; }
+        saving = false;
+        el('next').disabled = false;
+        el('next').textContent = 'Réessayer';
+        if (failure.code !== 'save_failed') setHaCheck(activeStage, 'err', 'Échec');
+        say('ha_test_error', failure.code === 'save_failed' ? 'Les tests ont réussi, mais l’enregistrement a échoué.' : haFailureMessage(failure.code), 'err');
+      });
+  }
+
+  function setMqttCheck(stage, state, label) {
+    var row = document.querySelector('[data-mqtt-check="' + stage + '"]');
+    row.className = 'connection-check ' + (state || '');
+    el('mqtt_check_' + stage).textContent = label;
+  }
+
+  function resetMqttChecks() {
+    setHidden(el('mqtt_test_status'), false);
+    ['host', 'port', 'auth'].forEach(function (stage) { setMqttCheck(stage, '', 'En attente'); });
+    say('mqtt_test_error', '', '');
+  }
+
+  function runMqttCheck(stage) {
+    setMqttCheck(stage, 'testing', 'Vérification…');
+    return fetch(url('/api/test-mqtt'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        stage: stage,
+        broker_host: el('broker_host').value.trim(),
+        broker_port: parseInt(el('broker_port').value, 10) || 0,
+        username: el('username').value.trim(),
+        password: el('password').value
+      })
+    }).then(function (response) {
+      return response.json().then(function (result) {
+        if (!response.ok || !result.ok) { var failure = new Error(result.error || 'test_failed'); failure.code = result.error; throw failure; }
+        setMqttCheck(stage, 'ok', 'Validé');
+      });
+    });
+  }
+
+  function mqttFailureMessage(code) {
+    if (code === 'mqtt_host_unresolved') return 'Serveur MQTT introuvable. Si son adresse se termine par .local, essayez son adresse IP locale.';
+    if (code === 'mqtt_port_unreachable') return 'Serveur trouvé, mais le port MQTT est inaccessible.';
+    if (code === 'mqtt_auth_failed') return 'La connexion MQTT a été refusée. Vérifiez l’identifiant et le mot de passe.';
+    return 'Le test MQTT a échoué.';
+  }
+
+  function testMqttStep() {
+    if (saving) return;
+    if (demo) { showStep(2); return; }
+    saving = true;
+    resetMqttChecks();
+    el('next').disabled = true;
+    el('next').textContent = 'Test en cours…';
+    var activeStage = 'host';
+    runMqttCheck('host')
+      .then(function () { activeStage = 'port'; return runMqttCheck('port'); })
+      .then(function () { activeStage = 'auth'; return runMqttCheck('auth'); })
+      .then(function () {
+        return saveSection('/api/config/mqtt', {
+          broker_host: el('broker_host').value.trim(),
+          broker_port: parseInt(el('broker_port').value, 10) || 0,
+          username: el('username').value.trim(),
+          password: el('password').value,
+          device_name: el('device_name').value.trim()
+        });
+      })
+      .then(function () { saving = false; el('next').disabled = false; showStep(2); })
+      .catch(function (failure) {
+        if (!failure.code || failure.code === 'server_unavailable') { saving = false; showServerUnavailable(); return; }
+        saving = false;
+        el('next').disabled = false;
+        el('next').textContent = 'Réessayer';
+        if (failure.code !== 'save_failed') setMqttCheck(activeStage, 'err', 'Échec');
+        say('mqtt_test_error', failure.code === 'save_failed' ? 'Les tests ont réussi, mais l’enregistrement a échoué.' : mqttFailureMessage(failure.code), 'err');
+      });
+  }
+
   function configBody() {
     var body = {}; fields.forEach(function (field) { body[field] = el(field).value; }); body.broker_port = parseInt(body.broker_port, 10) || 0; return body;
   }
@@ -71,7 +221,7 @@
     fetch(url('/api/config'), { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(configBody()) })
       .then(function (response) { return response.json(); })
       .then(function (result) { if (!result.ok) throw new Error(); showCompletion(); })
-      .catch(function () { saving = false; el('next').disabled = false; el('next').textContent = 'Réessayer'; say('config_status', 'L’enregistrement a échoué. Vérifiez la connexion.', 'err'); });
+      .catch(function () { saving = false; showServerUnavailable(); });
   }
 
   function showCompletion() {
@@ -84,10 +234,58 @@
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
-  el('next').addEventListener('click', function () { if (!validCurrentStep()) return; if (current < steps.length - 1) showStep(current + 1); else saveAll(); });
+  function showServerUnavailable() {
+    setHidden(document.querySelector('.wizard-context'), true);
+    setHidden(document.querySelector('.wizard-workspace'), true);
+    setHidden(document.querySelector('.wizard-navigation'), true);
+    setHidden(el('saved-view'), true);
+    setHidden(el('server-offline-view'), false);
+    el('progress-label').textContent = 'Connexion interrompue';
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function ensureServerAvailable() {
+    return fetch(url('/api/health'), { cache: 'no-store' }).then(function (response) {
+      if (!response.ok) throw new Error('server_unavailable');
+      return response.json();
+    }).then(function (result) {
+      if (!result.ok) throw new Error('server_unavailable');
+    });
+  }
+
+  function runCurrentAction() {
+    if (!validCurrentStep()) return;
+    if (demo) {
+      if (current === 0) showStep(1); else if (current === 1) showStep(2); else saveAll();
+      return;
+    }
+    if (checkingAvailability || saving) return;
+    checkingAvailability = true;
+    el('next').disabled = true;
+    var previousLabel = el('next').textContent;
+    el('next').textContent = 'Vérification du panneau…';
+    ensureServerAvailable().then(function () {
+      checkingAvailability = false;
+      el('next').disabled = false;
+      el('next').textContent = previousLabel;
+      if (current === 0) testHomeStep();
+      else if (current === 1) testMqttStep();
+      else saveAll();
+    }).catch(function () {
+      checkingAvailability = false;
+      showServerUnavailable();
+    });
+  }
+
+  el('next').addEventListener('click', runCurrentAction);
   el('back').addEventListener('click', function () { if (current > 0 && !saving) showStep(current - 1); });
   el('toggle-ha-token').addEventListener('click', function () { var input = el('ha_token'); var visible = input.type === 'text'; input.type = visible ? 'password' : 'text'; this.textContent = visible ? 'Afficher le jeton' : 'Masquer le jeton'; });
+  el('ha_url').addEventListener('input', updateMdnsWarning);
+  el('broker_host').addEventListener('input', updateMqttMdnsWarning);
+  el('retry-server').addEventListener('click', function () {
+    ensureServerAvailable().then(function () { window.location.reload(); }).catch(showServerUnavailable);
+  });
 
   buildProgress(); showStep(0);
-  if (demo) fill(sample); else fetch(url('/api/config')).then(function (response) { return response.json(); }).then(fill).catch(function () { say('config_status', 'Le panneau est injoignable', 'err'); });
+  if (demo) { fill(sample); updateMdnsWarning(); updateMqttMdnsWarning(); } else fetch(url('/api/config')).then(function (response) { if (!response.ok) throw new Error(); return response.json(); }).then(function (data) { fill(data); updateMdnsWarning(); updateMqttMdnsWarning(); }).catch(showServerUnavailable);
 })();

--- a/app/src/main/resources/webconfig/webconfig.css
+++ b/app/src/main/resources/webconfig/webconfig.css
@@ -50,6 +50,15 @@ button, input { font: inherit; }
 .wizard-field input::placeholder { color: rgb(255 255 255 / 45%); }
 .wizard-field input:focus { background: #2c2c2e; outline: 1px solid rgb(255 255 255 / 55%); }
 .field-error { margin: -1px 0 0; padding: 9px 16px 10px; border-top: 1px solid rgb(255 255 255 / 10%); background: #3a1717; color: #ffb4ae; font-size: .83rem; line-height: 1.4; }
+.field-warning { margin: -1px 0 0; padding: 10px 16px; border-top: 1px solid rgb(255 214 10 / 22%); background: rgb(255 214 10 / 9%); color: #ffd60a; font-size: .83rem; line-height: 1.45; }
+.connection-checks { margin-top: 12px; overflow: hidden; border-radius: 12px; background: #1c1c1e; box-shadow: 0 0 0 1px rgb(255 255 255 / 9%); }
+.connection-check { display: flex; min-height: 42px; align-items: center; justify-content: space-between; gap: 16px; padding: 8px 14px; border-top: 1px solid rgb(255 255 255 / 9%); font-size: .88rem; }
+.connection-check:first-child { border-top: 0; }
+.connection-check strong { color: rgb(255 255 255 / 48%); font-weight: 600; }
+.connection-check.testing strong { color: #ffd60a; }
+.connection-check.ok strong { color: #30d158; }
+.connection-check.err strong { color: #ff6961; }
+.connection-checks .status { padding-inline: 14px; }
 .text-action { min-height: 44px; margin-top: 6px; border: 0; background: transparent; color: #0a84ff; font-size: .9rem; cursor: pointer; }
 .text-action:focus-visible { outline: 2px solid #fff; outline-offset: -4px; border-radius: 8px; }
 .step-note { margin: 0 0 14px; padding: 13px 15px; border-radius: 10px; background: #1c1c1e; color: rgb(255 255 255 / 70%); font-size: .9rem; line-height: 1.5; }
@@ -72,6 +81,7 @@ button, input { font: inherit; }
 .nav-primary:hover { background: #2997ff; }
 .completion-view { grid-column: 1 / -1; align-self: center; justify-self: center; max-width: 520px; padding: 48px 24px; text-align: center; }
 .completion-check { display: grid; width: 64px; height: 64px; margin: 0 auto 22px; place-items: center; border-radius: 50%; background: #30d158; color: #000; font-size: 2rem; font-weight: 750; }
+.offline-symbol { display: grid; width: 64px; height: 64px; margin: 0 auto 22px; place-items: center; border-radius: 50%; background: rgb(255 159 10 / 18%); color: #ff9f0a; box-shadow: 0 0 0 1px rgb(255 159 10 / 45%); font-size: 2rem; font-weight: 750; }
 .completion-view h1 { margin: 0; font-size: clamp(1.8rem, 5vw, 2.5rem); letter-spacing: -.035em; }
 .completion-view p { margin: 14px 0 8px; color: rgb(255 255 255 / 60%); line-height: 1.55; }
 .completion-view strong { display: block; color: #fff; font-size: 1.05rem; }

--- a/app/src/test/java/com/iblu01/portallauncher/ClockDateFormatTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ClockDateFormatTest.kt
@@ -1,0 +1,19 @@
+package com.iblu01.portallauncher
+
+import com.iblu01.portallauncher.ui.theme.ClockDateFormat
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClockDateFormatTest {
+    @Test fun `stored date formats round trip by key`() {
+        ClockDateFormat.entries.forEach { format ->
+            assertEquals(format, ClockDateFormat.fromKey(format.key))
+        }
+    }
+
+    @Test fun `unknown stored date format keeps the historical long layout`() {
+        assertEquals(ClockDateFormat.LONG, ClockDateFormat.fromKey("future_format"))
+        assertEquals("EEEE d MMMM", ClockDateFormat.LONG.fullPattern)
+        assertEquals("EEE d MMM", ClockDateFormat.LONG.compactPattern)
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/ClockDateFormatTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ClockDateFormatTest.kt
@@ -2,6 +2,7 @@ package com.iblu01.portallauncher
 
 import com.iblu01.portallauncher.ui.theme.ClockDateFormat
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ClockDateFormatTest {
@@ -15,5 +16,13 @@ class ClockDateFormatTest {
         assertEquals(ClockDateFormat.LONG, ClockDateFormat.fromKey("future_format"))
         assertEquals("EEEE d MMMM", ClockDateFormat.LONG.fullPattern)
         assertEquals("EEE d MMM", ClockDateFormat.LONG.compactPattern)
+    }
+
+    @Test fun `textual and numeric layouts expose stable unique preference keys`() {
+        assertTrue(ClockDateFormat.entries.size >= 9)
+        assertEquals(ClockDateFormat.entries.size, ClockDateFormat.entries.map { it.key }.distinct().size)
+        assertTrue(ClockDateFormat.entries.any { "EEEE" in it.fullPattern })
+        assertTrue(ClockDateFormat.entries.any { it.fullPattern == "MMMM d" })
+        assertTrue(ClockDateFormat.entries.any { it.fullPattern == "dd/MM/yyyy" })
     }
 }

--- a/app/src/test/java/com/iblu01/portallauncher/WeatherDataTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/WeatherDataTest.kt
@@ -1,0 +1,31 @@
+package com.iblu01.portallauncher
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WeatherDataTest {
+    @Test fun `weather home wins and fallback is lexical`() {
+        assertEquals("weather.home", selectWeatherEntityId(listOf("weather.z", "weather.home", "weather.a")))
+        assertEquals("weather.a", selectWeatherEntityId(listOf("sensor.x", "weather.z", "weather.a")))
+        assertNull(selectWeatherEntityId(listOf("sensor.x")))
+    }
+
+    @Test fun `forecast without temperature is omitted instead of becoming zero`() {
+        val input = JSONArray()
+            .put(JSONObject().put("datetime", "2026-08-17T10:00:00Z").put("condition", "sunny"))
+            .put(JSONObject().put("datetime", "2026-08-17T11:00:00Z").put("temperature", 21.5))
+
+        val result = parseForecastPoints(input)
+
+        assertEquals(1, result.size)
+        assertEquals(21.5, result.single().temp, 0.0)
+    }
+
+    @Test fun `temperature conversion handles both directions`() {
+        assertEquals(0.0, convertTemperature(32.0, TemperatureUnit.FAHRENHEIT, TemperatureUnit.CELSIUS), 0.0001)
+        assertEquals(68.0, convertTemperature(20.0, TemperatureUnit.CELSIUS, TemperatureUnit.FAHRENHEIT), 0.0001)
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/WeatherTemperatureSummaryTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/WeatherTemperatureSummaryTest.kt
@@ -1,0 +1,47 @@
+package com.iblu01.portallauncher
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class WeatherTemperatureSummaryTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test fun `sensor readings are converted to weather entity unit`() {
+        val weather = HaEntity(
+            "weather.home",
+            "sunny",
+            JSONObject().put("temperature_unit", "°C").put("temperature", 20),
+        )
+        val indoorF = HaEntity(
+            "sensor.living_temperature",
+            "68",
+            JSONObject().put("device_class", "temperature").put("unit_of_measurement", "°F"),
+        )
+        val outdoorC = HaEntity(
+            "sensor.outdoor_temperature",
+            "10",
+            JSONObject().put("device_class", "temperature").put("unit_of_measurement", "°C"),
+        )
+        val rules = listOf(
+            PillRule(indoorF.entityId, PillKind.CLIMATE, "Living room"),
+            PillRule(outdoorC.entityId, PillKind.CLIMATE, "Outdoor"),
+        )
+
+        val result = PillRepository(context).temperatureSummary(
+            rules,
+            listOf(weather, indoorF, outdoorC).associateBy(HaEntity::entityId),
+        )
+
+        assertEquals("20°C", result.indoorMin)
+        assertEquals("20°C", result.indoorMax)
+        assertEquals("10°C", result.outdoor)
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/WebConfigServerTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/WebConfigServerTest.kt
@@ -76,6 +76,49 @@ class WebConfigServerTest {
         assertTrue(page.contains("Vous pouvez fermer cet onglet"))
         assertTrue(page.contains("id=\"next\""))
         assertTrue(page.contains("id=\"back\""))
+        assertTrue(page.contains("id=\"ha_mdns_warning\""))
+        assertTrue(page.contains("adresse IP locale du serveur"))
+        assertTrue(page.contains("id=\"ha_check_host\""))
+        assertTrue(page.contains("id=\"ha_check_port\""))
+        assertTrue(page.contains("id=\"ha_check_token\""))
+        assertTrue(page.contains("id=\"mqtt_check_host\""))
+        assertTrue(page.contains("id=\"mqtt_check_port\""))
+        assertTrue(page.contains("id=\"mqtt_check_auth\""))
+        assertTrue(page.contains("id=\"mqtt_mdns_warning\""))
+        assertTrue(page.contains("id=\"server-offline-view\""))
+        assertTrue(page.contains("Le launcher n’est pas en mode configuration"))
+    }
+
+    @Test
+    fun `home step tests host then port then token before continuing`() {
+        val script = WebConfigPage.asset("config.js")
+
+        val host = script.indexOf("runHaCheck('host')")
+        val port = script.indexOf("runHaCheck('port')", host + 1)
+        val token = script.indexOf("runHaCheck('token')", port + 1)
+        val continueToMqtt = script.indexOf("showStep(1)", token + 1)
+
+        assertTrue(script.contains("/api/test-ha"))
+        assertTrue(host >= 0)
+        assertTrue(port > host)
+        assertTrue(token > port)
+        assertTrue(continueToMqtt > token)
+    }
+
+    @Test
+    fun `mqtt step tests host then port then authentication before continuing`() {
+        val script = WebConfigPage.asset("config.js")
+
+        val host = script.indexOf("runMqttCheck('host')")
+        val port = script.indexOf("runMqttCheck('port')", host + 1)
+        val auth = script.indexOf("runMqttCheck('auth')", port + 1)
+        val continueToSummary = script.indexOf("showStep(2)", auth + 1)
+
+        assertTrue(script.contains("/api/test-mqtt"))
+        assertTrue(host >= 0)
+        assertTrue(port > host)
+        assertTrue(auth > port)
+        assertTrue(continueToSummary > auth)
     }
 
     @Test

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/ConnectionProblemBannerTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/ConnectionProblemBannerTest.kt
@@ -1,0 +1,60 @@
+package com.iblu01.portallauncher.ui.components
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.iblu01.portallauncher.ui.theme.PortalTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class ConnectionProblemBannerTest {
+
+    @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun `an initial mdns failure explains the local ip workaround and opens settings`() {
+        var clicked = false
+        rule.setContent {
+            PortalTheme {
+                ConnectionProblemBanner(
+                    lastUpdateAt = 0L,
+                    usesMdnsAddress = true,
+                    onClick = { clicked = true },
+                )
+            }
+        }
+
+        rule.onNodeWithTag("connectionProblemBanner")
+            .assertIsDisplayed()
+            .assertHasClickAction()
+            .performClick()
+        rule.onNodeWithText("Home Assistant is unreachable").assertIsDisplayed()
+        rule.onNodeWithText("This .local address may not resolve", substring = true).assertIsDisplayed()
+        rule.runOnIdle { assertTrue(clicked) }
+    }
+
+    @Test
+    fun `a dropped connection reports frozen information`() {
+        rule.setContent {
+            PortalTheme {
+                ConnectionProblemBanner(
+                    lastUpdateAt = System.currentTimeMillis() - 5_000L,
+                    usesMdnsAddress = false,
+                    onClick = {},
+                )
+            }
+        }
+
+        rule.onNodeWithText("Offline: info frozen since", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("Check the address and local network", substring = true).assertIsDisplayed()
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/IndividualPillPanelTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/IndividualPillPanelTest.kt
@@ -4,10 +4,15 @@ import android.content.Context
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.test.core.app.ApplicationProvider
 import com.iblu01.portallauncher.HaEntity
 import com.iblu01.portallauncher.LauncherChip
@@ -96,7 +101,9 @@ class IndividualPillPanelTest {
             }
         }
 
-        rule.onNodeWithContentDescription("Activé").assertExists()
+        rule.onNode(
+            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Switch) and hasClickAction(),
+        ).assertIsOn()
     }
 
     @Test fun `plain fan shows running state once and exposes horizontal oscillation choices`() {

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/WeatherCityTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/WeatherCityTest.kt
@@ -14,13 +14,13 @@ class WeatherCityTest {
                 .put("friendly_name", "Forecast Home"),
         )
 
-        assertEquals("Nantes", weatherCity(entity))
+        assertEquals("Nantes", explicitWeatherCity(entity))
     }
 
-    @Test fun `location then friendly name provide fallbacks`() {
-        assertEquals("Paris", weatherCity(weatherEntity(JSONObject().put("location", "Paris"))))
-        assertEquals("Maison", weatherCity(weatherEntity(JSONObject().put("friendly_name", "Maison"))))
-        assertEquals("", weatherCity(weatherEntity(JSONObject())))
+    @Test fun `location is accepted but friendly name is never presented as a city`() {
+        assertEquals("Paris", explicitWeatherCity(weatherEntity(JSONObject().put("location", "Paris"))))
+        assertEquals("", explicitWeatherCity(weatherEntity(JSONObject().put("friendly_name", "Forecast Maison"))))
+        assertEquals("", explicitWeatherCity(weatherEntity(JSONObject())))
     }
 
     private fun weatherEntity(attributes: JSONObject) =

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/WeatherCityTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/WeatherCityTest.kt
@@ -1,0 +1,28 @@
+package com.iblu01.portallauncher.ui.components
+
+import com.iblu01.portallauncher.HaEntity
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WeatherCityTest {
+    @Test fun `explicit city wins over location and friendly name`() {
+        val entity = weatherEntity(
+            JSONObject()
+                .put("city", "Nantes")
+                .put("location", "Loire-Atlantique")
+                .put("friendly_name", "Forecast Home"),
+        )
+
+        assertEquals("Nantes", weatherCity(entity))
+    }
+
+    @Test fun `location then friendly name provide fallbacks`() {
+        assertEquals("Paris", weatherCity(weatherEntity(JSONObject().put("location", "Paris"))))
+        assertEquals("Maison", weatherCity(weatherEntity(JSONObject().put("friendly_name", "Maison"))))
+        assertEquals("", weatherCity(weatherEntity(JSONObject())))
+    }
+
+    private fun weatherEntity(attributes: JSONObject) =
+        HaEntity("weather.home", "sunny", attributes)
+}

--- a/app/src/test/java/com/iblu01/portallauncher/ui/components/WeatherForecastLabelTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/components/WeatherForecastLabelTest.kt
@@ -1,0 +1,23 @@
+package com.iblu01.portallauncher.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+import java.util.TimeZone
+
+class WeatherForecastLabelTest {
+    @Test fun `hour label follows 24 hour preference`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        assertEquals("14:05", forecastPointLabel("2026-08-17T14:05:00Z", true, true, Locale.ENGLISH))
+    }
+
+    @Test fun `hour label follows 12 hour preference`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        assertEquals("2 PM", forecastPointLabel("2026-08-17T14:05:00Z", true, false, Locale.ENGLISH))
+    }
+
+    @Test fun `day label follows locale`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        assertEquals("Lun.", forecastPointLabel("2026-08-17T14:05:00Z", false, true, Locale.FRENCH))
+    }
+}

--- a/app/src/test/java/com/iblu01/portallauncher/ui/onboarding/OnboardingUrlsTest.kt
+++ b/app/src/test/java/com/iblu01/portallauncher/ui/onboarding/OnboardingUrlsTest.kt
@@ -46,6 +46,14 @@ class OnboardingUrlsTest {
     }
 
     @Test
+    fun `mdns warning is limited to local hostnames`() {
+        assertTrue(OnboardingUrls.usesMdnsHostname("http://homeassistant.local:8123"))
+        assertTrue(OnboardingUrls.usesMdnsHostname("HTTPS://HA.LOCAL"))
+        assertFalse(OnboardingUrls.usesMdnsHostname("http://192.168.1.20:8123"))
+        assertFalse(OnboardingUrls.usesMdnsHostname("https://ha.example.com"))
+    }
+
+    @Test
     fun `an unusable address falls back to the default broker host`() {
         assertEquals("homeassistant.local", OnboardingUrls.suggestedMqttHost(""))
         assertEquals("homeassistant.local", OnboardingUrls.suggestedMqttHost("nonsense://"))

--- a/docs/NEXT_RELEASE_SCENES_CAMERAS_SPEC.md
+++ b/docs/NEXT_RELEASE_SCENES_CAMERAS_SPEC.md
@@ -1,0 +1,159 @@
+# Prochaine version : scènes et centre caméra — Spécification
+
+**Créée le :** 2026-08-15  
+**Score d’ambiguïté :** 0,15 (seuil : ≤ 0,20)  
+**Exigences verrouillées :** 12
+
+## Objectif
+
+Permettre de retrouver et d’épingler les scènes et les caméras Home Assistant sous forme de pills, d’activer une scène d’un toucher et d’ouvrir les caméras dans un centre plein écran configurable proposant le flux en direct, le son et les commandes PTZ réellement disponibles.
+
+## Contexte
+
+Portal Launcher sait déjà découvrir, afficher, ordonner et épingler plusieurs types d’entités Home Assistant. Les préférences d’accueil conservent un ordre de pills épinglées et l’interface réserve trois positions principales puis six positions secondaires.
+
+Le type interne `PillKind.SCENE` et ses libellés existent, mais le domaine Home Assistant `scene` n’est pas découvert comme entité utilisable, les scènes sont masquées par le moteur de pills et aucune action ne leur est associée. Le domaine `camera` est explicitement exclu du catalogue. Il n’existe ni type de pill caméra, ni écran de lecture vidéo, ni préférences de centre caméra.
+
+## Exigences
+
+1. **Découverte des scènes** : chaque entité Home Assistant disponible du domaine `scene` figure dans la liste des pills configurables.
+   - État actuel : le type `SCENE` existe partiellement, mais les entités `scene.*` ne sont pas retenues comme pills utilisables.
+   - Cible : les scènes disponibles apparaissent avec leur nom et leur icône Home Assistant, sans être confondues avec une pill d’état persistante.
+   - Validation : avec deux scènes disponibles et une scène indisponible, les deux scènes disponibles apparaissent dans la liste et peuvent être sélectionnées ; l’indisponibilité de la troisième est indiquée.
+
+2. **Activation immédiate d’une scène** : toucher une pill de scène appelle immédiatement le service d’activation de cette scène, sans ouvrir de panneau ni demander de confirmation.
+   - État actuel : aucune action n’est routée pour `PillKind.SCENE`.
+   - Cible : un toucher sur `scene.<id>` déclenche exactement une activation et fournit un retour visuel temporaire de demande en cours, de réussite ou d’échec.
+   - Validation : un toucher produit un seul appel Home Assistant visant l’entité choisie ; un échec réseau ne produit pas de réussite trompeuse et la pill redevient utilisable.
+
+3. **Épinglage des scènes** : une scène peut être épinglée, désépinglée et ordonnée sur l’écran principal avec les mécanismes existants.
+   - État actuel : les références et préférences d’épinglage existent, mais aucune scène ne peut entrer dans le catalogue correspondant.
+   - Cible : une scène épinglée occupe les positions principales ou secondaires selon son ordre sauvegardé, comme les autres pills.
+   - Validation : après épinglage, réordonnancement puis redémarrage de l’application, la scène reste à la position enregistrée et demeure activable.
+
+4. **Découverte des caméras** : chaque entité Home Assistant disponible du domaine `camera` figure comme pill caméra configurable.
+   - État actuel : `camera` est explicitement exclu du support des pills.
+   - Cible : les caméras apparaissent avec leur nom, leur icône et leur état de disponibilité ; une caméra indisponible reste identifiable mais ne tente pas d’afficher un faux flux actif.
+   - Validation : les caméras connues de Home Assistant sont présentes dans les réglages et leur disponibilité correspond à l’état reçu.
+
+5. **Pills caméra individuelles** : chaque caméra sélectionnée peut être épinglée sur l’écran principal et ouvre le centre directement sur cette caméra.
+   - État actuel : aucun type ni routage de pill caméra n’existe.
+   - Cible : l’épinglage, le désépinglage, l’ordre et la persistance suivent les règles communes des pills ; toucher la pill ouvre la caméra correspondante même si une autre caméra principale est configurée.
+   - Validation : toucher successivement deux pills de caméras différentes ouvre à chaque fois le flux correspondant ; leur ordre survit au redémarrage.
+
+6. **Pill générale Caméras** : une pill générale permet d’ouvrir le centre caméra dans sa vue par défaut.
+   - État actuel : aucune entrée globale pour les caméras n’existe.
+   - Cible : la pill « Caméras » est configurable et épinglable ; elle ouvre le mode et la caméra principale enregistrés dans les réglages.
+   - Validation : après modification du mode par défaut et de la caméra principale, toucher la pill générale ouvre exactement cette configuration.
+
+7. **Centre caméra plein écran** : le centre caméra est une page superposée occupant toute la surface utile, quelle que soit la taille du téléphone, de la tablette ou de l’écran mural.
+   - État actuel : les entités pilotables ouvrent des panneaux adaptés aux appareils, sans page vidéo dédiée.
+   - Cible : le centre masque les pages du launcher derrière lui, adapte son contenu aux dimensions disponibles et fournit une action de fermeture explicite ainsi que la navigation Retour Android.
+   - Validation : sur les tailles de référence compactes et larges du projet, aucun élément essentiel n’est hors écran ; Retour ferme le centre et restitue la page précédemment affichée.
+
+8. **Modes caméra principale et grille** : le centre propose un mode « caméra principale » et un mode « grille », sélectionnables dans les réglages et commutables depuis le centre.
+   - État actuel : aucun mode d’affichage caméra n’existe.
+   - Cible : le mode caméra principale privilégie un grand flux et permet de choisir une autre caméra ; le mode grille affiche toutes les caméras rendues visibles dans les réglages. Sélectionner une caméra dans la grille l’ouvre comme caméra principale.
+   - Validation : avec au moins trois caméras sélectionnées, les deux modes affichent le bon ensemble ; choisir une vignette de grille ouvre le bon flux principal.
+
+9. **Flux en direct robuste** : chaque caméra sélectionnée affiche son flux Home Assistant avec des états explicites de chargement, d’indisponibilité et d’erreur récupérable.
+   - État actuel : aucun lecteur caméra ni cycle de connexion vidéo n’existe.
+   - Cible : le lecteur s’authentifie avec la connexion Home Assistant existante, ne divulgue pas le jeton, arrête les ressources lorsque le centre est fermé et propose une nouvelle tentative après erreur.
+   - Validation : un flux compatible devient visible ; une URL invalide ou une caméra indisponible affiche une erreur et permet de réessayer ; fermer le centre arrête la lecture et l’activité réseau associée.
+
+10. **Son du flux** : lorsqu’un flux possède une piste audio, l’utilisateur peut l’écouter et la couper depuis le centre caméra.
+    - État actuel : aucun média caméra n’est lu.
+    - Cible : un contrôle muet/sonore est disponible pour les flux audio ; l’absence de piste audio ne provoque pas d’erreur et n’affiche pas un contrôle mensonger.
+    - Validation : le contrôle change effectivement l’état audio d’un flux avec son ; un flux sans son reste lisible sans échec.
+
+11. **PTZ conditionnel** : les commandes panoramique, inclinaison et zoom ne sont affichées que lorsqu’elles sont réellement supportées par la caméra active.
+    - État actuel : aucune capacité ni commande PTZ n’est gérée.
+    - Cible : les capacités exposées par Home Assistant déterminent les contrôles proposés ; chaque action vise uniquement la caméra active et une caméra fixe n’affiche aucun contrôle PTZ.
+    - Validation : une caméra PTZ de test expose uniquement ses commandes prises en charge et reçoit l’action choisie ; une caméra fixe n’affiche aucune commande PTZ.
+
+12. **Configuration du centre caméra** : les réglages permettent de choisir les caméras visibles, leur ordre, la caméra principale, le mode par défaut et les pills caméra épinglées.
+    - État actuel : aucune préférence caméra n’existe.
+    - Cible : ces choix sont modifiables sans éditer Home Assistant, persistent après redémarrage et tolèrent la disparition ou l’indisponibilité d’une caméra enregistrée.
+    - Validation : une configuration complète survit au redémarrage ; retirer une caméra de Home Assistant ne bloque ni les réglages ni l’ouverture des autres flux.
+
+## Limites
+
+### Inclus
+
+- Découverte et pills individuelles des scènes Home Assistant.
+- Activation immédiate et retour d’état des scènes.
+- Découverte, sélection, ordre et pills individuelles des caméras.
+- Pill générale « Caméras ».
+- Centre caméra plein écran sur toutes les tailles prises en charge.
+- Modes caméra principale et grille.
+- Choix d’une caméra principale.
+- Flux vidéo en direct, son et commandes PTZ selon les capacités.
+- Gestion des chargements, erreurs, indisponibilités et nouvelles tentatives.
+- Persistance de tous les réglages caméra et d’épinglage.
+- Libellés français et anglais ainsi que l’accessibilité des nouvelles actions.
+
+### Exclus
+
+- Enregistrement vidéo et consultation des enregistrements — cette version est centrée sur le direct.
+- Historique et chronologie des caméras — à traiter avec les enregistrements.
+- Création ou téléchargement de snapshots — non nécessaire pour consulter le direct.
+- Détection, affichage et notification des événements — fonctionnalité distincte du visionnage.
+- Interphone, microphone et audio bidirectionnel — le son inclus est uniquement celui reçu avec le flux.
+- Création, édition ou suppression de scènes — ces opérations restent gérées dans Home Assistant.
+- Gestion des utilisateurs et permissions Home Assistant — les droits existants sont respectés tels quels.
+
+## Contraintes
+
+- Compatibilité Android 9 / API 28 minimum et respect de la cible Android actuelle du projet.
+- Interface utilisable sur téléphone, tablette et écran mural, sans supposer une diagonale ni un ratio précis.
+- Réutilisation des règles d’épinglage existantes : trois positions principales, six secondaires et débordement géré par l’accueil.
+- Les identifiants et jetons Home Assistant ne doivent jamais apparaître dans l’interface, les journaux applicatifs ou une URL transmise à une application externe.
+- Le protocole de flux retenu devra être compatible avec les formats réellement fournis par Home Assistant et permettre la libération déterministe des lecteurs.
+- Une caméra sans son ou sans PTZ reste pleinement utilisable pour la vidéo.
+- Les nouvelles chaînes visibles doivent exister en français et en anglais.
+
+## Critères d’acceptation globaux
+
+- [ ] Toutes les scènes Home Assistant disponibles apparaissent dans la liste des pills configurables.
+- [ ] Toucher une scène envoie une seule demande d’activation sans confirmation ni panneau intermédiaire.
+- [ ] Les scènes épinglées conservent leur position après redémarrage.
+- [ ] Toutes les caméras Home Assistant apparaissent dans les réglages avec leur disponibilité correcte.
+- [ ] Une pill caméra individuelle ouvre directement cette caméra.
+- [ ] La pill générale « Caméras » ouvre le mode par défaut et la caméra principale configurés.
+- [ ] Le centre occupe toute la surface utile et se ferme correctement par son action dédiée et par Retour Android.
+- [ ] Le mode caméra principale et le mode grille fonctionnent avec au moins trois caméras.
+- [ ] Le flux fournit des états distincts de chargement, lecture, indisponibilité et erreur avec nouvelle tentative.
+- [ ] La fermeture du centre arrête les lecteurs et leurs connexions.
+- [ ] Le son est contrôlable lorsqu’il existe et son absence n’empêche pas la vidéo.
+- [ ] Seules les commandes PTZ prises en charge par la caméra active sont affichées et exécutables.
+- [ ] Sélection, ordre, caméra principale, mode par défaut et épinglages persistent après redémarrage.
+- [ ] Une caméra supprimée ou devenue indisponible ne bloque pas les autres caméras ni l’accès aux réglages.
+- [ ] Les nouveaux écrans et actions possèdent des libellés français et anglais et des descriptions d’accessibilité.
+- [ ] Les tests existants liés aux pills, à l’accueil et à la navigation restent au vert.
+
+## Rapport d’ambiguïté
+
+| Dimension | Score | Minimum | État | Notes |
+|---|---:|---:|:---:|---|
+| Clarté du but | 0,93 | 0,75 | ✓ | Parcours scènes et caméras explicités |
+| Clarté du périmètre | 0,92 | 0,70 | ✓ | Direct inclus ; archives, événements et interphone exclus |
+| Clarté des contraintes | 0,74 | 0,65 | ✓ | Capacités, écrans et compatibilité cadrés |
+| Critères d’acceptation | 0,75 | 0,70 | ✓ | Parcours principaux vérifiables en réussite et en erreur |
+| **Ambiguïté** | **0,15** | **≤ 0,20** | **✓** | Prête pour les décisions d’implémentation |
+
+## Journal des décisions
+
+| Tour | Perspective | Question résumée | Décision verrouillée |
+|---:|---|---|---|
+| 1 | État des lieux | Que fait un toucher sur une scène ? | Activation immédiate |
+| 1 | État des lieux | Comment s’ouvre une caméra ? | Centre caméra plein écran ; présentation choisie dans les réglages |
+| 1 | État des lieux | Quelles fonctions caméra ? | Flux requis ; son et PTZ également inclus |
+| 2 | Simplification | Quels modes d’affichage ? | Caméra principale et grille, avec caméra principale configurable |
+| 2 | Simplification | Pill individuelle ou entrée globale ? | Les deux : pill individuelle ciblée et pill générale configurée |
+| 3 | Gardien du périmètre | Qu’est-ce qui est exclu ? | Enregistrements, historique, snapshots, événements et interphone |
+| 3 | Gardien du périmètre | Comment exposer le PTZ ? | Uniquement selon les capacités réelles de chaque caméra |
+| 3 | Gardien du périmètre | Que peut-on régler ? | Visibilité, ordre, principale, mode par défaut et épinglages |
+
+---
+
+*Étape suivante : décider l’architecture du flux Home Assistant, la détection des capacités audio/PTZ, le modèle de préférences et le découpage d’implémentation.*


### PR DESCRIPTION
## Summary

Release **1.0.2** (versionCode 10).

### Added
- **Connection problem banner**: tappable, action-driven banner on the home and clock screens when Home Assistant is unreachable, with a dedicated `.local` hint.
- **mDNS warnings**: `.local` hostnames flagged in onboarding, connection settings and web config.
- **Staged web-config testing**: HA (address/port/token) and MQTT (host/port/auth) validated live before saving, per-section status cards and an offline/retry view.
- **Clock date formats**: nine layouts selectable from the clock theme with a localized preview.
- **Weather corrections**: deterministic entity selection, forecast temperature filtering, reverse-geocoded city, `°C`/`°F` conversion.
- **Accessibility pass**: roles, hardware-key activation and touch targets for controls; dialogs announced.

### Changed
- Clock colon drawn via Canvas with optional AM/PM suffix; date follows the selected format.
- Web-config entry promoted to a prominent tile; single save screen replaced by progress/completion states.
- Dialogs constrained and scrollable; remaining hard-coded French strings moved to resources.

### Removed
- `StaleBanner` (replaced by `ConnectionProblemBanner`); mock preview pills; monolithic `configurationSaved`/save callback.

### Performance
- GPU-drawn clock colon; reverse-geocoding off the main thread; forecast parsing no longer fabricates entries.

### Tests
- New: `ClockDateFormatTest`, `WeatherDataTest`, `WeatherTemperatureSummaryTest`, `ConnectionProblemBannerTest`, `WeatherCityTest`, `WeatherForecastLabelTest`; extended `WebConfigServerTest`, `IndividualPillPanelTest`, `OnboardingUrlsTest`.